### PR TITLE
Added gtk-dark.css to every dark theme

### DIFF
--- a/ZorinBlue-Dark/gtk-3.0/gtk-dark.css
+++ b/ZorinBlue-Dark/gtk-3.0/gtk-dark.css
@@ -1,0 +1,2308 @@
+/*************************** Check and Radio buttons * */
+@keyframes ripple_effect { to { background-size: 1000% 1000%; } }
+
+* { padding: 0; -GtkToolButton-icon-spacing: 4; -GtkTextView-error-underline-color: #fb7c7c; -GtkScrolledWindow-scrollbar-spacing: 0; -GtkToolItemGroup-expander-size: 11; -GtkWidget-text-handle-width: 20; -GtkWidget-text-handle-height: 24; -GtkDialog-button-spacing: 4; -GtkDialog-action-area-border: 0; outline-color: alpha(currentColor,0.3); outline-style: dashed; outline-offset: -3px; outline-width: 1px; -gtk-outline-radius: 8px; -gtk-secondary-caret-color: #bde6fb; }
+
+/*************** Base States * */
+.background { color: #bde6fb; background-color: #1e2529; }
+
+.background.csd { border-radius: 0 0 10px 10px; }
+
+.background.maximized, .background.solid-csd, .background.fullscreen, .background.tiled, .background.tiled-top, .background.tiled-right, .background.tiled-bottom, .background.tiled-left { border-radius: 0; }
+
+.background:backdrop { color: #6f828a; background-color: #1a2022; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* These wildcard seems unavoidable, need to investigate. Wildcards are bad and troublesome, use them with care, or better, just don't. Everytime a wildcard is used a kitten dies, painfully. */
+*:disabled { -gtk-icon-effect: dim; }
+
+.gtkstyle-fallback { color: #bde6fb; background-color: #1e2529; }
+
+.gtkstyle-fallback:hover { color: #bde6fb; background-color: #334047; }
+
+.gtkstyle-fallback:active { color: #bde6fb; background-color: #080b0c; }
+
+.gtkstyle-fallback:disabled { color: #6d8692; background-color: #1e2529; }
+
+.gtkstyle-fallback:selected { color: #171d20; background-color: #bde6fb; }
+
+.view, iconview, .view text, iconview text, textview text { color: #bde6fb; background-color: #171d20; border-radius: 10px; }
+
+.view:disabled, iconview:disabled, .view text:disabled, iconview text:disabled, textview text:disabled { color: #6d8692; background-color: #1e2529; }
+
+.view:backdrop, iconview:backdrop, .view text:backdrop, iconview text:backdrop, textview text:backdrop { color: #6f828a; background-color: #14191a; }
+
+.view:backdrop:disabled, iconview:backdrop:disabled, .view text:backdrop:disabled, iconview text:backdrop:disabled, textview text:backdrop:disabled { color: #3b494d; background-color: #1a2022; }
+
+.view:selected:focus, iconview:selected:focus, .view:selected, iconview:selected, .view text:selected:focus, iconview text:selected:focus, textview text:selected:focus, .view text:selected, iconview text:selected, textview text:selected { border-radius: 8px; }
+
+.view.sourceview, iconview.sourceview, .view.sourceview > *, iconview.sourceview > *, textview.sourceview, textview.sourceview > * { border-radius: 0; }
+
+textview border { background-color: #1a2125; }
+
+iconview { border-radius: 0 0 10px 10px; }
+
+iconview, iconview:hover, iconview:selected { border-radius: 8px; }
+
+.rubberband, rubberband, XfdesktopIconView.view .rubberband, .content-view rubberband, .content-view .rubberband, treeview.view rubberband, flowbox rubberband { border: 1px solid #8dd4f8; background-color: rgba(141, 212, 248, 0.2); border-radius: 0; }
+
+flowbox flowboxchild { padding: 3px; }
+
+flowbox flowboxchild:selected { outline-offset: -2px; }
+
+.content-view .tile { margin: 2px; background-color: transparent; border-radius: 0; padding: 0; }
+
+label { caret-color: currentColor; }
+
+label:disabled { color: #6d8692; }
+
+button label:disabled { color: inherit; }
+
+label:disabled:backdrop { color: #3b494d; }
+
+button label:disabled:backdrop { color: inherit; }
+
+label.error { color: #fb7c7c; }
+
+label.error:disabled { color: rgba(251, 124, 124, 0.5); }
+
+label.error:disabled:backdrop { color: rgba(251, 124, 124, 0.4); }
+
+.accent { color: #bde6fb; }
+
+.dim-label, .titlebar:not(headerbar) .subtitle, headerbar .subtitle, label.separator { opacity: 0.55; text-shadow: none; }
+
+assistant .sidebar { background-color: #1e2529; border-top: 1px solid #2a3439; }
+
+assistant .sidebar:backdrop { background-color: #1a2022; border-color: #283033; }
+
+assistant.csd .sidebar { border-top-style: none; }
+
+assistant .sidebar label { padding: 6px 12px; }
+
+assistant .sidebar label.highlight { background-color: #3d4c53; }
+
+.osd .scale-popup, .app-notification, .app-notification.frame, .osd { border: none; background-color: #171d20; background-clip: padding-box; border-radius: 8px; box-shadow: inset 0 0 0 1px rgba(42, 52, 57, 0.75); }
+
+.osd .scale-popup:backdrop, .app-notification:backdrop, .osd:backdrop { background-color: #14191a; box-shadow: inset 0 0 0 1px rgba(40, 48, 51, 0.75); }
+
+.osd .scale-popup:disabled, .app-notification:disabled, .osd:disabled { box-shadow: none; }
+
+/********************* Spinner Animation * */
+@keyframes spin { to { -gtk-icon-transform: rotate(1turn); } }
+
+spinner { background: none; opacity: 0; -gtk-icon-source: -gtk-icontheme("process-working-symbolic"); }
+
+spinner:backdrop { color: #6f828a; }
+
+spinner:checked { opacity: 1; animation: spin 1s linear infinite; }
+
+spinner:checked:disabled { opacity: 0.5; }
+
+/********************** General Typography * */
+.large-title { font-weight: 300; font-size: 24pt; }
+
+.title-1, .h1 { font-weight: 800; font-size: 20pt; }
+
+.title-2, .h2 { font-weight: 800; font-size: 15pt; }
+
+.title-3, .h3 { font-weight: 700; font-size: 15pt; }
+
+.title-4, .h4 { font-weight: 700; font-size: 13pt; }
+
+.heading { font-weight: 700; font-size: 11pt; }
+
+.body { font-weight: 400; font-size: 11pt; }
+
+.caption-heading { font-weight: 700; font-size: 9pt; }
+
+.caption { font-weight: 400; font-size: 9pt; }
+
+.category-label { color: rgba(189, 230, 251, 0.8); font-weight: 700; }
+
+/**************** Text Entries * */
+spinbutton:not(.vertical), entry { min-height: 32px; padding-left: 8px; padding-right: 8px; margin: 1px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); color: #bde6fb; background-color: #171d20; box-shadow: inset 0 0 0 1px #2a3439; }
+
+spinbutton:not(.vertical) image.left, entry image.left { margin-right: 6px; }
+
+spinbutton:not(.vertical) image.right, entry image.right { margin-left: 6px; }
+
+spinbutton.flat:not(.vertical), entry.flat:focus, entry.flat:backdrop, entry.flat:disabled, entry.flat { min-height: 0; padding: 2px; background-color: transparent; border-color: transparent; border-radius: 0; }
+
+spinbutton:focus:not(.vertical), entry:focus { color: #bde6fb; background-color: #171d20; box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2), inset 0 0 0 2px #bde6fb; }
+
+spinbutton:disabled:not(.vertical), entry:disabled { color: #6d8692; background-color: transparent; box-shadow: none; }
+
+spinbutton:backdrop:not(.vertical), entry:backdrop { color: #6f828a; background-color: #14191a; box-shadow: inset 0 0 0 1px #283033; border-color: #1a2022; transition: 150ms ease-out; }
+
+spinbutton:backdrop:disabled:not(.vertical), entry:backdrop:disabled { color: #3b494d; background-color: transparent; box-shadow: none; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; border-color: transparent; }
+
+spinbutton.error:focus:not(.vertical), entry.error:focus { color: #fb7c7c; background-color: #171d20; box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2), inset 0 0 0 2px #bde6fb; }
+
+spinbutton.error:not(.vertical) selection, entry.error selection { color: #171d20; background-color: #fb7c7c; }
+
+spinbutton.warning:not(.vertical), entry.warning { color: #faa483; border-color: transparent; }
+
+spinbutton.warning:focus:not(.vertical), entry.warning:focus { color: #faa483; background-color: #171d20; box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2), inset 0 0 0 2px #bde6fb; }
+
+spinbutton.warning:not(.vertical) selection, entry.warning selection { color: #171d20; background-color: #faa483; }
+
+spinbutton:not(.vertical) image, entry image { color: #9cbecf; }
+
+spinbutton:not(.vertical) image:hover, entry image:hover { color: #bde6fb; }
+
+spinbutton:not(.vertical) image:active, entry image:active { color: #bde6fb; }
+
+spinbutton:not(.vertical) image:backdrop, entry image:backdrop { color: #5d6d74; }
+
+spinbutton:drop(active):not(.vertical), entry:drop(active):focus, entry:drop(active) { color: #4cd9a4; border-color: transparent; background-color: #274942; }
+
+spinbutton:not(.vertical) progress, entry progress { margin: 1px -6px; background-color: transparent; background-image: none; border-radius: 3px; border-width: 0 0 3px; border-color: #bde6fb; border-style: solid; box-shadow: none; }
+
+spinbutton:not(.vertical) progress:backdrop, entry progress:backdrop { background-color: transparent; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; }
+
+treeview entry:focus:dir(rtl), treeview entry:focus:dir(ltr) { background-color: #171d20; transition-property: color, background; }
+
+treeview entry.flat, treeview entry { border: none; border-radius: 0; background-image: none; background-color: #171d20; }
+
+.entry-tag { padding: 5px; margin-top: 4px; margin-bottom: 4px; border-style: none; color: #171d20; background-color: #bde6fb; }
+
+:dir(ltr) .entry-tag { margin-left: 8px; margin-right: -5px; }
+
+:dir(rtl) .entry-tag { margin-left: -5px; margin-right: 8px; }
+
+.entry-tag:hover { background-color: #edf8fe; }
+
+:backdrop .entry-tag { color: #14191a; background-color: #bde6fb; }
+
+.entry-tag.button { background-color: transparent; color: rgba(23, 29, 32, 0.7); }
+
+:not(:backdrop) .entry-tag.button:hover { border: 1px solid #bde6fb; color: #171d20; }
+
+:not(:backdrop) .entry-tag.button:active { background-color: #bde6fb; color: #171d20; }
+
+/*********** Buttons * */
+@keyframes needs_attention { from { background-image: -gtk-gradient(radial, center center, 0, center center, 0.01, to(#bde6fb), to(transparent)); }
+  to { background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#bde6fb), to(transparent)); } }
+
+button.titlebutton, notebook > header > tabs > arrow, button { min-height: 24px; min-width: 16px; margin: 1px; padding: 4px 9px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #2a3439; background-image: none; }
+
+button.titlebutton, button.sidebar-button, notebook > header > tabs > arrow, notebook > header > tabs > arrow.flat, button.flat { background-color: transparent; background-image: none; background-image: none; transition: none; }
+
+button.titlebutton:hover, button.sidebar-button:hover, notebook > header > tabs > arrow:hover, button.flat:hover { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-duration: 500ms; }
+
+button.titlebutton:hover:active, button.sidebar-button:hover:active, notebook > header > tabs > arrow:hover:active, button.flat:hover:active { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header > tabs > arrow:hover, button:hover { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #354249; background-image: none; }
+
+notebook > header > tabs > arrow:active, button:active { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #3d4c53; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #4d5f68 10%, transparent 0%); background-size: 0% 0%; }
+
+notebook > header > tabs > arrow:checked, button:checked { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; background: image(#bde6fb); box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); }
+
+notebook > header > tabs > arrow:checked:active, button:checked:active { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); }
+
+notebook > header > tabs > arrow:backdrop, button:backdrop.flat, button:backdrop { background-color: #20272a; background-image: none; transition: 150ms ease-out; -gtk-icon-effect: none; }
+
+notebook > header > tabs > arrow:backdrop label, notebook > header > tabs > arrow:backdrop, button:backdrop.flat label, button:backdrop.flat, button:backdrop label, button:backdrop { color: #6f828a; }
+
+notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active, button:backdrop:active { background-color: #2b3437; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:active label, notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active label, button:backdrop.flat:active, button:backdrop:active label, button:backdrop:active { color: #6f828a; }
+
+notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked, button:backdrop:checked { background-color: #7f96a1; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:checked label, notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked label, button:backdrop.flat:checked, button:backdrop:checked label, button:backdrop:checked { color: #14191a; }
+
+notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled, button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled label, notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled label, button:backdrop.flat:disabled, button:backdrop:disabled label, button:backdrop:disabled { color: #3b494d; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active, button:backdrop:disabled:checked { background-color: #272f33; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active label, notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked label, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active label, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked label, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active label, button:backdrop:disabled:active, button:backdrop:disabled:checked label, button:backdrop:disabled:checked { color: #3b494d; }
+
+button.titlebutton:backdrop, button.sidebar-button:backdrop, notebook > header > tabs > arrow:backdrop, button.titlebutton:disabled, button.sidebar-button:disabled, notebook > header > tabs > arrow:disabled, button.flat:backdrop, button.flat:disabled, button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+notebook > header > tabs > arrow:disabled, button:disabled { color: #6d8692; background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:disabled:active, notebook > header > tabs > arrow:disabled:checked, button:disabled:active, button:disabled:checked { color: #6d8692; background-color: #222a2f; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow.image-button, button.image-button { min-width: 24px; padding-left: 5px; padding-right: 5px; }
+
+notebook > header > tabs > arrow.flat image, notebook > header > tabs > arrow.image-button image, button.flat image, button.image-button image { -gtk-icon-transform: scale(1); transition: -gtk-icon-transform 150ms ease; }
+
+notebook > header > tabs > arrow.flat:active image, notebook > header > tabs > arrow.image-button:active image, button.flat:active image, button.image-button:active image { -gtk-icon-transform: scale(0.85); }
+
+notebook > header > tabs > arrow.text-button, button.text-button { padding-left: 16px; padding-right: 16px; }
+
+notebook > header > tabs > arrow.text-button.image-button, button.text-button.image-button { padding-left: 8px; padding-right: 8px; }
+
+notebook > header > tabs > arrow.text-button.image-button label, button.text-button.image-button label { padding-left: 8px; padding-right: 8px; }
+
+combobox:drop(active) button.combo, notebook > header > tabs > arrow:drop(active), button:drop(active) { color: #171d20; border-color: transparent; background-color: #4cd9a4; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled), row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled) { color: #171d20; border-color: transparent; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled):backdrop, row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled):backdrop { color: #14191a; }
+
+button.osd { min-width: 26px; min-height: 32px; border-radius: 8px; border: none; }
+
+button.osd.image-button { min-width: 34px; }
+
+button.suggested-action { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; background: image(#bde6fb); font-weight: 700; }
+
+button.suggested-action.flat { background-color: transparent; background-image: none; background-image: none; color: #bde6fb; }
+
+button.suggested-action:hover { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background: image(#d2f3ff); background-color: #d2f3ff; }
+
+button.suggested-action:active, button.suggested-action:checked { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-image: none; background-color: #8dd4f8; box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); }
+
+button.suggested-action:backdrop, button.suggested-action.flat:backdrop { background-color: #bee5fa; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop label, button.suggested-action:backdrop, button.suggested-action.flat:backdrop label, button.suggested-action.flat:backdrop { color: #14191a; }
+
+button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked { background-color: #8fd3f6; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop:active label, button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked label, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active label, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked label, button.suggested-action.flat:backdrop:checked { color: #14191a; }
+
+button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.suggested-action:backdrop:disabled label, button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled label, button.suggested-action.flat:backdrop:disabled { color: #3b494d; }
+
+button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked { background-color: #b5dcef; box-shadow: none; background-image: none; }
+
+button.suggested-action:backdrop:disabled:active label, button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked label, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active label, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked label, button.suggested-action.flat:backdrop:disabled:checked { color: #3b494d; }
+
+button.suggested-action.flat:backdrop, button.suggested-action.flat:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(189, 230, 251, 0.8); }
+
+button.suggested-action:disabled { color: #6d8692; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.suggested-action:disabled:active, button.suggested-action:disabled:checked { color: #6d8692; background-color: #b9e1f5; box-shadow: none; background-image: none; }
+
+button.destructive-action { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #fb7c7c; background: image(#fb7c7c); font-weight: 700; }
+
+button.destructive-action.flat { background-color: transparent; background-image: none; background-image: none; color: #fb7c7c; }
+
+button.destructive-action:hover { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background: image(#ff929b); background-color: #ff929b; }
+
+button.destructive-action:active, button.destructive-action:checked { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-image: none; background-color: #fa4a4a; box-shadow: 0 2px 4px rgba(251, 124, 124, 0.2); }
+
+button.destructive-action:backdrop, button.destructive-action.flat:backdrop { background-color: #f97e7e; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop label, button.destructive-action:backdrop, button.destructive-action.flat:backdrop label, button.destructive-action.flat:backdrop { color: #14191a; }
+
+button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked { background-color: #f74d4d; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop:active label, button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked label, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active label, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked label, button.destructive-action.flat:backdrop:checked { color: #14191a; }
+
+button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.destructive-action:backdrop:disabled label, button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled label, button.destructive-action.flat:backdrop:disabled { color: #3b494d; }
+
+button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked { background-color: #ee7979; box-shadow: none; background-image: none; }
+
+button.destructive-action:backdrop:disabled:active label, button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked label, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active label, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked label, button.destructive-action.flat:backdrop:disabled:checked { color: #3b494d; }
+
+button.destructive-action.flat:backdrop, button.destructive-action.flat:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(251, 124, 124, 0.8); }
+
+button.destructive-action:disabled { color: #6d8692; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.destructive-action:disabled:active, button.destructive-action:disabled:checked { color: #6d8692; background-color: #f67a7a; box-shadow: none; background-image: none; }
+
+.stack-switcher > button, stackswitcher > button { padding-top: 2px; padding-bottom: 2px; margin: 2px 1px; background-color: transparent; color: #9cbecf; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; outline-offset: -3px; }
+
+.stack-switcher > button:first-child:dir(ltr), stackswitcher > button:first-child:dir(ltr) { margin-left: 2px; }
+
+.stack-switcher > button:first-child:dir(rtl), stackswitcher > button:first-child:dir(rtl) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(ltr), stackswitcher > button:last-child:dir(ltr) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(rtl), stackswitcher > button:last-child:dir(rtl) { margin-left: 2px; }
+
+.stack-switcher > button:hover, stackswitcher > button:hover { color: #bde6fb; background-color: rgba(189, 230, 251, 0.05); }
+
+.stack-switcher > button:checked, stackswitcher > button:checked { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-image: none; background-color: #354249; box-shadow: 0 2px 4px rgba(23, 29, 32, 0.075); }
+
+.stack-switcher > button:backdrop, stackswitcher > button:backdrop { color: #6f828a; }
+
+.stack-switcher > button:backdrop:hover, stackswitcher > button:backdrop:hover { background-color: transparent; }
+
+.stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked { background-image: none; background-color: #272f32; box-shadow: 0 1px 2px rgba(20, 25, 26, 0.075); }
+
+.stack-switcher > button:backdrop:checked label, .stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked label, stackswitcher > button:backdrop:checked { color: #6f828a; }
+
+.stack-switcher > button > label, stackswitcher > button > label { padding-left: 6px; padding-right: 6px; }
+
+.stack-switcher > button > image, stackswitcher > button > image { padding-left: 6px; padding-right: 6px; padding-top: 3px; padding-bottom: 3px; }
+
+.stack-switcher > button.text-button, stackswitcher > button.text-button { padding-left: 10px; padding-right: 10px; }
+
+.stack-switcher > button.image-button, stackswitcher > button.image-button { padding-left: 2px; padding-right: 2px; }
+
+.stack-switcher > button.needs-attention:active > label, .stack-switcher > button.needs-attention:active > image, .stack-switcher > button.needs-attention:checked > label, .stack-switcher > button.needs-attention:checked > image, stackswitcher > button.needs-attention:active > label, stackswitcher > button.needs-attention:active > image, stackswitcher > button.needs-attention:checked > label, stackswitcher > button.needs-attention:checked > image { animation: none; background-image: none; }
+
+button.font separator, button.file separator { background-color: transparent; }
+
+button.font > box > box > label { font-weight: bold; }
+
+.primary-toolbar button { -gtk-icon-shadow: none; }
+
+button.circular { border-radius: 9999px; -gtk-outline-radius: 9999px; }
+
+button.circular label { padding: 0; }
+
+stacksidebar row.needs-attention > label, .stack-switcher > button.needs-attention > label, .stack-switcher > button.needs-attention > image, stackswitcher > button.needs-attention > label, stackswitcher > button.needs-attention > image { animation: needs_attention 150ms ease-in; background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#bde6fb), to(transparent)), -gtk-gradient(radial, center center, 0, center center, 0.45, to(rgba(0, 0, 0, 0.888627)), to(transparent)); background-size: 6px 6px, 6px 6px; background-repeat: no-repeat; background-position: right 3px, right 2px; }
+
+stacksidebar row.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > image:backdrop, stackswitcher > button.needs-attention > label:backdrop, stackswitcher > button.needs-attention > image:backdrop { background-size: 6px 6px, 0 0; }
+
+stacksidebar row.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), stackswitcher > button.needs-attention > label:dir(rtl), stackswitcher > button.needs-attention > image:dir(rtl) { background-position: left 3px, left 2px; }
+
+.inline-toolbar toolbutton > button { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #2a3439; background-image: none; }
+
+.inline-toolbar toolbutton > button:hover { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #354249; background-image: none; }
+
+.inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #3d4c53; }
+
+.inline-toolbar toolbutton > button:disabled { color: #6d8692; background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:disabled:active, .inline-toolbar toolbutton > button:disabled:checked { color: #6d8692; background-color: #222a2f; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop { background-color: #20272a; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop label, .inline-toolbar toolbutton > button:backdrop { color: #6f828a; }
+
+.inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked { background-color: #2b3437; background-image: none; box-shadow: none; }
+
+.inline-toolbar toolbutton > button:backdrop:active label, .inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked label, .inline-toolbar toolbutton > button:backdrop:checked { color: #6f828a; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled label, .inline-toolbar toolbutton > button:backdrop:disabled { color: #3b494d; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked { background-color: #272f33; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active label, .inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked label, .inline-toolbar toolbutton > button:backdrop:disabled:checked { color: #3b494d; }
+
+.linked:not(.vertical) > combobox > box > button.combo, filechooser .path-bar.linked > button, .linked:not(.vertical) > spinbutton:not(.vertical), .linked:not(.vertical) > entry, .inline-toolbar button, .linked > button, toolbar.inline-toolbar toolbutton > button.flat { border-right-style: none; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked:not(.vertical) > combobox:first-child > box > button.combo, combobox.linked button:nth-child(2):dir(rtl), filechooser .path-bar.linked > button:dir(rtl):last-child, filechooser .path-bar.linked > button:dir(ltr):first-child, .linked:not(.vertical) > spinbutton:first-child:not(.vertical), .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat { border-top-left-radius: 8px; border-bottom-left-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-bottom-left-radius: 8px; }
+
+.linked:not(.vertical) > combobox:last-child > box > button.combo, combobox.linked button:nth-child(2):dir(ltr), filechooser .path-bar.linked > button:dir(rtl):first-child, filechooser .path-bar.linked > button:dir(ltr):last-child, .linked:not(.vertical) > spinbutton:last-child:not(.vertical), .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat { border-right-style: solid; border-top-right-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-top-right-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked:not(.vertical) > combobox:only-child > box > button.combo, filechooser .path-bar.linked > button:only-child, .linked:not(.vertical) > spinbutton:only-child:not(.vertical), .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.linked.vertical > combobox > box > button.combo, .linked.vertical > spinbutton:not(.vertical), .linked.vertical > entry, .linked.vertical > button { border-style: solid solid none solid; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked.vertical > combobox:first-child > box > button.combo, .linked.vertical > spinbutton:first-child:not(.vertical), .linked.vertical > entry:first-child, .linked.vertical > button:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-top-right-radius: 8px; }
+
+.linked.vertical > combobox:last-child > box > button.combo, .linked.vertical > spinbutton:last-child:not(.vertical), .linked.vertical > entry:last-child, .linked.vertical > button:last-child { border-bottom-style: solid; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-bottom-left-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked.vertical > combobox:only-child > box > button.combo, .linked.vertical > spinbutton:only-child:not(.vertical), .linked.vertical > entry:only-child, .linked.vertical > button:only-child { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.scale-popup button:backdrop:hover, .scale-popup button:backdrop:disabled, .scale-popup button:backdrop, .scale-popup button:hover, calendar.button, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, button:link, button:visited, modelbutton.flat:backdrop, modelbutton.flat:backdrop:hover, modelbutton.flat, .menuitem.button.flat { background-color: transparent; background-image: none; border-color: transparent; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* menu buttons */
+modelbutton.flat, .menuitem.button.flat { min-height: 26px; padding-left: 5px; padding-right: 5px; border-radius: 8px; outline-offset: -2px; }
+
+modelbutton.flat:hover, .menuitem.button.flat:hover { background-color: #2a3439; }
+
+modelbutton.flat arrow { background: none; }
+
+modelbutton.flat arrow:hover { background: none; }
+
+modelbutton.flat arrow.left { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+modelbutton.flat arrow.right { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+button.color { padding: 4px; box-shadow: none; }
+
+button.color colorswatch:only-child, button.color colorswatch:only-child overlay { border-radius: 0; }
+
+/********* Links * */
+button:link > label, button:visited > label, button:link, button:visited, *:link { color: #edf8fe; }
+
+button:link > label:visited, button:visited > label:visited, button:visited, *:link:visited { color: white; }
+
+*:selected button:link > label:visited, *:selected button:visited > label:visited, *:selected button:visited, *:selected *:link:visited { color: #747779; }
+
+button:link > label:hover, button:visited > label:hover, button:hover:link, button:hover:visited, *:link:hover { color: white; }
+
+*:selected button:link > label:hover, *:selected button:visited > label:hover, *:selected button:hover:link, *:selected button:hover:visited, *:selected *:link:hover { color: #2e3436; }
+
+button:link > label:active, button:visited > label:active, button:active:link, button:active:visited, *:link:active { color: #edf8fe; }
+
+*:selected button:link > label:active, *:selected button:visited > label:active, *:selected button:active:link, *:selected button:active:visited, *:selected *:link:active { color: #42494c; }
+
+button:link > label:disabled, button:visited > label:disabled, button:disabled:link, button:disabled:visited, *:link:disabled, *:link:disabled:backdrop { color: rgba(245, 245, 245, 0.8); }
+
+button:link > label:backdrop, button:visited > label:backdrop, button:backdrop:link, button:backdrop:visited, *:link:backdrop:backdrop:hover, *:link:backdrop:backdrop:hover:selected, *:link:backdrop { color: rgba(237, 248, 254, 0.9); }
+
+.selection-mode .titlebar:not(headerbar) .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link, .selection-mode headerbar .subtitle:link, headerbar.selection-mode .subtitle:link, button:link > label:selected, button:visited > label:selected, button:selected:link, button:selected:visited, *:selected button:link > label, *:selected button:visited > label, *:selected button:link, *:selected button:visited, *:link:selected, *:selected *:link { color: #42494c; }
+
+button:link, button:visited { text-shadow: none; }
+
+button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked { text-shadow: none; }
+
+button:link > label, button:visited > label { text-decoration-line: underline; }
+
+/****************** Stack Switcher * */
+stackswitcher, .stack-switcher { border-radius: 8px; background-color: #171d20; }
+
+stackswitcher:backdrop, .stack-switcher:backdrop { background-color: #14191a; }
+
+stackswitcher > button, .stack-switcher > button { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+/***************** GtkSpinButton * */
+spinbutton { font-feature-settings: "tnum"; }
+
+spinbutton:not(.vertical) { padding: 0; }
+
+spinbutton:not(.vertical) entry { min-width: 28px; margin: 0; background: none; background-color: transparent; border: none; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) entry:backdrop:disabled { background-color: transparent; }
+
+spinbutton:not(.vertical) button { min-height: 16px; margin: 0; padding-bottom: 0; padding-top: 0; color: #bde6fb; background-image: none; border-style: none none none solid; border-color: transparent; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) button:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:disabled { color: #6d8692; background-color: #1e2529; }
+
+spinbutton:not(.vertical) button:backdrop:disabled { color: #3b494d; background-color: #1a2022; background-image: none; border-style: none none none solid; }
+
+spinbutton:not(.vertical) button:backdrop:disabled:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:dir(ltr):last-child { border-radius: 0 7px 7px 0; }
+
+spinbutton:not(.vertical) button:dir(rtl):first-child { border-radius: 7px 0 0 7px; }
+
+spinbutton.vertical:disabled { color: #6d8692; }
+
+spinbutton.vertical:backdrop:disabled { color: #3b494d; }
+
+spinbutton.vertical:drop(active) { border-color: transparent; box-shadow: none; }
+
+spinbutton.vertical entry { min-height: 32px; min-width: 32px; padding: 0; border-radius: 0; }
+
+spinbutton.vertical button { min-height: 32px; min-width: 32px; padding: 0; }
+
+spinbutton.vertical button.up { border-radius: 8px 8px 0 0; border-style: solid solid none solid; }
+
+spinbutton.vertical button.down { border-radius: 0 0 8px 8px; border-style: none solid solid solid; }
+
+treeview spinbutton:not(.vertical) { min-height: 0; border-style: none; border-radius: 0; }
+
+treeview spinbutton:not(.vertical) entry { min-height: 0; padding: 1px 2px; }
+
+/************** ComboBoxes * */
+combobox arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); min-height: 16px; min-width: 16px; }
+
+combobox:drop(active) { box-shadow: none; }
+
+/************ Toolbars * */
+searchbar > revealer > box, .location-bar, .inline-toolbar, toolbar { -GtkWidget-window-dragging: true; padding: 4px; background-color: #1e2529; }
+
+searchbar > revealer > box:backdrop, .location-bar:backdrop, .inline-toolbar:backdrop, toolbar:backdrop { background-color: #1a2022; }
+
+toolbar { padding: 4px 3px 3px 4px; }
+
+.osd toolbar { background-color: transparent; }
+
+toolbar.osd { padding: 13px; border: none; border-radius: 8px; }
+
+toolbar.osd.left, toolbar.osd.right, toolbar.osd.top, toolbar.osd.bottom { border-radius: 0; }
+
+toolbar.horizontal separator { margin: 0 7px 1px 6px; }
+
+toolbar.vertical separator { margin: 6px 1px 7px 0; }
+
+toolbar:not(.inline-toolbar):not(.osd) > *:not(.toggle):not(.popup) > * { margin-right: 1px; margin-bottom: 1px; }
+
+.inline-toolbar { padding: 3px; border-width: 0 1px 1px; border-radius: 0 0 8px 8px; }
+
+.background.csd .inline-toolbar { border-radius: 0 0 10px 10px; }
+
+searchbar > revealer > box, .location-bar { border-width: 0 0 1px; padding: 3px; }
+
+searchbar > revealer > box { margin: -6px; padding: 6px; }
+
+revealer box.view { background-color: transparent; }
+
+.inline-toolbar, searchbar > revealer > box, .location-bar { border-style: none; background-color: #1e2529; }
+
+.inline-toolbar:backdrop, searchbar > revealer > box:backdrop, .location-bar:backdrop { background-color: #1a2022; }
+
+/*************** Header bars * */
+@keyframes header_ripple_effect { from { background-image: radial-gradient(circle farthest-corner at center, #1e2529 0%, transparent 0%); }
+  to { background-image: radial-gradient(circle farthest-corner at center, #bde6fb 100%, transparent 0%); } }
+
+.titlebar:not(headerbar), headerbar { padding: 0 6px; min-height: 46px; border: none; border-radius: 0; background-color: #1e2529; /* hide the close button separator */ }
+
+.titlebar:backdrop:not(headerbar), headerbar:backdrop { background-color: #1a2022; background-image: none; }
+
+.titlebar:not(headerbar) .title, headerbar .title { padding-left: 12px; padding-right: 12px; font-weight: bold; }
+
+.titlebar:not(headerbar) .subtitle, headerbar .subtitle { font-size: smaller; padding-left: 12px; padding-right: 12px; }
+
+.selection-mode .titlebar:not(headerbar), .selection-mode.titlebar:not(headerbar), .selection-mode headerbar, headerbar.selection-mode { color: #171d20; border-color: transparent; background-color: #bde6fb; transition: background-color 0.00001s 150ms, color 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); animation: header_ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+.selection-mode .titlebar:backdrop:not(headerbar), .selection-mode.titlebar:backdrop:not(headerbar), .selection-mode headerbar:backdrop, headerbar.selection-mode:backdrop { color: #171d20; background-color: #bde6fb; background-image: none; }
+
+.selection-mode .titlebar:backdrop:not(headerbar) label, .selection-mode.titlebar:backdrop:not(headerbar) label, .selection-mode headerbar:backdrop label, headerbar.selection-mode:backdrop label { text-shadow: none; color: #171d20; }
+
+.selection-mode .titlebar:not(headerbar) button, .selection-mode.titlebar:not(headerbar) button, .selection-mode headerbar button, headerbar.selection-mode button { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #b0d7ea; background-image: none; }
+
+.selection-mode button.titlebutton, .selection-mode .titlebar:not(headerbar) button.flat, .selection-mode.titlebar:not(headerbar) button.flat, .selection-mode headerbar button.flat, headerbar.selection-mode button.flat { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:hover, .selection-mode.titlebar:not(headerbar) button:hover, .selection-mode headerbar button:hover, headerbar.selection-mode button:hover { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #a4c8da; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:active, .selection-mode .titlebar:not(headerbar) button:checked, .selection-mode.titlebar:not(headerbar) button:active, .selection-mode.titlebar:not(headerbar) button:checked, .selection-mode headerbar button:active, .selection-mode headerbar button:checked, .selection-mode headerbar button.toggle:checked, .selection-mode headerbar button.toggle:active, headerbar.selection-mode button:active, headerbar.selection-mode button:checked, headerbar.selection-mode button.toggle:checked, headerbar.selection-mode button.toggle:active { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #9cbecf; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop { background-color: #20272a; background-image: none; -gtk-icon-effect: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop label, .selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop label, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat label, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop label, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat label, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop label, headerbar.selection-mode button:backdrop { color: #6f828a; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked { background-color: #2b3437; background-image: none; box-shadow: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active label, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked label, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active label, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked label, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active label, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked label, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active label, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked label, headerbar.selection-mode button:backdrop:checked { color: #6f828a; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled label, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled label, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled label, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled label, headerbar.selection-mode button:backdrop:disabled { color: #3b494d; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked { background-color: #b5dcef; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active label, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked label, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active label, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked label, headerbar.selection-mode button:backdrop:disabled:checked { color: #3b494d; }
+
+.selection-mode button.titlebutton:backdrop, .selection-mode button.titlebutton:disabled, .selection-mode .titlebar:not(headerbar) button.flat:backdrop, .selection-mode .titlebar:not(headerbar) button.flat:disabled, .selection-mode.titlebar:not(headerbar) button.flat:backdrop, .selection-mode.titlebar:not(headerbar) button.flat:disabled, .selection-mode headerbar button.flat:backdrop, .selection-mode headerbar button.flat:disabled, .selection-mode headerbar button.flat:backdrop:disabled, headerbar.selection-mode button.flat:backdrop, headerbar.selection-mode button.flat:disabled, headerbar.selection-mode button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled, .selection-mode.titlebar:not(headerbar) button:disabled, .selection-mode headerbar button:disabled, headerbar.selection-mode button:disabled { color: #6d8692; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled:active, .selection-mode .titlebar:not(headerbar) button:disabled:checked, .selection-mode.titlebar:not(headerbar) button:disabled:active, .selection-mode.titlebar:not(headerbar) button:disabled:checked, .selection-mode headerbar button:disabled:active, .selection-mode headerbar button:disabled:checked, headerbar.selection-mode button:disabled:active, headerbar.selection-mode button:disabled:checked { color: #6d8692; background-color: #b9e1f5; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action, .selection-mode.titlebar:not(headerbar) button.suggested-action, .selection-mode headerbar button.suggested-action, headerbar.selection-mode button.suggested-action { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #2a3439; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:hover, .selection-mode.titlebar:not(headerbar) button.suggested-action:hover, .selection-mode headerbar button.suggested-action:hover, headerbar.selection-mode button.suggested-action:hover { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #354249; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:active, .selection-mode.titlebar:not(headerbar) button.suggested-action:active, .selection-mode headerbar button.suggested-action:active, headerbar.selection-mode button.suggested-action:active { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #3d4c53; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode headerbar button.suggested-action:disabled, headerbar.selection-mode button.suggested-action:disabled { color: #6d8692; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop { background-color: #20272a; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop label, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop label, headerbar.selection-mode button.suggested-action:backdrop { color: #6f828a; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled label, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled label, headerbar.selection-mode button.suggested-action:backdrop:disabled { color: #3b494d; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu, .selection-mode.titlebar:not(headerbar) .selection-menu, .selection-mode headerbar .selection-menu:backdrop, .selection-mode headerbar .selection-menu, headerbar.selection-mode .selection-menu:backdrop, headerbar.selection-mode .selection-menu { border-color: rgba(189, 230, 251, 0); background-color: rgba(189, 230, 251, 0); background-image: none; box-shadow: none; min-height: 20px; padding: 6px 10px; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu arrow, .selection-mode.titlebar:not(headerbar) .selection-menu arrow, .selection-mode headerbar .selection-menu:backdrop arrow, .selection-mode headerbar .selection-menu arrow, headerbar.selection-mode .selection-menu:backdrop arrow, headerbar.selection-mode .selection-menu arrow { -GtkArrow-arrow-scaling: 1; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu .arrow, .selection-mode.titlebar:not(headerbar) .selection-menu .arrow, .selection-mode headerbar .selection-menu:backdrop .arrow, .selection-mode headerbar .selection-menu .arrow, headerbar.selection-mode .selection-menu:backdrop .arrow, headerbar.selection-mode .selection-menu .arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); color: rgba(23, 29, 32, 0.5); -gtk-icon-shadow: none; }
+
+.tiled .titlebar:not(headerbar), .tiled-top .titlebar:not(headerbar), .tiled-right .titlebar:not(headerbar), .tiled-bottom .titlebar:not(headerbar), .tiled-left .titlebar:not(headerbar), .maximized .titlebar:not(headerbar), .fullscreen .titlebar:not(headerbar), .tiled headerbar, .tiled-top headerbar, .tiled-right headerbar, .tiled-bottom headerbar, .tiled-left headerbar, .maximized headerbar, .fullscreen headerbar { border-radius: 0; }
+
+.default-decoration.titlebar:not(headerbar), headerbar.default-decoration { min-height: 28px; padding: 4px; border-color: transparent; }
+
+.default-decoration.titlebar:not(headerbar) button.titlebutton, headerbar.default-decoration button.titlebutton { min-height: 26px; min-width: 26px; margin: 0; padding: 0; }
+
+.titlebar:not(headerbar) separator.titlebutton, headerbar separator.titlebutton { opacity: 0; }
+
+.solid-csd .titlebar:dir(rtl):not(headerbar), .solid-csd .titlebar:dir(ltr):not(headerbar), .solid-csd headerbar:backdrop:dir(rtl), .solid-csd headerbar:backdrop:dir(ltr), .solid-csd headerbar:dir(rtl), .solid-csd headerbar:dir(ltr) { margin-left: -1px; margin-right: -1px; margin-top: -1px; border-radius: 0; box-shadow: none; }
+
+headerbar entry, headerbar spinbutton, headerbar separator:not(.sidebar), headerbar button { margin-top: 6px; margin-bottom: 6px; }
+
+headerbar switch { margin-top: 10px; margin-bottom: 10px; }
+
+headerbar stackswitcher button, headerbar .stack-switcher button { min-height: 24px; min-width: 80px; margin: 4px 2px; }
+
+headerbar stackswitcher button:first-child:dir(ltr), headerbar .stack-switcher button:first-child:dir(ltr) { margin-left: 4px; }
+
+headerbar stackswitcher button:first-child:dir(rtl), headerbar .stack-switcher button:first-child:dir(rtl) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(ltr), headerbar .stack-switcher button:last-child:dir(ltr) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(rtl), headerbar .stack-switcher button:last-child:dir(rtl) { margin-left: 4px; }
+
+#MozillaGtkWidget.background headerbar button.close:hover, headerbar button.close:hover { color: #fb7c7c; background-color: #3f3236; }
+
+#MozillaGtkWidget.background headerbar button.close:active, #MozillaGtkWidget.background headerbar button.close:checked, headerbar button.close:active, headerbar button.close:checked { color: #fb7c7c; background-color: #4a373a; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #4a373a 10%, transparent 0%); background-size: 0% 0%; }
+
+headerbar.titlebar headerbar:not(.titlebar) { background: none; box-shadow: none; }
+
+.background .titlebar:backdrop, .background .titlebar { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+.background.tiled .titlebar:backdrop, .background.tiled .titlebar, .background.tiled-top .titlebar:backdrop, .background.tiled-top .titlebar, .background.tiled-right .titlebar:backdrop, .background.tiled-right .titlebar, .background.tiled-bottom .titlebar:backdrop, .background.tiled-bottom .titlebar, .background.tiled-left .titlebar:backdrop, .background.tiled-left .titlebar, .background.maximized .titlebar:backdrop, .background.maximized .titlebar, .background.solid-csd .titlebar:backdrop, .background.solid-csd .titlebar { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window separator:first-child + headerbar:backdrop, window separator:first-child + headerbar, window headerbar:first-child:backdrop, window headerbar:first-child { border-top-left-radius: 10px; }
+
+window headerbar:last-child:backdrop, window headerbar:last-child { border-top-right-radius: 10px; }
+
+window stack headerbar:first-child:backdrop, window stack headerbar:first-child, window stack headerbar:last-child:backdrop, window stack headerbar:last-child { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+window.tiled headerbar, window.tiled headerbar:first-child, window.tiled headerbar:last-child, window.tiled headerbar:only-child, window.tiled headerbar:backdrop, window.tiled headerbar:backdrop:first-child, window.tiled headerbar:backdrop:last-child, window.tiled headerbar:backdrop:only-child, window.tiled-top headerbar, window.tiled-top headerbar:first-child, window.tiled-top headerbar:last-child, window.tiled-top headerbar:only-child, window.tiled-top headerbar:backdrop, window.tiled-top headerbar:backdrop:first-child, window.tiled-top headerbar:backdrop:last-child, window.tiled-top headerbar:backdrop:only-child, window.tiled-right headerbar, window.tiled-right headerbar:first-child, window.tiled-right headerbar:last-child, window.tiled-right headerbar:only-child, window.tiled-right headerbar:backdrop, window.tiled-right headerbar:backdrop:first-child, window.tiled-right headerbar:backdrop:last-child, window.tiled-right headerbar:backdrop:only-child, window.tiled-bottom headerbar, window.tiled-bottom headerbar:first-child, window.tiled-bottom headerbar:last-child, window.tiled-bottom headerbar:only-child, window.tiled-bottom headerbar:backdrop, window.tiled-bottom headerbar:backdrop:first-child, window.tiled-bottom headerbar:backdrop:last-child, window.tiled-bottom headerbar:backdrop:only-child, window.tiled-left headerbar, window.tiled-left headerbar:first-child, window.tiled-left headerbar:last-child, window.tiled-left headerbar:only-child, window.tiled-left headerbar:backdrop, window.tiled-left headerbar:backdrop:first-child, window.tiled-left headerbar:backdrop:last-child, window.tiled-left headerbar:backdrop:only-child, window.maximized headerbar, window.maximized headerbar:first-child, window.maximized headerbar:last-child, window.maximized headerbar:only-child, window.maximized headerbar:backdrop, window.maximized headerbar:backdrop:first-child, window.maximized headerbar:backdrop:last-child, window.maximized headerbar:backdrop:only-child, window.fullscreen headerbar, window.fullscreen headerbar:first-child, window.fullscreen headerbar:last-child, window.fullscreen headerbar:only-child, window.fullscreen headerbar:backdrop, window.fullscreen headerbar:backdrop:first-child, window.fullscreen headerbar:backdrop:last-child, window.fullscreen headerbar:backdrop:only-child, window.solid-csd headerbar, window.solid-csd headerbar:first-child, window.solid-csd headerbar:last-child, window.solid-csd headerbar:only-child, window.solid-csd headerbar:backdrop, window.solid-csd headerbar:backdrop:first-child, window.solid-csd headerbar:backdrop:last-child, window.solid-csd headerbar:backdrop:only-child { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window.csd > .titlebar:not(headerbar) { padding: 0; background-color: transparent; background-image: none; border-style: none; border-color: transparent; box-shadow: none; }
+
+.titlebar:not(headerbar) separator { background-color: #1e2529; }
+
+.titlebar:not(headerbar) separator:backdrop { background-color: #1a2022; }
+
+window.devel headerbar.titlebar:not(.selection-mode) { background: #1e2529 cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, linear-gradient(to right, transparent 65%, rgba(189, 230, 251, 0.15)); }
+
+window.devel headerbar.titlebar:not(.selection-mode):backdrop { background: #1e2529 cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, image(#1e2529); /* background-color would flash */ }
+
+/************ Pathbars * */
+.path-bar button.text-button, .path-bar button.image-button, .path-bar button { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.text-button.image-button label { padding-left: 0; padding-right: 0; }
+
+.path-bar button.text-button.image-button label:last-child, .path-bar button label:last-child { padding-right: 8px; }
+
+.path-bar button.text-button.image-button label:first-child, .path-bar button label:first-child { padding-left: 8px; }
+
+.path-bar button image { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.slider-button { padding-left: 0; padding-right: 0; }
+
+/************** Tree Views * */
+treeview.view { border-left-color: rgba(189, 230, 251, 0.15); border-top-color: #1e2529; border-radius: 0px; }
+
+* { -GtkTreeView-horizontal-separator: 4; -GtkTreeView-grid-line-width: 1; -GtkTreeView-grid-line-pattern: ''; -GtkTreeView-tree-line-width: 1; -GtkTreeView-tree-line-pattern: ''; -GtkTreeView-expander-size: 16; }
+
+treeview.view:selected:focus, treeview.view:selected { border-radius: 0; }
+
+treeview.view:selected:backdrop, treeview.view:selected { border-left-color: #4b5960; border-top-color: rgba(111, 130, 138, 0.1); }
+
+treeview.view:disabled { color: #6d8692; }
+
+treeview.view:disabled:selected { color: #7a95a3; }
+
+treeview.view:disabled:selected:backdrop { color: #5f7078; }
+
+treeview.view:disabled:backdrop { color: #3b494d; }
+
+treeview.view.separator { min-height: 2px; color: #1e2529; }
+
+treeview.view.separator:backdrop { color: #1a2022; }
+
+treeview.view:backdrop { border-left-color: #445156; border-top: #1a2022; }
+
+treeview.view:drop(active) { border-style: solid none; border-width: 1px; border-color: #afd5e8; }
+
+treeview.view:drop(active).after { border-top-style: none; }
+
+treeview.view:drop(active).before { border-bottom-style: none; }
+
+treeview.view.expander { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); color: #8baab9; }
+
+treeview.view.expander:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+treeview.view.expander:hover { color: #bde6fb; }
+
+treeview.view.expander:selected { color: #495962; }
+
+treeview.view.expander:selected:hover { color: #171d20; }
+
+treeview.view.expander:selected:backdrop { color: #343e42; }
+
+treeview.view.expander:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+treeview.view.expander:backdrop { color: #546269; }
+
+treeview.view.progressbar { color: #171d20; background-color: #bde6fb; background: image(#bde6fb); box-shadow: none; border-radius: 8px; }
+
+treeview.view.progressbar:backdrop { color: #14191a; background-color: #7f96a1; background-image: none; }
+
+treeview.view.progressbar:selected:focus, treeview.view.progressbar:selected { border-radius: 8px; color: #bde6fb; background-color: #171d20; background-image: none; }
+
+treeview.view.progressbar:selected:backdrop { color: #7f96a1; background-color: #14191a; }
+
+treeview.view.trough { background-color: rgba(189, 230, 251, 0.1); border-radius: 8px; }
+
+treeview.view.trough:backdrop { background-color: rgba(111, 130, 138, 0.1); }
+
+treeview.view.trough:selected { border-radius: 8px; }
+
+treeview.view.trough:selected:focus, treeview.view.trough:selected { background-color: rgba(23, 29, 32, 0.3); }
+
+treeview.view.trough:selected:backdrop { background-color: rgba(23, 29, 32, 0.3); }
+
+treeview.view header button { color: #6a818d; background-color: #171d20; font-weight: bold; text-shadow: none; box-shadow: none; margin: 0 1px 1px 0; }
+
+treeview.view header button:last-child { margin-right: 0; }
+
+treeview.view header button:hover { color: #93b3c4; box-shadow: none; transition: none; }
+
+treeview.view header button:active { color: #bde6fb; transition: none; }
+
+treeview.view button.dnd:active, treeview.view button.dnd:selected, treeview.view button.dnd:hover, treeview.view button.dnd, treeview.view header.button.dnd:active, treeview.view header.button.dnd:selected, treeview.view header.button.dnd:hover, treeview.view header.button.dnd { padding: 0 6px; color: #171d20; background-image: none; background-color: #bde6fb; border-style: none; border-radius: 0; box-shadow: inset 0 0 0 1px #171d20; text-shadow: none; transition: none; }
+
+treeview.view acceleditor > label { background-color: #bde6fb; }
+
+treeview.view header button, treeview.view header button:hover, treeview.view header button:active { padding: 0 6px; background-image: none; border-style: none solid solid none; border-color: #1e2529; border-radius: 0; text-shadow: none; }
+
+treeview.view header button:disabled { border-color: #1e2529; background-image: none; }
+
+treeview.view header button:backdrop { color: #445156; border-color: #1a2022; border-style: none solid solid none; background-image: none; background-color: #14191a; }
+
+treeview.view header button:backdrop:disabled { border-color: #1a2022; background-image: none; }
+
+treeview.view header button:last-child { border-right-style: none; }
+
+/********* Menus * */
+menubar, .menubar { -GtkWidget-window-dragging: true; padding: 0px; }
+
+menubar:backdrop, .menubar:backdrop { background-color: #1a2022; }
+
+menubar > menuitem, .menubar > menuitem { min-height: 16px; padding: 4px 8px; }
+
+menubar > menuitem menu:dir(rtl), menubar > menuitem menu:dir(ltr), .menubar > menuitem menu:dir(rtl), .menubar > menuitem menu:dir(ltr) { border-radius: 0; padding: 0; }
+
+menubar > menuitem:hover, .menubar > menuitem:hover { box-shadow: inset 0 -3px #bde6fb; color: #edf8fe; }
+
+menubar > menuitem:disabled, .menubar > menuitem:disabled { color: #6d8692; box-shadow: none; }
+
+menubar .csd.popup decoration, .menubar .csd.popup decoration { border-radius: 0; }
+
+.background.popup { background-color: transparent; }
+
+menu, .menu, .context-menu { margin: 8px; padding: 8px 0px; background-color: #171d20; border: 1px solid rgba(42, 52, 57, 0.75); }
+
+.csd menu, .csd .menu, .csd .context-menu { border: none; border-radius: 8px; }
+
+menu:backdrop, .menu:backdrop, .context-menu:backdrop { background-color: #14191a; border-color: rgba(40, 48, 51, 0.75); }
+
+menu menuitem, .menu menuitem, .context-menu menuitem { min-height: 16px; min-width: 40px; padding: 4px 6px; text-shadow: none; }
+
+menu menuitem:hover, .menu menuitem:hover, .context-menu menuitem:hover { color: #171d20; background-color: #bde6fb; background: image(#bde6fb); }
+
+menu menuitem:disabled, .menu menuitem:disabled, .context-menu menuitem:disabled { color: #6d8692; }
+
+menu menuitem:disabled:backdrop, .menu menuitem:disabled:backdrop, .context-menu menuitem:disabled:backdrop { color: #3b494d; }
+
+menu menuitem:backdrop, menu menuitem:backdrop:hover, .menu menuitem:backdrop, .menu menuitem:backdrop:hover, .context-menu menuitem:backdrop, .context-menu menuitem:backdrop:hover { color: #6f828a; background-color: transparent; }
+
+menu menuitem arrow, .menu menuitem arrow, .context-menu menuitem arrow { min-height: 16px; min-width: 16px; }
+
+menu menuitem arrow:dir(ltr), .menu menuitem arrow:dir(ltr), .context-menu menuitem arrow:dir(ltr) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); margin-left: 10px; }
+
+menu menuitem arrow:dir(rtl), .menu menuitem arrow:dir(rtl), .context-menu menuitem arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); margin-right: 10px; }
+
+menu menuitem label:dir(rtl), menu menuitem label:dir(ltr), .menu menuitem label:dir(rtl), .menu menuitem label:dir(ltr), .context-menu menuitem label:dir(rtl), .context-menu menuitem label:dir(ltr) { color: inherit; }
+
+menu separator, .menu separator, .context-menu separator { margin: 3px 16px; }
+
+menu > arrow, .menu > arrow, .context-menu > arrow { background-color: transparent; background-image: none; background-image: none; min-height: 16px; min-width: 16px; padding: 4px; background-color: #171d20; border-radius: 0; }
+
+menu > arrow.top, .menu > arrow.top, .context-menu > arrow.top { margin-top: -8px; border-bottom: 1px solid #283136; border-top-right-radius: 8px; border-top-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+menu > arrow.bottom, .menu > arrow.bottom, .context-menu > arrow.bottom { margin-top: 16px; margin-bottom: -24px; border-top: 1px solid #283136; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+menu > arrow:hover, .menu > arrow:hover, .context-menu > arrow:hover { background-color: #303b41; }
+
+menu > arrow:backdrop, .menu > arrow:backdrop, .context-menu > arrow:backdrop { background-color: #14191a; }
+
+menu > arrow:disabled, .menu > arrow:disabled, .context-menu > arrow:disabled { color: transparent; background-color: transparent; border-color: transparent; }
+
+menuitem accelerator { color: alpha(currentColor,0.55); }
+
+menuitem check, menuitem radio { min-height: 16px; min-width: 16px; }
+
+menuitem check:dir(ltr), menuitem radio:dir(ltr) { margin-right: 7px; }
+
+menuitem check:dir(rtl), menuitem radio:dir(rtl) { margin-left: 7px; }
+
+/*************** Popovers   * */
+popover.background { padding: 2px; background-color: #171d20; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.csd popover.background, popover.background { border: 1px solid rgba(42, 52, 57, 0.75); border-radius: 10px; }
+
+.csd popover.background { background-clip: padding-box; }
+
+popover.background:backdrop { background-color: #14191a; box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); border-color: rgba(40, 48, 51, 0.75); }
+
+popover.background > list, popover.background > .view, popover.background > iconview, popover.background > toolbar { border-style: none; background-color: transparent; }
+
+popover.background separator { margin: 3px; }
+
+popover.background list separator { margin: 0px; }
+
+/************* Notebooks * */
+notebook > header { padding: 2px; border-style: none; background-color: #171d20; }
+
+notebook > header:backdrop { background-color: #14191a; }
+
+notebook > header.top { border-radius: 8px 8px 0 0; }
+
+notebook > header.bottom { border-radius: 0 0 8px 8px; }
+
+notebook > header.left { border-radius: 8px 0 0 8px; }
+
+notebook > header.right { border-radius: 0 8px 8px 0; }
+
+notebook > header > button { padding: 2px 9px; margin: 2px; }
+
+notebook > header.left > tabs > arrow, notebook > header.right > tabs > arrow { margin-top: -5px; margin-bottom: -5px; padding-top: 4px; padding-bottom: 4px; }
+
+notebook > header.left > tabs > arrow.down, notebook > header.right > tabs > arrow.down { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+notebook > header.left > tabs > arrow.up, notebook > header.right > tabs > arrow.up { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+notebook > header > tabs > arrow { transition: none; min-height: 16px; min-width: 16px; }
+
+notebook > header > tabs > arrow:hover:not(:active):not(:backdrop) { background-clip: padding-box; background-image: none; border-color: transparent; box-shadow: none; transition: none; }
+
+notebook > header > tabs > arrow:disabled { color: #6d8692; background-color: transparent; background-image: none; }
+
+notebook > header tab { min-height: 24px; min-width: 30px; padding: 2px 9px; margin: 2px; outline-offset: -3px; border-radius: 8px; color: #9cbecf; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header tab:hover { color: #bde6fb; background-color: rgba(189, 230, 251, 0.05); }
+
+notebook > header tab:backdrop { color: #6f828a; }
+
+notebook > header tab:backdrop.reorderable-page { background-color: transparent; }
+
+notebook > header tab:checked { color: #bde6fb; background-color: #354249; box-shadow: 0 2px 4px rgba(23, 29, 32, 0.075); }
+
+notebook > header tab:backdrop:checked { color: #6f828a; background-color: #272f32; box-shadow: 0 1px 2px rgba(20, 25, 26, 0.075); }
+
+notebook > header tab:backdrop:checked.reorderable-page { background-color: #272f32; }
+
+notebook > header tab button.flat { border-radius: 999px; padding: 0; margin-top: 2px; margin-bottom: 2px; min-width: 20px; min-height: 20px; }
+
+notebook > header tab button.flat:hover { color: currentColor; }
+
+notebook > header tab button.flat, notebook > header tab button.flat:backdrop { color: alpha(currentColor,0.3); }
+
+notebook > header tab button.flat:last-child { margin-left: 4px; margin-right: -4px; }
+
+notebook > header tab button.flat:first-child { margin-left: -4px; margin-right: 4px; }
+
+notebook > stack:not(:only-child) { background-color: transparent; }
+
+notebook > stack:not(:only-child):backdrop { background-color: transparent; }
+
+/************** Scrollbars * */
+scrollbar { background-color: transparent; transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border-radius: 8px; }
+
+* { -GtkScrollbar-has-backward-stepper: false; -GtkScrollbar-has-forward-stepper: false; }
+
+scrollbar:backdrop { border-color: #283033; transition: 150ms ease-out; }
+
+scrollbar slider { min-width: 6px; min-height: 6px; margin: -1px; border: 4px solid transparent; border-radius: 8px; background-clip: padding-box; background-color: #7d99a7; }
+
+scrollbar slider:hover { background-color: #9dbfd1; }
+
+scrollbar slider:hover:active { background-color: #bde6fb; }
+
+scrollbar slider:backdrop { background-color: #55646b; }
+
+scrollbar slider:disabled { background-color: transparent; }
+
+scrollbar.fine-tune slider { min-width: 4px; min-height: 4px; }
+
+scrollbar.fine-tune.horizontal slider { border-width: 5px 4px; }
+
+scrollbar.fine-tune.vertical slider { border-width: 4px 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) { border-color: transparent; opacity: 0.4; background-color: transparent; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider { margin: 0; min-width: 3px; min-height: 3px; background-color: #bde6fb; border: 1px solid black; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) button { min-width: 5px; min-height: 5px; background-color: #bde6fb; background-clip: padding-box; border-radius: 100%; border: 1px solid black; -gtk-icon-source: none; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider { margin: 0 2px; min-width: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal button { margin: 1px 2px; min-width: 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider { margin: 2px 0; min-height: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical button { margin: 2px 1px; min-height: 5px; }
+
+scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering { opacity: 0.8; }
+
+scrollbar.horizontal slider { min-width: 40px; }
+
+scrollbar.vertical slider { min-height: 40px; }
+
+scrollbar button { padding: 0; min-width: 12px; min-height: 12px; border-style: none; border-radius: 0; transition-property: min-height, min-width, color; background-color: transparent; background-image: none; background-image: none; color: #7d99a7; }
+
+scrollbar button:hover { background-color: transparent; background-image: none; background-image: none; color: #9dbfd1; }
+
+scrollbar button:active, scrollbar button:checked { background-color: transparent; background-image: none; background-image: none; color: #bde6fb; }
+
+scrollbar button:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(125, 153, 167, 0.2); }
+
+scrollbar button:backdrop { background-color: transparent; background-image: none; background-image: none; color: #55646b; }
+
+scrollbar button:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(85, 100, 107, 0.2); }
+
+scrollbar.vertical button.down { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+scrollbar.vertical button.up { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+scrollbar.horizontal button.down { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+scrollbar.horizontal button.up { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+/********** Switch * */
+switch { font-size: 0; outline-offset: -4px; min-width: 36px; min-height: 18px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border: none; padding: 2px; border-radius: 999px; background-color: #3d4c53; background-image: none; color: transparent; }
+
+switch:checked { background-color: #bde6fb; background: image(#bde6fb); }
+
+switch:disabled { background-color: #2a3439; background-image: none; }
+
+switch:disabled:checked { background-color: #566973; background-image: none; }
+
+switch:backdrop { background-color: #384347; background-image: none; transition: 150ms ease-out; }
+
+switch:backdrop:checked { background-color: #7f96a1; background-image: none; }
+
+switch:backdrop:disabled { background-color: #283033; background-image: none; }
+
+switch:backdrop:disabled:checked { background-color: #3d484d; background-image: none; }
+
+switch slider { margin: 2px; min-width: 18px; min-height: 18px; border: none; border-radius: 999px; -gtk-outline-radius: 999px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-color: #171d20; box-shadow: 0 2px 4px rgba(23, 29, 32, 0.075); }
+
+switch:disabled slider { background-color: #1e2529; box-shadow: none; }
+
+switch:backdrop slider { transition: 150ms ease-out; background-color: #1a2022; box-shadow: 0 2px 4px rgba(20, 25, 26, 0.075); }
+
+switch:checked slider { background-color: #171d20; box-shadow: none; }
+
+switch:backdrop:checked slider { background-color: #14191a; }
+
+row:selected switch { box-shadow: none; box-shadow: inset 0 0 0 1px #171d20; }
+
+/************************* Check and Radio items * */
+.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view:not(list) check { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view:not(list) check:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view:not(list) check:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view:not(list) check:backdrop { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view:not(list) check:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view:not(list) check:checked:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view:not(list) check:checked:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view:not(list) check:backdrop:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+checkbutton.text-button, radiobutton.text-button { padding: 2px 0; outline-offset: 0; }
+
+checkbutton.text-button label:not(:only-child):first-child, radiobutton.text-button label:not(:only-child):first-child { margin-left: 4px; }
+
+checkbutton.text-button label:not(:only-child):last-child, radiobutton.text-button label:not(:only-child):last-child { margin-right: 4px; }
+
+check, radio { margin: 0 4px; min-height: 14px; min-width: 14px; padding: 1px; border: none; -gtk-icon-source: none; }
+
+check:only-child, radio:only-child { margin: 0; }
+
+popover check.left:dir(rtl), popover radio.left:dir(rtl) { margin-left: 0; margin-right: 12px; }
+
+popover check.right:dir(ltr), popover radio.right:dir(ltr) { margin-left: 12px; margin-right: 0; }
+
+check, radio { background-clip: padding-box; background: image(#171d20); box-shadow: inset 0 0 0 1px #3d4c53; color: #bde6fb; }
+
+check:hover, radio:hover { background: image(#1f272b); }
+
+check:active, radio:active { background: image(#283136); }
+
+check:disabled, radio:disabled { box-shadow: none; background-image: none; background-color: #1a2125; color: rgba(189, 230, 251, 0.7); }
+
+check:backdrop, radio:backdrop { background-image: none; background-color: #191e20; box-shadow: inset 0 0 0 1px #3f4b51; color: #bde6fb; }
+
+check:backdrop:disabled, radio:backdrop:disabled { box-shadow: none; background-image: none; background-color: #1b2124; color: rgba(189, 230, 251, 0.7); }
+
+check:checked, radio:checked { background-clip: border-box; background: image(#bde6fb); box-shadow: none; color: #171d20; }
+
+check:checked:hover, radio:checked:hover { background: image(#bde6fb); }
+
+check:checked:active, radio:checked:active { background: image(#bde6fb); }
+
+check:checked:disabled, radio:checked:disabled { box-shadow: none; background-image: none; background-color: #6d8692; color: rgba(23, 29, 32, 0.7); }
+
+check:checked:backdrop, radio:checked:backdrop { background-image: none; background-color: #8fa9b7; box-shadow: none; color: #171d20; }
+
+check:checked:backdrop:disabled, radio:checked:backdrop:disabled { box-shadow: none; background-image: none; background-color: #71858e; color: rgba(23, 29, 32, 0.7); }
+
+check:indeterminate, radio:indeterminate { background-clip: border-box; background: image(#bde6fb); box-shadow: none; color: #171d20; }
+
+check:indeterminate:hover, radio:indeterminate:hover { background: image(#bde6fb); }
+
+check:indeterminate:active, radio:indeterminate:active { background: image(#bde6fb); }
+
+check:indeterminate:disabled, radio:indeterminate:disabled { box-shadow: none; background-image: none; background-color: #6d8692; color: rgba(23, 29, 32, 0.7); }
+
+check:indeterminate:backdrop, radio:indeterminate:backdrop { background-image: none; background-color: #8fa9b7; box-shadow: none; color: #171d20; }
+
+check:indeterminate:backdrop:disabled, radio:indeterminate:backdrop:disabled { box-shadow: none; background-image: none; background-color: #71858e; color: rgba(23, 29, 32, 0.7); }
+
+check:backdrop, radio:backdrop { transition: 150ms ease-out; }
+
+menu menuitem check, menu menuitem radio { margin: 0; }
+
+menu menuitem check, menu menuitem check:hover, menu menuitem check:disabled, menu menuitem check:checked, menu menuitem check:checked:hover, menu menuitem check:checked:disabled, menu menuitem check:indeterminate, menu menuitem check:indeterminate:hover, menu menuitem check:indeterminate:disabled, menu menuitem radio, menu menuitem radio:hover, menu menuitem radio:disabled, menu menuitem radio:checked, menu menuitem radio:checked:hover, menu menuitem radio:checked:disabled, menu menuitem radio:indeterminate, menu menuitem radio:indeterminate:hover, menu menuitem radio:indeterminate:disabled { min-height: 14px; min-width: 14px; background-image: none; background-color: transparent; box-shadow: none; -gtk-icon-shadow: none; color: inherit; border: 1px solid currentColor; padding: 0; }
+
+check { border-radius: 4px; }
+
+check:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/check-symbolic.svg")), -gtk-recolor(url("assets/check-symbolic.symbolic.png"))); }
+
+check:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+treeview.view radio:selected:focus, treeview.view radio:selected, radio { border-radius: 100%; }
+
+treeview.view radio:checked:selected, radio:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/bullet-symbolic.svg")), -gtk-recolor(url("assets/bullet-symbolic.symbolic.png"))); }
+
+treeview.view radio:indeterminate:selected, radio:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+radio:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: scale(0); }
+
+check:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: translate(6px, -3px) rotate(-45deg) scaleY(0.2) rotate(45deg) scaleX(0); }
+
+radio:active, check:active { -gtk-icon-transform: scale(0, 1); }
+
+radio:checked:not(:backdrop), radio:indeterminate:not(:backdrop), check:checked:not(:backdrop), check:indeterminate:not(:backdrop) { -gtk-icon-transform: unset; transition: 400ms; }
+
+menu menuitem radio:checked:not(:backdrop), menu menuitem radio:indeterminate:not(:backdrop), menu menuitem check:checked:not(:backdrop), menu menuitem check:indeterminate:not(:backdrop) { transition: none; }
+
+treeview.view check:selected:focus, treeview.view check:selected, treeview.view radio:selected:focus, treeview.view radio:selected { color: #171d20; border: 1px solid #afd5e8; }
+
+treeview.view check:selected:focus:backdrop, treeview.view check:selected:backdrop, treeview.view radio:selected:focus:backdrop, treeview.view radio:selected:backdrop { border-color: #92b0bf; }
+
+/************ GtkScale * */
+levelbar block.empty, progressbar trough, scale fill, scale trough { border: none; border-radius: 8px; background-color: #2a3439; }
+
+levelbar block.empty:disabled, progressbar trough:disabled, scale fill:disabled, scale trough:disabled { background-color: #2a3439; }
+
+levelbar block.empty:backdrop, progressbar trough:backdrop, scale fill:backdrop, scale trough:backdrop { background-color: #283033; transition: 150ms ease-out; }
+
+levelbar block.empty:backdrop:disabled, progressbar trough:backdrop:disabled, scale fill:backdrop:disabled, scale trough:backdrop:disabled { background-color: #283033; }
+
+row:selected levelbar block.empty, levelbar row:selected block.empty, row:selected progressbar trough, progressbar row:selected trough, row:selected scale fill, scale row:selected fill, row:selected scale trough, scale row:selected trough { border: 1px solid #171d20; }
+
+progressbar progress, scale highlight { border: none; border-radius: 8px; background-color: #bde6fb; background: image(#bde6fb); }
+
+scale.vertical progressbar progress, progressbar scale.vertical progress, scale.vertical highlight, progressbar.vertical progress, progressbar.vertical scale highlight, scale progressbar.vertical highlight { background: image(#bde6fb); }
+
+progressbar progress:disabled, scale highlight:disabled { background-image: none; background-color: #3d4c53; }
+
+progressbar progress:backdrop, scale highlight:backdrop { background-image: none; background-color: #7f96a1; }
+
+progressbar progress:backdrop:disabled, scale highlight:backdrop:disabled { background-image: none; background-color: #384347; }
+
+row:selected progressbar progress, progressbar row:selected progress, row:selected scale highlight, scale row:selected highlight { border: 1px solid #171d20; }
+
+scale { min-height: 10px; min-width: 10px; padding: 12px; }
+
+scale slider { min-height: 16px; min-width: 16px; margin: -8px; }
+
+scale.fine-tune.horizontal { padding-top: 9px; padding-bottom: 9px; min-height: 16px; }
+
+scale.fine-tune.vertical { padding-left: 9px; padding-right: 9px; min-width: 16px; }
+
+scale.fine-tune slider { margin: -6px; }
+
+scale.fine-tune fill, scale.fine-tune highlight, scale.fine-tune trough { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+scale trough { outline-offset: 2px; -gtk-outline-radius: 8px; }
+
+scale fill:backdrop, scale fill { background-color: #2a3439; }
+
+scale fill:disabled:backdrop, scale fill:disabled { border-color: transparent; background-color: transparent; }
+
+scale slider { border: 2px solid #bde6fb; border-radius: 100%; background-color: #1e2529; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-property: background, border, box-shadow; }
+
+row scale slider, popover scale slider { background-color: #171d20; }
+
+scale slider:hover { background-color: #171d20; }
+
+row scale slider:hover, popover scale slider:hover { background-color: #1e2529; }
+
+scale slider:active, row scale slider:active, popover scale slider:active { background-color: #bde6fb; }
+
+scale slider:disabled { border-color: #3d4c53; }
+
+scale slider:backdrop { background-color: #1a2022; border-color: #7f96a1; transition: 150ms ease-out; }
+
+scale slider:backdrop:disabled { border-color: #384347; }
+
+row:selected scale slider:disabled, row:selected scale slider { border-color: #afd5e8; }
+
+scale marks, scale value { color: alpha(currentColor,0.55); font-feature-settings: "tnum"; }
+
+scale.horizontal marks.top { margin-bottom: 6px; margin-top: -12px; }
+
+scale.horizontal.fine-tune marks.top { margin-bottom: 6px; margin-top: -9px; }
+
+scale.horizontal marks.bottom { margin-top: 6px; margin-bottom: -12px; }
+
+scale.horizontal.fine-tune marks.bottom { margin-top: 6px; margin-bottom: -9px; }
+
+scale.vertical marks.top { margin-right: 6px; margin-left: -12px; }
+
+scale.vertical.fine-tune marks.top { margin-right: 6px; margin-left: -9px; }
+
+scale.vertical marks.bottom { margin-left: 6px; margin-right: -12px; }
+
+scale.vertical.fine-tune marks.bottom { margin-left: 6px; margin-right: -9px; }
+
+scale.horizontal indicator { min-height: 6px; min-width: 1px; }
+
+scale.horizontal.fine-tune indicator { min-height: 3px; }
+
+scale.vertical indicator { min-height: 1px; min-width: 6px; }
+
+scale.vertical.fine-tune indicator { min-width: 3px; }
+
+scale.horizontal.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #bde6fb; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-top: -13px; background-position: top; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:hover { color: #d5effc; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:active { color: #bde6fb; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:disabled { color: #3d4c53; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop { color: #7f96a1; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop:disabled { color: #384347; }
+
+scale.horizontal.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-top: -11px; }
+
+scale.horizontal.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #bde6fb; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-bottom: -13px; background-position: bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:hover { color: #d5effc; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:active { color: #bde6fb; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:disabled { color: #3d4c53; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop { color: #7f96a1; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop:disabled { color: #384347; }
+
+scale.horizontal.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-bottom: -11px; }
+
+scale.vertical.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #bde6fb; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-left: -13px; background-position: left bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-before:not(.marks-after) slider:hover { color: #d5effc; }
+
+scale.vertical.marks-before:not(.marks-after) slider:active { color: #bde6fb; }
+
+scale.vertical.marks-before:not(.marks-after) slider:disabled { color: #3d4c53; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop { color: #7f96a1; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop:disabled { color: #384347; }
+
+scale.vertical.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-left: -11px; }
+
+scale.vertical.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #bde6fb; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-right: -13px; background-position: right bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-after:not(.marks-before) slider:hover { color: #d5effc; }
+
+scale.vertical.marks-after:not(.marks-before) slider:active { color: #bde6fb; }
+
+scale.vertical.marks-after:not(.marks-before) slider:disabled { color: #3d4c53; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop { color: #7f96a1; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop:disabled { color: #384347; }
+
+scale.vertical.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-right: -11px; }
+
+scale.color { min-height: 0; min-width: 0; }
+
+scale.color trough { background-color: transparent; }
+
+scale.color.horizontal { padding: 0 0 15px 0; }
+
+scale.color.horizontal trough { padding-bottom: 4px; background-position: 0 -3px; border-top-left-radius: 0; border-top-right-radius: 0; }
+
+scale.color.horizontal slider:dir(ltr):hover, scale.color.horizontal slider:dir(ltr):backdrop, scale.color.horizontal slider:dir(ltr):disabled, scale.color.horizontal slider:dir(ltr):backdrop:disabled, scale.color.horizontal slider:dir(ltr), scale.color.horizontal slider:dir(rtl):hover, scale.color.horizontal slider:dir(rtl):backdrop, scale.color.horizontal slider:dir(rtl):disabled, scale.color.horizontal slider:dir(rtl):backdrop:disabled, scale.color.horizontal slider:dir(rtl) { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.vertical:dir(ltr) { padding: 0 0 0 15px; }
+
+scale.color.vertical:dir(ltr) trough { padding-left: 4px; background-position: 3px 0; border-bottom-right-radius: 0; border-top-right-radius: 0; }
+
+scale.color.vertical:dir(ltr) slider:hover, scale.color.vertical:dir(ltr) slider:backdrop, scale.color.vertical:dir(ltr) slider:disabled, scale.color.vertical:dir(ltr) slider:backdrop:disabled, scale.color.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.vertical:dir(rtl) { padding: 0 15px 0 0; }
+
+scale.color.vertical:dir(rtl) trough { padding-right: 4px; background-position: -3px 0; border-bottom-left-radius: 0; border-top-left-radius: 0; }
+
+scale.color.vertical:dir(rtl) slider:hover, scale.color.vertical:dir(rtl) slider:backdrop, scale.color.vertical:dir(rtl) slider:disabled, scale.color.vertical:dir(rtl) slider:backdrop:disabled, scale.color.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr), scale.color.fine-tune.horizontal:dir(rtl) { padding: 0 0 12px 0; }
+
+scale.color.fine-tune.horizontal:dir(ltr) trough, scale.color.fine-tune.horizontal:dir(rtl) trough { padding-bottom: 7px; background-position: 0 -6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr) slider, scale.color.fine-tune.horizontal:dir(rtl) slider { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.fine-tune.vertical:dir(ltr) { padding: 0 0 0 12px; }
+
+scale.color.fine-tune.vertical:dir(ltr) trough { padding-left: 7px; background-position: 6px 0; }
+
+scale.color.fine-tune.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.fine-tune.vertical:dir(rtl) { padding: 0 12px 0 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) trough { padding-right: 7px; background-position: -6px 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+/***************** Progress bars * */
+@keyframes progress { from { background-position: 0, calc(0% - 64px), 0%; }
+  to { background-position: 0, calc(100% + 64px), 0%; } }
+
+progressbar { font-size: smaller; color: rgba(189, 230, 251, 0.4); font-feature-settings: "tnum"; }
+
+progressbar.horizontal trough, progressbar.horizontal progress { min-height: 4px; }
+
+progressbar.vertical trough, progressbar.vertical progress { min-width: 4px; }
+
+progressbar:backdrop { box-shadow: none; transition: 150ms ease-out; }
+
+progressbar trough { border-radius: 999px; }
+
+progressbar progress { background-image: none; background-color: #bde6fb; border-radius: 999px; }
+
+progressbar progress, progressbar progress:backdrop, .horizontal progressbar progress { animation: none; }
+
+progressbar.horizontal progress { margin: 0 -1px; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled) { animation: progress 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite; background-size: cover, 64px 100%; background-repeat: no-repeat; background-image: linear-gradient(to bottom, alpha(@progress_bg_color, 0.2), rgba(157, 191, 209, 0)), linear-gradient(to right, rgba(157, 191, 209, 0), #9dbfd1 60%, rgba(157, 191, 209, 0)); }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled).right { animation-direction: reverse; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled):backdrop { animation: none; background-image: none; }
+
+progressbar.vertical progress { margin: -1px 0; }
+
+progressbar.osd { min-width: 4px; min-height: 4px; background-color: transparent; }
+
+progressbar.osd trough { border-style: none; border-radius: 0; background-color: transparent; box-shadow: none; }
+
+progressbar.osd progress { border-style: none; border-radius: 0; }
+
+progressbar trough.empty progress { all: unset; }
+
+/************* Level Bar * */
+levelbar.horizontal block { min-height: 4px; }
+
+levelbar.horizontal.discrete block { margin: 0 2px; min-width: 32px; }
+
+levelbar.horizontal.discrete block:first-child { margin-left: 0; }
+
+levelbar.horizontal.discrete block:last-child { margin-right: 0; }
+
+levelbar.vertical block { min-width: 4px; }
+
+levelbar.vertical.discrete block { margin: 2px 0; min-height: 32px; }
+
+levelbar.vertical.discrete block:first-child { margin-top: 0; }
+
+levelbar.vertical.discrete block:last-child { margin-bottom: 0; }
+
+levelbar:backdrop { transition: 150ms ease-out; }
+
+levelbar trough { border: none; padding: 0; background-color: transparent; }
+
+levelbar block { border: none; border-radius: 999px; }
+
+levelbar block.warning-battery-offset { background-color: #fb7c7c; background: image(#fb7c7c); }
+
+levelbar block.warning-battery-offset:backdrop { background-image: none; background-color: #7f96a1; }
+
+levelbar block.low, levelbar block.low-battery-offset { background-color: #faa483; background: image(#faa483); }
+
+levelbar block.low:backdrop, levelbar block.low-battery-offset:backdrop { background-image: none; background-color: #7f96a1; }
+
+levelbar block.high, levelbar block:not(.empty) { background-color: #bde6fb; background: image(#bde6fb); }
+
+levelbar block.high:backdrop, levelbar block:not(.empty):backdrop { background-image: none; background-color: #7f96a1; }
+
+levelbar block.full, levelbar block.high-battery-offset { background-color: #6ee1b6; background: image(#6ee1b6); }
+
+levelbar block.full:backdrop, levelbar block.high-battery-offset:backdrop { background-image: none; background-color: #7f96a1; }
+
+levelbar block.empty { background-image: none; }
+
+levelbar block:disabled { background-image: none; background-color: #3d4c53; }
+
+levelbar block:disabled:backdrop { background-image: none; background-color: #384347; }
+
+/**************** Print dialog * */
+printdialog paper { color: black; border: 1px solid #595959; background: white; padding: 0; }
+
+printdialog paper:backdrop { color: #595959; border: 1px solid #262626; }
+
+printdialog .dialog-action-box { margin: 12px; }
+
+/********** Frames * */
+frame > border, .frame { box-shadow: none; margin: 0; padding: 0; border-radius: 10px; border: 1px solid #1e2529; }
+
+frame > border.flat, .frame.flat { border-style: none; }
+
+frame > border:backdrop, .frame:backdrop { border-color: #1a2022; }
+
+.background.csd revealer > actionbar { border-radius: 0 0 10px 10px; }
+
+actionbar > revealer > box { padding: 6px; border-top: 1px solid #2a3439; }
+
+actionbar > revealer > box:backdrop { border-color: #283033; }
+
+scrolledwindow { background-color: transparent; border-radius: 0 0 8px 8px; }
+
+scrolledwindow viewport.frame { border-style: none; }
+
+scrolledwindow overshoot.top { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(rgba(189, 230, 251, 0.5)), to(rgba(189, 230, 251, 0))), -gtk-gradient(radial, center top, 0, center top, 0.6, from(rgba(189, 230, 251, 0.1)), to(rgba(189, 230, 251, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.top:backdrop { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(#283033), to(rgba(40, 48, 51, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(rgba(189, 230, 251, 0.5)), to(rgba(189, 230, 251, 0))), -gtk-gradient(radial, center bottom, 0, center bottom, 0.6, from(rgba(189, 230, 251, 0.1)), to(rgba(189, 230, 251, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom:backdrop { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(#283033), to(rgba(40, 48, 51, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(rgba(189, 230, 251, 0.5)), to(rgba(189, 230, 251, 0))), -gtk-gradient(radial, left center, 0, left center, 0.6, from(rgba(189, 230, 251, 0.1)), to(rgba(189, 230, 251, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left:backdrop { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(#283033), to(rgba(40, 48, 51, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(rgba(189, 230, 251, 0.5)), to(rgba(189, 230, 251, 0))), -gtk-gradient(radial, right center, 0, right center, 0.6, from(rgba(189, 230, 251, 0.1)), to(rgba(189, 230, 251, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right:backdrop { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(#283033), to(rgba(40, 48, 51, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+scrolledwindow junction { border-color: transparent; border-image: linear-gradient(to bottom, #2a3439 1px, transparent 1px) 0 0 0 1/0 1px stretch; background-color: transparent; }
+
+scrolledwindow junction:dir(rtl) { border-image-slice: 0 1 0 0; }
+
+scrolledwindow junction:backdrop { border-image-source: linear-gradient(to bottom, #283033 1px, transparent 1px); background-color: transparent; transition: 150ms ease-out; }
+
+separator { background: #2a3439; min-width: 1px; min-height: 1px; }
+
+/********* Lists * */
+list { color: #bde6fb; background-color: #171d20; border-color: transparent; border-radius: 10px; }
+
+list, list.frame { padding-top: 4px; padding-bottom: 4px; }
+
+list.content, list.content list { background-color: transparent; padding: 0; }
+
+list:backdrop { background-color: #14191a; color: #6f828a; border-color: transparent; }
+
+list separator.horizontal { margin: 1px 16px; }
+
+list separator.vertical { margin: 16px 1px; }
+
+list row { padding: 2px; }
+
+row { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+list:not(.content) row { border-radius: 8px; margin: 1px 6px; }
+
+list.content row { background-color: #171d20; }
+
+list.content row:backdrop { background-color: #14191a; }
+
+list.content row:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+list.content row:last-child { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+row.expander { padding: 0px; }
+
+row:hover { transition: none; }
+
+row:backdrop { transition: 150ms ease-out; }
+
+row.activatable { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+row.activatable.has-open-popup, row.activatable:hover { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #2a3439; background-image: none; background-color: rgba(189, 230, 251, 0.05); }
+
+row.activatable:active { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #354249; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, rgba(189, 230, 251, 0.15) 10%, transparent 0%); background-size: 0% 0%; }
+
+row.activatable:backdrop:hover { background-color: transparent; background-image: none; background-image: none; color: #6f828a; }
+
+row.activatable:selected { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; background: image(#bde6fb); box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); }
+
+row.activatable:selected label { color: #171d20; }
+
+row.activatable:selected:active { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); }
+
+row.activatable:selected:backdrop { background-color: #7f96a1; background-image: none; box-shadow: none; }
+
+row.activatable:selected:backdrop label, row.activatable:selected:backdrop { color: #14191a; }
+
+/********************* App Notifications * */
+.app-notification, .app-notification.frame { padding: 10px; margin: 8px; border-radius: 30px; border: 1px solid rgba(42, 52, 57, 0.75); box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification:backdrop, .app-notification.frame:backdrop { background-color: #14191a; transition: 150ms ease-out; border-color: rgba(40, 48, 51, 0.75); box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification border, .app-notification.frame border { border: none; }
+
+.app-notification button:not(.linked), .app-notification.frame button:not(.linked) { border-radius: 999px; -gtk-outline-radius: 999px; }
+
+/************* Expanders * */
+expander title > arrow { min-width: 16px; min-height: 16px; -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+expander title > arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+expander title > arrow:hover { color: white; }
+
+expander title > arrow:disabled { color: #6d8692; }
+
+expander title > arrow:disabled:backdrop { color: #3b494d; }
+
+expander title > arrow:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+/************ Calendar * */
+calendar { color: #bde6fb; }
+
+calendar:selected { border-radius: 8px; }
+
+calendar.header { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.header:backdrop { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.button { color: rgba(189, 230, 251, 0.45); }
+
+calendar.button:hover { color: #bde6fb; }
+
+calendar.button:backdrop { color: rgba(111, 130, 138, 0.45); }
+
+calendar.button:disabled { color: rgba(109, 134, 146, 0.45); }
+
+calendar.highlight { color: #6d8692; }
+
+calendar.highlight:backdrop { color: #3b494d; }
+
+calendar:backdrop { color: #6f828a; border-color: #283033; }
+
+calendar:indeterminate { color: alpha(currentColor,0.1); }
+
+/*********** Dialogs * */
+messagedialog .titlebar { min-height: 20px; background-image: none; background-color: #1e2529; border-style: none; border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+messagedialog.csd.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button { padding: 10px 14px; border-right-style: none; border-bottom-style: none; border-radius: 0; margin: 0 2px 0 0; -gtk-outline-radius: 0; }
+
+messagedialog.csd .dialog-action-area button:first-child { border-left-style: none; border-bottom-left-radius: 10px; -gtk-outline-bottom-left-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button:last-child { border-bottom-right-radius: 10px; margin-right: 0; -gtk-outline-bottom-right-radius: 10px; }
+
+filechooser .dialog-action-box { border-top: 1px solid #2a3439; }
+
+filechooser .dialog-action-box:backdrop { border-top-color: #283033; }
+
+filechooser #pathbarbox { border: none; }
+
+filechooser #pathbarbox:backdrop { background-color: #1a2022; }
+
+filechooserbutton:drop(active) { box-shadow: none; border-color: transparent; }
+
+/*********** Sidebar * */
+.sidebar { border-style: none; background-color: transparent; border-radius: 0 0 10px 10px; }
+
+stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:not(separator):dir(ltr), .sidebar:not(separator).left { border-right: 1px solid #2a3439; border-left-style: none; }
+
+stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:not(separator):dir(rtl), .sidebar:not(separator).right { border-left: 1px solid #2a3439; border-right-style: none; }
+
+.sidebar:backdrop { border-color: #283033; transition: 150ms ease-out; }
+
+.sidebar list { background-color: transparent; }
+
+paned .sidebar.left, paned .sidebar.right, paned .sidebar.left:dir(rtl), paned .sidebar:dir(rtl), paned .sidebar:dir(ltr), paned .sidebar { border-style: none; }
+
+stacksidebar row { padding: 10px 4px; }
+
+stacksidebar row > label { padding-left: 6px; padding-right: 6px; }
+
+stacksidebar row.needs-attention > label { background-size: 6px 6px, 0 0; }
+
+separator.sidebar { background-color: #2a3439; }
+
+separator.sidebar:backdrop { background-color: #283033; }
+
+separator.sidebar.selection-mode, .selection-mode separator.sidebar { background-color: #afd5e8; }
+
+/**************** File chooser * */
+row image.sidebar-icon { opacity: 0.7; }
+
+placessidebar > viewport.frame { border-style: none; background-color: transparent; }
+
+placessidebar undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+placessidebar list { padding-top: 0; }
+
+placessidebar row { min-height: 36px; padding: 0px; margin-top: 0; margin-bottom: 0; }
+
+placessidebar row:first-child { margin-top: 0; }
+
+placessidebar row > revealer { padding: 0 8px; }
+
+placessidebar row:selected { color: #171d20; }
+
+placessidebar row:disabled { color: #6d8692; }
+
+placessidebar row:backdrop { color: #6f828a; }
+
+placessidebar row:backdrop:selected { color: #14191a; }
+
+placessidebar row:backdrop:disabled { color: #3b494d; }
+
+placessidebar row image.sidebar-icon:dir(ltr) { padding-right: 8px; }
+
+placessidebar row image.sidebar-icon:dir(rtl) { padding-left: 8px; }
+
+placessidebar row label.sidebar-label:dir(ltr) { padding-right: 2px; }
+
+placessidebar row label.sidebar-label:dir(rtl) { padding-left: 2px; }
+
+button.sidebar-button { min-height: 26px; min-width: 26px; margin: 0; padding: 0; border-radius: 100%; -gtk-outline-radius: 100%; }
+
+button.sidebar-button:not(:hover):not(:active) > image, button.sidebar-button:backdrop > image { opacity: 0.7; }
+
+placessidebar row:selected:active { box-shadow: none; }
+
+placessidebar row.sidebar-placeholder-row { padding: 0 8px; min-height: 2px; background-image: image(#4cd9a4); background-clip: content-box; }
+
+placessidebar row.sidebar-new-bookmark-row { color: #bde6fb; }
+
+placessidebar row:drop(active):not(:disabled) { color: #4cd9a4; box-shadow: inset 0 0 0 2px #4cd9a4; }
+
+placessidebar row:drop(active):not(:disabled):selected { color: #171d20; background-color: #4cd9a4; }
+
+placesview list { background-color: #1e2529; border-radius: 0 0 10px 0; }
+
+placesview list:backdrop { background-color: #1a2022; }
+
+placesview .server-list-button > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(0turn); }
+
+placesview .server-list-button:checked > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(-0.5turn); }
+
+placesview row.activatable:hover { background-color: transparent; }
+
+placesview > actionbar > revealer > box > label { padding-left: 8px; padding-right: 8px; }
+
+/********* Paned * */
+paned > separator { min-width: 1px; min-height: 1px; -gtk-icon-source: none; border-style: none; background-color: transparent; background-image: image(#2a3439); background-size: 1px 1px; }
+
+paned > separator:selected { background-image: image(#bde6fb); }
+
+paned > separator:backdrop { background-image: image(#283033); }
+
+paned > separator.wide { min-width: 5px; min-height: 5px; background-color: #1e2529; background-image: image(#2a3439), image(#2a3439); background-size: 1px 1px, 1px 1px; }
+
+paned > separator.wide:backdrop { background-color: #1a2022; background-image: image(#283033), image(#283033); }
+
+paned.horizontal > separator { background-repeat: repeat-y; }
+
+paned.horizontal > separator:dir(ltr) { margin: 0 -8px 0 0; padding: 0 8px 0 0; background-position: left; }
+
+paned.horizontal > separator:dir(rtl) { margin: 0 0 0 -8px; padding: 0 0 0 8px; background-position: right; }
+
+paned.horizontal > separator.wide { margin: 0; padding: 0; background-repeat: repeat-y, repeat-y; background-position: left, right; }
+
+paned.vertical > separator { margin: 0 0 -8px 0; padding: 0 0 8px 0; background-repeat: repeat-x; background-position: top; }
+
+paned.vertical > separator.wide { margin: 0; padding: 0; background-repeat: repeat-x, repeat-x; background-position: bottom, top; }
+
+/************** GtkInfoBar * */
+infobar { border-style: none; }
+
+infobar.action:hover > revealer > box { background-color: #2c1d17; border-bottom: 1px solid #1e2529; }
+
+infobar.info, infobar.question, infobar.warning, infobar.error { text-shadow: none; }
+
+infobar.info:backdrop > revealer > box, infobar.info > revealer > box, infobar.question:backdrop > revealer > box, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box, infobar.error > revealer > box { background-color: #32211a; border-bottom: 1px solid #1e2529; }
+
+infobar.info:backdrop > revealer > box label, infobar.info:backdrop > revealer > box, infobar.info > revealer > box label, infobar.info > revealer > box, infobar.question:backdrop > revealer > box label, infobar.question:backdrop > revealer > box, infobar.question > revealer > box label, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box label, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box label, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box label, infobar.error:backdrop > revealer > box, infobar.error > revealer > box label, infobar.error > revealer > box { color: #faa483; }
+
+infobar.info:backdrop, infobar.question:backdrop, infobar.warning:backdrop, infobar.error:backdrop { text-shadow: none; }
+
+infobar.info button, infobar.question button, infobar.warning button, infobar.error button { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #412b22; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #50352a; background-image: none; }
+
+infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #5a3b2f; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #6e483a 10%, transparent 0%); background-size: 0% 0%; }
+
+infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; background: image(#bde6fb); box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); }
+
+infobar.info button:checked:active, infobar.question button:checked:active, infobar.warning button:checked:active, infobar.error button:checked:active { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); }
+
+infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled { color: #6d8692; background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop, infobar.question button:backdrop, infobar.warning button:backdrop, infobar.error button:backdrop { background-color: #20272a; background-image: none; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.error button:backdrop label, infobar.error button:backdrop { color: #6f828a; }
+
+infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop:disabled label, infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled label, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled label, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled label, infobar.error button:backdrop:disabled { color: #3b494d; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.info button label, infobar.info button, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.question button label, infobar.question button, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.warning button label, infobar.warning button, infobar.error button:backdrop label, infobar.error button:backdrop, infobar.error button label, infobar.error button { color: #faa483; }
+
+infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection { background-color: #080b0c; }
+
+infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link { color: #edf8fe; }
+
+/************ Tooltips * */
+tooltip { padding: 4px; /* not working */ border-radius: 10px; box-shadow: none; }
+
+tooltip.background, tooltip.background.csd { border-radius: 10px; background-color: rgba(0, 0, 0, 0.8); background-clip: padding-box; border: 1px solid rgba(255, 255, 255, 0.1); }
+
+tooltip decoration { background-color: transparent; }
+
+tooltip * { padding: 4px; background-color: transparent; color: white; }
+
+/***************** Color Chooser * */
+colorswatch:drop(active), colorswatch { border-style: none; }
+
+colorswatch.top { border-top-left-radius: 8.5px; border-top-right-radius: 8.5px; }
+
+colorswatch.top overlay { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+colorswatch.bottom { border-bottom-left-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.bottom overlay { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.left, colorswatch:first-child:not(.top) { border-top-left-radius: 8.5px; border-bottom-left-radius: 8.5px; }
+
+colorswatch.left overlay, colorswatch:first-child:not(.top) overlay { border-top-left-radius: 8px; border-bottom-left-radius: 8px; }
+
+colorswatch.right, colorswatch:last-child:not(.bottom) { border-top-right-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.right overlay, colorswatch:last-child:not(.bottom) overlay { border-top-right-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.dark { outline-color: rgba(255, 255, 255, 0.6); }
+
+colorswatch.dark overlay { color: white; }
+
+colorswatch.dark overlay:backdrop { color: rgba(255, 255, 255, 0.5); }
+
+colorswatch.light { outline-color: rgba(0, 0, 0, 0.6); }
+
+colorswatch.light overlay { color: black; }
+
+colorswatch.light overlay:backdrop { color: rgba(0, 0, 0, 0.5); }
+
+colorswatch:drop(active) { box-shadow: none; }
+
+colorswatch:drop(active).light overlay { border-color: #4cd9a4; }
+
+colorswatch:drop(active).dark overlay { border-color: #4cd9a4; }
+
+colorswatch overlay { border: 1px solid transparent; }
+
+colorswatch#add-color-button { border-radius: 8px 8px 0 0; }
+
+colorswatch#add-color-button:only-child { border-radius: 8px; }
+
+colorswatch#add-color-button overlay { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #2a3439; background-image: none; }
+
+colorswatch#add-color-button overlay:hover { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-color: #354249; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop { background-color: #20272a; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop label, colorswatch#add-color-button overlay:backdrop { color: #6f828a; }
+
+colorswatch:disabled { opacity: 0.5; }
+
+colorswatch:disabled overlay { border-color: rgba(0, 0, 0, 0.6); box-shadow: none; }
+
+row:selected colorswatch { box-shadow: 0 0 0 2px #171d20; }
+
+colorswatch#editor-color-sample { border-radius: 8px; }
+
+colorswatch#editor-color-sample overlay { border-radius: 8.5px; }
+
+colorchooser .popover.osd { border-radius: 8px; }
+
+/******** Misc * */
+.content-view { background-color: #181f22; }
+
+.content-view:hover { -gtk-icon-effect: highlight; }
+
+.content-view:backdrop { background-color: #14191b; }
+
+.osd .scale-popup button.flat { border-style: none; border-radius: 8px; }
+
+.scale-popup button:hover { background-color: rgba(189, 230, 251, 0.15); border-radius: 8px; }
+
+/********************** Window Decorations * */
+decoration { border-radius: 10px; border-width: 0px; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(189, 230, 251, 0.1); margin: 10px; }
+
+decoration:backdrop { box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(111, 130, 138, 0.125); transition: 150ms ease-out; }
+
+.maximized decoration, .fullscreen decoration, .tiled decoration, .tiled-top decoration, .tiled-right decoration, .tiled-bottom decoration, .tiled-left decoration { border-radius: 0; }
+
+.popup decoration { box-shadow: none; }
+
+.ssd decoration { box-shadow: 0 0 0 1px rgba(189, 230, 251, 0.1); }
+
+.csd.popup decoration { border-radius: 8px; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(189, 230, 251, 0.1); }
+
+.csd.popup decoration:backdrop { box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(111, 130, 138, 0.125); }
+
+tooltip.csd decoration { border-radius: 10px; box-shadow: none; }
+
+messagedialog.csd decoration { border-radius: 10px; box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(189, 230, 251, 0.1); }
+
+messagedialog.csd decoration:backdrop { box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(111, 130, 138, 0.125); }
+
+.solid-csd decoration { margin: 0; padding: 4px; background-color: #2a3439; border: solid 1px #2a3439; border-radius: 0; box-shadow: none; }
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized), window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration, window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration-overlay { border-radius: 10px; }
+
+button.titlebutton:not(.appmenu) { border-radius: 9999px; padding: 6px; margin: 0 2px; min-width: 0; min-height: 0; }
+
+button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.selection-mode headerbar button.titlebutton:backdrop, .selection-mode .titlebar button.titlebutton:backdrop, headerbar.selection-mode button.titlebutton:backdrop, .titlebar.selection-mode button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { background-color: #bde6fb; }
+
+.selection-mode button.titlebutton, .view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { color: #171d20; }
+
+.selection-mode button.titlebutton:disabled, .view:disabled:selected, textview text:disabled:selected:focus, .view text:disabled:selected, textview text:disabled:selected, iconview:disabled:selected:focus, iconview:disabled:selected, flowbox flowboxchild:disabled:selected, modelbutton.flat:disabled:selected, .menuitem.button.flat:disabled:selected, treeview.view:disabled:selected, row:disabled:selected, calendar:disabled:selected { color: #6a818d; }
+
+.selection-mode button.titlebutton:backdrop, .view:backdrop:selected, textview text:backdrop:selected:focus, .view text:backdrop:selected, textview text:backdrop:selected, iconview:backdrop:selected:focus, iconview:backdrop:selected, flowbox flowboxchild:backdrop:selected, modelbutton.flat:backdrop:selected, .menuitem.button.flat:backdrop:selected, treeview.view:backdrop:selected, row:backdrop:selected, calendar:backdrop:selected { color: #14191a; background-color: #7f96a1; }
+
+.selection-mode button.titlebutton:backdrop:disabled, .view:backdrop:disabled:selected, .view text:backdrop:disabled:selected, textview text:backdrop:disabled:selected, iconview:backdrop:disabled:selected, flowbox flowboxchild:backdrop:disabled:selected, modelbutton.flat:backdrop:disabled:selected, .menuitem.button.flat:backdrop:disabled:selected, row:backdrop:disabled:selected, calendar:backdrop:disabled:selected { color: #8aa8b7; }
+
+.view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { background-color: #415158; }
+
+label:selected, .view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { color: #bde6fb; }
+
+label:disabled selection, label:disabled:selected, .view text selection:disabled, textview text selection:disabled:focus, textview text selection:disabled, iconview text selection:disabled:focus, iconview text selection:disabled, label selection:disabled, entry selection:disabled, spinbutton:not(.vertical) selection:disabled { color: #75909c; }
+
+label:backdrop selection, label:backdrop:selected, .view text selection:backdrop, textview text selection:backdrop:focus, textview text selection:backdrop, iconview text selection:backdrop:focus, iconview text selection:backdrop, label selection:backdrop, entry selection:backdrop, spinbutton:not(.vertical) selection:backdrop { background-color: #313b3f; color: #70848d; }
+
+label:backdrop selection:disabled, label:backdrop:disabled:selected, .view text selection:backdrop:disabled, textview text selection:backdrop:disabled, iconview text selection:backdrop:disabled, label selection:backdrop:disabled, entry selection:backdrop:disabled, spinbutton:not(.vertical) selection:backdrop:disabled { color: #425156; }
+
+.monospace { font-family: monospace; }
+
+/********************** Touch Copy & Paste * */
+cursor-handle { background-color: transparent; background-image: none; box-shadow: none; border-style: none; color: #bde6fb; }
+
+cursor-handle:hover { color: white; }
+
+cursor-handle:active { color: #bde6fb; }
+
+cursor-handle.top:dir(ltr), cursor-handle.bottom:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-start-symbolic.svg")), -gtk-recolor(url("assets/text-select-start-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.bottom:dir(ltr), cursor-handle.top:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-end-symbolic.svg")), -gtk-recolor(url("assets/text-select-end-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); }
+
+.context-menu { font: initial; }
+
+.keycap { min-width: 20px; min-height: 25px; margin-top: 2px; padding-bottom: 3px; padding-left: 6px; padding-right: 6px; color: #bde6fb; background-color: #171d20; border: 1px solid; border-color: #2a3439; border-radius: 4px; box-shadow: inset 0 -3px #222b2f; font-size: smaller; }
+
+.keycap:backdrop { background-color: #14191a; color: #6f828a; transition: 150ms ease-out; }
+
+:not(decoration):not(window):drop(active):focus, :not(decoration):not(window):drop(active) { border-color: #4cd9a4; box-shadow: inset 0 0 0 1px #4cd9a4; caret-color: #4cd9a4; }
+
+stackswitcher button.text-button { min-width: 100px; }
+
+stackswitcher button.circular, stackswitcher button.text-button.circular { min-width: 32px; min-height: 32px; padding: 0; }
+
+/************* App Icons * */
+/* Outline for low res icons */
+.lowres-icon { -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/* Dropshadow for large icons */
+.icon-dropshadow { -gtk-icon-shadow: 0 1px 12px rgba(0, 0, 0, 0.05), 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/********* Emoji * */
+popover.emoji-picker { padding-left: 0; padding-right: 0; }
+
+popover.emoji-picker entry.search { margin: 3px 5px 5px 5px; }
+
+button.emoji-section { border-color: transparent; border-width: 3px; border-style: none none solid; border-radius: 0; margin: 2px 4px 2px 4px; padding: 3px 0 0; min-width: 32px; min-height: 28px; /* reset props inherited from the button style */ background: none; box-shadow: none; text-shadow: none; outline-offset: -5px; }
+
+button.emoji-section:first-child { margin-left: 7px; }
+
+button.emoji-section:last-child { margin-right: 7px; }
+
+button.emoji-section:backdrop:not(:checked) { border-color: transparent; }
+
+button.emoji-section:hover { border-color: #2a3439; }
+
+button.emoji-section:checked { color: #bde6fb; border-color: #bde6fb; }
+
+button.emoji-section:checked:backdrop { color: #6f828a; background-color: transparent; }
+
+button.emoji-section label { padding: 0; opacity: 0.55; }
+
+button.emoji-section:hover label { opacity: 0.775; }
+
+button.emoji-section:checked label { opacity: 1; }
+
+popover.emoji-picker .emoji { font-size: x-large; padding: 6px; }
+
+popover.emoji-picker .emoji :hover { background: #bde6fb; border-radius: 8px; }
+
+popover.emoji-completion arrow { border: none; background: none; }
+
+popover.emoji-completion contents row box { padding: 2px 10px; }
+
+popover.emoji-completion .emoji:hover { background: #2a3439; }
+
+/***************** View Switcher * */
+viewswitcher button { margin: 0; padding: 0; border-radius: 0; border: none; box-shadow: none; }
+
+viewswitcher button:checked { box-shadow: none; }
+
+viewswitcher button stack > box.narrow { font-size: smaller; padding-top: 6px; padding-bottom: 6px; }
+
+viewswitcher button stack > box.narrow image, viewswitcher button stack > box.narrow label { padding-left: 6px; padding-right: 6px; }
+
+viewswitcher button stack > box.wide { padding: 0 12px; }
+
+viewswitcherbar > actionbar > revealer > box { padding: 0; }
+
+viewswitcherbar > actionbar > revealer > box viewswitcher button:not(:checked):not(:hover) { background: transparent; }
+
+headerbar viewswitcher > box > button:first-child { border-bottom-left-radius: 8px; }
+
+headerbar viewswitcher > box > button:last-child { border-bottom-right-radius: 8px; }
+
+/*********** Chromium * */
+window.background.chromium { background-color: #171d20; }
+
+window.background.chromium headerbar.titlebar button.toggle, window.background.chromium headerbar.titlebar button.titlebutton { border: none; }
+
+window.background.chromium headerbar.titlebar button.titlebutton { background-image: none; }
+
+window.background.chromium button { border-style: solid; border-width: 1px; border-color: #2a3439; }
+
+window.background.chromium > textview.view { background-color: #1e2529; }
+
+/*********** Firefox * */
+#MozillaGtkWidget.background { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+
+#MozillaGtkWidget.background scrollbar { background-color: transparent; border-color: transparent; }
+
+/****************** Gnome Calendar * */
+window.background.csd.org-gnome-Calendar > overlay > box.vertical > stack.view { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > button.text-button { margin: 0; border-bottom-right-radius: 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > stack > .sidebar.vertical { border-radius: 0; }
+
+window.background.csd.org-gnome-Calendar.maximized calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.tiled calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.fullscreen calendar-view.year-view > box.vertical > button.text-button { border-bottom-right-radius: 0; }
+
+/*************** LibreOffice * */
+toolbutton > button.image-button.text-button.flat button { background-color: transparent; background-image: none; background-image: none; }
+
+toolbutton > button.image-button.text-button.flat button:hover { background-color: #2a3439; }
+
+toolbutton > button.image-button.text-button.flat button:active, toolbutton > button.image-button.text-button.flat button:checked { background-color: #354249; box-shadow: none; }
+
+window.background:not(.solid-csd) > notebook:not(.frame) tab { margin-bottom: 4px; }
+
+/************ Nautilus * */
+.nautilus-window .floating-bar { min-height: 32px; padding: 0; border-radius: 10px 10px 0 0; background-color: #171d20; background-clip: padding-box; }
+
+.nautilus-window .floating-bar.bottom.left { margin-right: 7px; border-top-left-radius: 0; border-bottom-left-radius: 10px; }
+
+.nautilus-window .floating-bar.bottom.right { margin-left: 7px; border-top-right-radius: 0; border-bottom-right-radius: 10px; }
+
+.nautilus-window .floating-bar button { padding: 0; }
+
+.nautilus-window .nautilus-list-view { background-color: #171d20; border-radius: 0 0 10px 10px; }
+
+.nautilus-window .nautilus-list-view treeview.view:not(:hover):not(:active):not(:selected) { background-color: transparent; border-radius: 0; }
+
+.nautilus-window.maximized .floating-bar, .nautilus-window.maximized .nautilus-list-view, .nautilus-window.tiled .floating-bar, .nautilus-window.tiled .nautilus-list-view, .nautilus-window.fullscreen .floating-bar, .nautilus-window.fullscreen .nautilus-list-view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.nautilus-window headerbar .path-bar-box { color: transparent; background: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; background: image(#bde6fb); box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child:active { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { background-color: #7f96a1; background-image: none; box-shadow: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child label, .nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { color: #14191a; }
+
+.nautilus-window notebook > header.top:dir(ltr) { border-top-left-radius: 0; }
+
+.nautilus-window notebook > header.top:dir(rtl) { border-top-right-radius: 0; }
+
+.nautilus-canvas-item { border-radius: 8px; }
+
+.nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator, headerbar .nautilus-canvas-item.subtitle, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle, popover.background label.nautilus-canvas-item.separator, .nautilus-list-dim-label { color: #758f9d; }
+
+.nautilus-canvas-item.dim-label:backdrop, label.nautilus-canvas-item.separator:backdrop, headerbar .nautilus-canvas-item.subtitle:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:backdrop, popover.background label.nautilus-canvas-item.separator:backdrop, .nautilus-list-dim-label:backdrop { color: #49565b; }
+
+.nautilus-canvas-item.dim-label:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected, label.nautilus-canvas-item.separator:selected:focus, headerbar .nautilus-canvas-item.subtitle:selected, headerbar .nautilus-canvas-item.subtitle:selected:focus, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus, popover.background label.nautilus-canvas-item.separator:selected, popover.background label.nautilus-canvas-item.separator:selected:focus, .nautilus-list-dim-label:selected, .nautilus-list-dim-label:selected:focus { color: rgba(23, 29, 32, 0.45); }
+
+.nautilus-canvas-item.dim-label:selected:backdrop, .nautilus-canvas-item.dim-label:selected:focus:backdrop, label.nautilus-canvas-item.separator:selected:backdrop, label.nautilus-canvas-item.separator:selected:focus:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:focus:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus:backdrop, popover.background label.nautilus-canvas-item.separator:selected:backdrop, popover.background label.nautilus-canvas-item.separator:selected:focus:backdrop, .nautilus-list-dim-label:selected:backdrop, .nautilus-list-dim-label:selected:focus:backdrop { color: rgba(20, 25, 26, 0.45); }
+
+.disk-space-display.unknown { background-color: rgba(189, 230, 251, 0.4); color: rgba(189, 230, 251, 0.4); }
+
+.disk-space-display.used { background-color: #bde6fb; color: #bde6fb; }
+
+.disk-space-display.free { background-color: rgba(189, 230, 251, 0.1); color: rgba(189, 230, 251, 0.1); }
+
+dialog > box > grid > scrolledwindow > viewport > box > list { padding: 0; background-color: transparent; border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list:backdrop { background-color: transparent; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list > row { border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list separator.horizontal { margin: 0; }
+
+/**************************************************** documents-scrolledwin (Totem, Documents, EvView) * */
+.documents-scrolledwin:backdrop, .documents-scrolledwin { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover), .documents-scrolledwin .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin .content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:hover, .documents-scrolledwin .content-view:hover { background-color: rgba(189, 230, 251, 0.075); }
+
+.documents-scrolledwin:backdrop viewport.frame, .documents-scrolledwin viewport.frame { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover), .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover) border, .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) border { border: none; }
+
+/******************* Document Viewer * */
+window.background.csd > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { background-color: transparent; border-radius: 10px; }
+
+window.background.csd > box.vertical > paned.horizontal > box.vertical > scrolledwindow > treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+window.background.csd evview.view.content-view { background-color: transparent; border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.maximized > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { border-radius: 0; }
+
+window.background.csd.maximized evview.view.content-view, window.background.csd.tiled evview.view.content-view, window.background.csd.fullscreen evview.view.content-view { border-radius: 0; }
+
+/******************* Archive Manager * */
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow { border-radius: 0 0 10px 10px; background-color: #171d20; }
+
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-radius: 0 0 0 10px; background-color: #1e2529; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/********* Geary * */
+frame.geary-conversation-frame scrolledwindow treeview.view:not(:selected) { background: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected { color: #171d20; outline-color: rgba(23, 29, 32, 0.3); background-color: #bde6fb; background: image(#bde6fb); box-shadow: 0 2px 4px rgba(189, 230, 251, 0.2); box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { background-color: #7f96a1; background-image: none; box-shadow: none; box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop label, frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { color: #14191a; }
+
+.geary_email { padding-bottom: 6px; border-radius: 8px; }
+
+.geary_email .geary-message { border-radius: 8px; }
+
+.geary-attachment-pane > separator.horizontal { margin: 0; }
+
+.geary-attachment-pane flowboxchild { border-radius: 8px; }
+
+.geary-attachment-pane > actionbar { background-color: #171d20; }
+
+.geary-attachment-pane > actionbar:backdrop { background-color: #14191a; }
+
+/********* Gedit * */
+window.org-gnome-gedit stack scrolledwindow viewport.frame list.gedit-document-panel { background-color: transparent; }
+
+window.org-gnome-gedit .gedit-search-entry-occurrences-tag { border: none; box-shadow: none; margin: 2px; padding: 2px; }
+
+/******************** Gnome Calculator * */
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list { padding: 0; border-radius: 0; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry { margin: 0; border-radius: 0; background-color: #1e2529; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry:backdrop { background-color: #1a2022; }
+
+grid > viewport > box > scrolledwindow.display-scrolled > .sourceview.view > text, grid > viewport > box > scrolledwindow.display-scrolled > iconview.sourceview > text { border-radius: 10px 10px 0 0; }
+
+grid > viewport > box box > textview.view.info-view > text { border-radius: 0 0 10px 10px; }
+
+/************************ Gnome Control Center * */
+window.background.csd > leaflet > stack.background, window.background.csd > hdyleaflet > stack.background, window.background.csd > box.horizontal > stack.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-left-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+window.background.csd.maximized > leaflet > stack.background, window.background.csd.maximized > hdyleaflet > stack.background, window.background.csd.maximized > box.horizontal > stack.background, window.background.csd.maximized > leaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.tiled > leaflet > stack.background, window.background.csd.tiled > hdyleaflet > stack.background, window.background.csd.tiled > box.horizontal > stack.background, window.background.csd.tiled > leaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > leaflet > stack.background, window.background.csd.fullscreen > hdyleaflet > stack.background, window.background.csd.fullscreen > box.horizontal > stack.background, window.background.csd.fullscreen > leaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+window.background.csd > leaflet > stack.background > widget > box > box > scrolledwindow > viewport.frame > box.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+/************** Gnome Maps * */
+popover.maps-popover > grid > button.radio.layer-radio-button { border-radius: 4px; color: transparent; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:active { color: #bde6fb; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:checked { color: #bde6fb; }
+
+/*************** Gnome Music * */
+window.background.csd > box.vertical > overlay > stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > overlay > stack.background, window.background.csd.tiled > box.vertical > overlay > stack.background, window.background.csd.fullscreen > box.vertical > overlay > stack.background { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/****************** Gnome Software * */
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal { border-radius: 8px; background-color: #171d20; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal:backdrop { background-color: #14191a; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal list.app-updates-section { border: none; border-radius: 10px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software { padding-top: 2px; padding-bottom: 2px; margin: 4px 2px; min-height: 24px; min-width: 54px; border-radius: 8px; -gtk-outline-radius: 8px; background-color: transparent; color: #9cbecf; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(ltr) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(rtl) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(ltr) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(rtl) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:hover { color: #bde6fb; background-color: rgba(189, 230, 251, 0.05); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:checked { color: #bde6fb; outline-color: rgba(189, 230, 251, 0.3); background-image: none; background-color: #354249; box-shadow: 0 2px 4px rgba(23, 29, 32, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop { color: #6f828a; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:hover { background-color: transparent; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { background-image: none; background-color: #272f32; box-shadow: 0 1px 2px rgba(20, 25, 26, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked label, window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { color: #6f828a; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal button:checked + button { border-image: none; }
+
+window.background.csd button.text-button.content-rating { color: #171d20; }
+
+window.background.csd button.text-button.content-rating:backdrop { color: #14191a; }
+
+/****************** Gnome Terminal * */
+terminal-window.background.csd { border-radius: 0; }
+
+terminal-window decoration { background-color: #1e2529; border-radius: 10px 10px 0 0; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(189, 230, 251, 0.1), 0 0 0 1px #1e2529; }
+
+terminal-window decoration:backdrop { background-color: #1a2022; box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(111, 130, 138, 0.125), 0 0 0 1px #1a2022; }
+
+terminal-window .terminal-screen { background-color: #1e2529; color: #bde6fb; }
+
+terminal-window .terminal-screen:backdrop { background-color: #1a2022; color: #6f828a; }
+
+/*************** Gnome Todo * */
+window.background.csd.org-gnome-Todo > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Todo.maximized > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.maximized stack.background, window.background.csd.org-gnome-Todo.tiled > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.tiled stack.background, window.background.csd.org-gnome-Todo.fullscreen > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.fullscreen stack.background { border-radius: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row { box-shadow: none; padding: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row entry, window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row button { margin: 0; border-radius: 2.5px; }
+
+/**************** Gnome Tweaks * */
+hdyleaflet list.tweak-categories, leaflet list.tweak-categories { background-color: transparent; }
+
+hdyleaflet list.tweak-categories > separator, leaflet list.tweak-categories > separator { background-color: transparent; min-height: 0; }
+
+row#AutostartTitle.tweak { padding: 8px 8px 0 8px; }
+
+.tweak-group-startup { background-color: #171d20; }
+
+.tweak-group-startup:backdrop { background-color: #14191a; }
+
+/***************** Gnome Weather * */
+#weather-page, #weekly-forecast-frame { border-bottom-right-radius: 10px; }
+
+#weather-page-content-view { border-bottom-right-radius: 10px; border-bottom-left-radius: 10px; }
+
+/************ Ubiquity * */
+#live_installer #stepPartAuto #partition_container #resizewidget separator { background-image: none; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > * { background-color: transparent; border-radius: 0; border-color: #2a3439; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > *:backdrop { border-color: #283033; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box { background-color: #171d20; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box:backdrop { background-color: #14191a; }
+
+/******************** Zorin Appearance * */
+stacksidebar.sidebar > scrolledwindow > viewport.frame > list { border-radius: 0; }
+
+/********** Thunar * */
+.thunar .sidebar.frame { border: none; }
+
+.thunar .sidebar .view, .thunar .sidebar iconview { background-color: #1e2529; border: none; }
+
+.thunar .sidebar .view:selected, .thunar .sidebar iconview:selected { background-color: #354249; color: #bde6fb; }
+
+.thunar .sidebar .view:backdrop, .thunar .sidebar iconview:backdrop { background-color: #1a2022; }
+
+.thunar .sidebar .view:backdrop:selected, .thunar .sidebar iconview:backdrop:selected { background-color: #272f32; color: #6f828a; }
+
+.thunar .standard-view > .view, .thunar .standard-view > iconview { border-radius: 0; }
+
+/*********************** LightDM Gtk Greeter * */
+.lightdm-gtk-greeter #panel_window { border-radius: 0; border: none; background-color: #1e2529; }
+
+.lightdm-gtk-greeter #panel_window menubar { font-weight: bold; }
+
+.lightdm-gtk-greeter #panel_window menubar menu menuitem { font-weight: normal; }
+
+.lightdm-gtk-greeter #buttonbox_frame { padding-top: 20px; }
+
+.lightdm-gtk-greeter #login_window, .lightdm-gtk-greeter #shutdown_dialog, .lightdm-gtk-greeter #restart_dialog { border-style: none; border-radius: 10px; background-color: #1e2529; color: #bde6fb; box-shadow: none; }
+
+.lightdm-gtk-greeter #login_window menu { border-radius: 0; }
+
+/******** XFCE * */
+.xfce4-panel.background { background-color: #171d20; }
+
+.xfce4-panel.background button { border-radius: 0; margin: 0; font-weight: bold; }
+
+.xfce4-panel.background button menuitem { font-weight: normal; }
+
+.xfce4-panel.background button:hover { background-color: #2a3439; }
+
+.xfce4-panel.background button:active, .xfce4-panel.background button:checked { color: #bde6fb; background-color: #354249; background-image: none; }
+
+.xfce4-panel.background button.flat image, .xfce4-panel.background button.image-button image { -gtk-icon-transform: scale(1); transition: none; }
+
+.xfce4-panel.background button.flat:active image, .xfce4-panel.background button.image-button:active image { -gtk-icon-transform: scale(1); }
+
+.tasklist button.toggle { background-color: transparent; border-top-width: 0; border-bottom-width: 0; }
+
+.tasklist button.toggle:checked { background: none; box-shadow: inset 0 -3px #bde6fb; }
+
+wnck-pager { background-color: #232c30; }
+
+wnck-pager:hover { background-color: #303b41; }
+
+wnck-pager:selected { background-color: #38454c; }
+
+XfdesktopIconView.view { background: transparent; color: white; }
+
+XfdesktopIconView.view:active { background: #bde6fb; color: #171d20; text-shadow: none; }
+
+XfdesktopIconView.view .label { text-shadow: 1px 1px 2px black; }
+
+#XfceNotifyWindow { background-color: #171d20; border: none; box-shadow: inset 0 0 0 1px rgba(42, 52, 57, 0.75); border-radius: 10px; }
+
+#XfceNotifyWindow label#summary { font-weight: bold; }
+
+#XfceNotifyWindow progressbar progress { animation: none; background-image: none; background: image(#bde6fb); }
+
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin { border-radius: 10px; }
+
+/* GTK NAMED COLORS ---------------- use responsibly! */
+/*
+widget text/foreground color */
+@define-color theme_fg_color #bde6fb;
+/*
+text color for entries, views and content in general */
+@define-color theme_text_color #bde6fb;
+/*
+widget base background color */
+@define-color theme_bg_color #1e2529;
+/*
+text widgets and the like base background color */
+@define-color theme_base_color #171d20;
+/*
+base background color of selections */
+@define-color theme_selected_bg_color #add3e6;
+/* Tinting in dark variant to avoid a white selection on white page background when highlighting text in Evince when using Grey-Dark theme */
+/*
+text/foreground color of selections */
+@define-color theme_selected_fg_color #171d20;
+/*
+base background color of insensitive widgets */
+@define-color insensitive_bg_color #1e2529;
+/*
+text foreground color of insensitive widgets */
+@define-color insensitive_fg_color #6d8692;
+/*
+insensitive text widgets and the like base background color */
+@define-color insensitive_base_color #171d20;
+/*
+widget text/foreground color on backdrop windows */
+@define-color theme_unfocused_fg_color #6f828a;
+/*
+text color for entries, views and content in general on backdrop windows */
+@define-color theme_unfocused_text_color #bde6fb;
+/*
+widget base background color on backdrop windows */
+@define-color theme_unfocused_bg_color #1a2022;
+/*
+text widgets and the like base background color on backdrop windows */
+@define-color theme_unfocused_base_color #14191a;
+/*
+base background color of selections on backdrop windows */
+@define-color theme_unfocused_selected_bg_color #bde6fb;
+/*
+text/foreground color of selections on backdrop windows */
+@define-color theme_unfocused_selected_fg_color #171d20;
+/*
+insensitive color on backdrop windows*/
+@define-color unfocused_insensitive_color #3b494d;
+/*
+widgets main borders color */
+@define-color borders #2a3439;
+/*
+widgets main borders color on backdrop windows */
+@define-color unfocused_borders #283033;
+/*
+these are pretty self explicative */
+@define-color placeholder_text_color #6a818d;
+@define-color warning_color #faa483;
+@define-color error_color #fb7c7c;
+@define-color success_color #6ee1b6;
+/*
+these colors are exported for the window manager and shouldn't be used in applications,
+read if you used those and something break with a version upgrade you're on your own... */
+@define-color wm_title shade(#bde6fb, 1.8);
+@define-color wm_unfocused_title #6f828a;
+@define-color wm_highlight transparent;
+@define-color wm_borders_edge rgba(189, 230, 251, 0.07);
+@define-color wm_bg_a shade(#1e2529, 1.2);
+@define-color wm_bg_b #1e2529;
+@define-color wm_shadow alpha(black, 0.35);
+@define-color wm_border alpha(black, 0.18);
+@define-color wm_button_hover_color_a shade(#1e2529, 1.3);
+@define-color wm_button_hover_color_b #1e2529;
+@define-color wm_button_active_color_a shade(#1e2529, 0.85);
+@define-color wm_button_active_color_b shade(#1e2529, 0.89);
+@define-color wm_button_active_color_c shade(#1e2529, 0.9);
+/* content view background such as thumbnails view in Photos or Boxes */
+@define-color content_view_bg #171d20;
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #171d20;

--- a/ZorinGreen-Dark/gtk-3.0/gtk-dark.css
+++ b/ZorinGreen-Dark/gtk-3.0/gtk-dark.css
@@ -1,0 +1,2308 @@
+/*************************** Check and Radio buttons * */
+@keyframes ripple_effect { to { background-size: 1000% 1000%; } }
+
+* { padding: 0; -GtkToolButton-icon-spacing: 4; -GtkTextView-error-underline-color: #fb7c7c; -GtkScrolledWindow-scrollbar-spacing: 0; -GtkToolItemGroup-expander-size: 11; -GtkWidget-text-handle-width: 20; -GtkWidget-text-handle-height: 24; -GtkDialog-button-spacing: 4; -GtkDialog-action-area-border: 0; outline-color: alpha(currentColor,0.3); outline-style: dashed; outline-offset: -3px; outline-width: 1px; -gtk-outline-radius: 8px; -gtk-secondary-caret-color: #bbf1dd; }
+
+/*************** Base States * */
+.background { color: #bbf1dd; background-color: #1b2421; }
+
+.background.csd { border-radius: 0 0 10px 10px; }
+
+.background.maximized, .background.solid-csd, .background.fullscreen, .background.tiled, .background.tiled-top, .background.tiled-right, .background.tiled-bottom, .background.tiled-left { border-radius: 0; }
+
+.background:backdrop { color: #6e837b; background-color: #181e1c; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* These wildcard seems unavoidable, need to investigate. Wildcards are bad and troublesome, use them with care, or better, just don't. Everytime a wildcard is used a kitten dies, painfully. */
+*:disabled { -gtk-icon-effect: dim; }
+
+.gtkstyle-fallback { color: #bbf1dd; background-color: #1b2421; }
+
+.gtkstyle-fallback:hover { color: #bbf1dd; background-color: #31413b; }
+
+.gtkstyle-fallback:active { color: #bbf1dd; background-color: #050706; }
+
+.gtkstyle-fallback:disabled { color: #6b8a7f; background-color: #1b2421; }
+
+.gtkstyle-fallback:selected { color: #151c19; background-color: #bbf1dd; }
+
+.view, iconview, .view text, iconview text, textview text { color: #bbf1dd; background-color: #151c19; border-radius: 10px; }
+
+.view:disabled, iconview:disabled, .view text:disabled, iconview text:disabled, textview text:disabled { color: #6b8a7f; background-color: #1b2421; }
+
+.view:backdrop, iconview:backdrop, .view text:backdrop, iconview text:backdrop, textview text:backdrop { color: #6e837b; background-color: #131716; }
+
+.view:backdrop:disabled, iconview:backdrop:disabled, .view text:backdrop:disabled, iconview text:backdrop:disabled, textview text:backdrop:disabled { color: #3a4944; background-color: #181e1c; }
+
+.view:selected:focus, iconview:selected:focus, .view:selected, iconview:selected, .view text:selected:focus, iconview text:selected:focus, textview text:selected:focus, .view text:selected, iconview text:selected, textview text:selected { border-radius: 8px; }
+
+.view.sourceview, iconview.sourceview, .view.sourceview > *, iconview.sourceview > *, textview.sourceview, textview.sourceview > * { border-radius: 0; }
+
+textview border { background-color: #18201d; }
+
+iconview { border-radius: 0 0 10px 10px; }
+
+iconview, iconview:hover, iconview:selected { border-radius: 8px; }
+
+.rubberband, rubberband, XfdesktopIconView.view .rubberband, .content-view rubberband, .content-view .rubberband, treeview.view rubberband, flowbox rubberband { border: 1px solid #91e8c8; background-color: rgba(145, 232, 200, 0.2); border-radius: 0; }
+
+flowbox flowboxchild { padding: 3px; }
+
+flowbox flowboxchild:selected { outline-offset: -2px; }
+
+.content-view .tile { margin: 2px; background-color: transparent; border-radius: 0; padding: 0; }
+
+label { caret-color: currentColor; }
+
+label:disabled { color: #6b8a7f; }
+
+button label:disabled { color: inherit; }
+
+label:disabled:backdrop { color: #3a4944; }
+
+button label:disabled:backdrop { color: inherit; }
+
+label.error { color: #fb7c7c; }
+
+label.error:disabled { color: rgba(251, 124, 124, 0.5); }
+
+label.error:disabled:backdrop { color: rgba(251, 124, 124, 0.4); }
+
+.accent { color: #bbf1dd; }
+
+.dim-label, .titlebar:not(headerbar) .subtitle, headerbar .subtitle, label.separator { opacity: 0.55; text-shadow: none; }
+
+assistant .sidebar { background-color: #1b2421; border-top: 1px solid #27332f; }
+
+assistant .sidebar:backdrop { background-color: #181e1c; border-color: #252e2b; }
+
+assistant.csd .sidebar { border-top-style: none; }
+
+assistant .sidebar label { padding: 6px 12px; }
+
+assistant .sidebar label.highlight { background-color: #3b4d46; }
+
+.osd .scale-popup, .app-notification, .app-notification.frame, .osd { border: none; background-color: #151c19; background-clip: padding-box; border-radius: 8px; box-shadow: inset 0 0 0 1px rgba(39, 51, 47, 0.75); }
+
+.osd .scale-popup:backdrop, .app-notification:backdrop, .osd:backdrop { background-color: #131716; box-shadow: inset 0 0 0 1px rgba(37, 46, 43, 0.75); }
+
+.osd .scale-popup:disabled, .app-notification:disabled, .osd:disabled { box-shadow: none; }
+
+/********************* Spinner Animation * */
+@keyframes spin { to { -gtk-icon-transform: rotate(1turn); } }
+
+spinner { background: none; opacity: 0; -gtk-icon-source: -gtk-icontheme("process-working-symbolic"); }
+
+spinner:backdrop { color: #6e837b; }
+
+spinner:checked { opacity: 1; animation: spin 1s linear infinite; }
+
+spinner:checked:disabled { opacity: 0.5; }
+
+/********************** General Typography * */
+.large-title { font-weight: 300; font-size: 24pt; }
+
+.title-1, .h1 { font-weight: 800; font-size: 20pt; }
+
+.title-2, .h2 { font-weight: 800; font-size: 15pt; }
+
+.title-3, .h3 { font-weight: 700; font-size: 15pt; }
+
+.title-4, .h4 { font-weight: 700; font-size: 13pt; }
+
+.heading { font-weight: 700; font-size: 11pt; }
+
+.body { font-weight: 400; font-size: 11pt; }
+
+.caption-heading { font-weight: 700; font-size: 9pt; }
+
+.caption { font-weight: 400; font-size: 9pt; }
+
+.category-label { color: rgba(187, 241, 221, 0.8); font-weight: 700; }
+
+/**************** Text Entries * */
+spinbutton:not(.vertical), entry { min-height: 32px; padding-left: 8px; padding-right: 8px; margin: 1px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); color: #bbf1dd; background-color: #151c19; box-shadow: inset 0 0 0 1px #27332f; }
+
+spinbutton:not(.vertical) image.left, entry image.left { margin-right: 6px; }
+
+spinbutton:not(.vertical) image.right, entry image.right { margin-left: 6px; }
+
+spinbutton.flat:not(.vertical), entry.flat:focus, entry.flat:backdrop, entry.flat:disabled, entry.flat { min-height: 0; padding: 2px; background-color: transparent; border-color: transparent; border-radius: 0; }
+
+spinbutton:focus:not(.vertical), entry:focus { color: #bbf1dd; background-color: #151c19; box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2), inset 0 0 0 2px #bbf1dd; }
+
+spinbutton:disabled:not(.vertical), entry:disabled { color: #6b8a7f; background-color: transparent; box-shadow: none; }
+
+spinbutton:backdrop:not(.vertical), entry:backdrop { color: #6e837b; background-color: #131716; box-shadow: inset 0 0 0 1px #252e2b; border-color: #181e1c; transition: 150ms ease-out; }
+
+spinbutton:backdrop:disabled:not(.vertical), entry:backdrop:disabled { color: #3a4944; background-color: transparent; box-shadow: none; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; border-color: transparent; }
+
+spinbutton.error:focus:not(.vertical), entry.error:focus { color: #fb7c7c; background-color: #151c19; box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2), inset 0 0 0 2px #bbf1dd; }
+
+spinbutton.error:not(.vertical) selection, entry.error selection { color: #151c19; background-color: #fb7c7c; }
+
+spinbutton.warning:not(.vertical), entry.warning { color: #faa483; border-color: transparent; }
+
+spinbutton.warning:focus:not(.vertical), entry.warning:focus { color: #faa483; background-color: #151c19; box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2), inset 0 0 0 2px #bbf1dd; }
+
+spinbutton.warning:not(.vertical) selection, entry.warning selection { color: #151c19; background-color: #faa483; }
+
+spinbutton:not(.vertical) image, entry image { color: #9ac6b6; }
+
+spinbutton:not(.vertical) image:hover, entry image:hover { color: #bbf1dd; }
+
+spinbutton:not(.vertical) image:active, entry image:active { color: #bbf1dd; }
+
+spinbutton:not(.vertical) image:backdrop, entry image:backdrop { color: #5b6e67; }
+
+spinbutton:drop(active):not(.vertical), entry:drop(active):focus, entry:drop(active) { color: #4cd9a4; border-color: transparent; background-color: #25483b; }
+
+spinbutton:not(.vertical) progress, entry progress { margin: 1px -6px; background-color: transparent; background-image: none; border-radius: 3px; border-width: 0 0 3px; border-color: #bbf1dd; border-style: solid; box-shadow: none; }
+
+spinbutton:not(.vertical) progress:backdrop, entry progress:backdrop { background-color: transparent; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; }
+
+treeview entry:focus:dir(rtl), treeview entry:focus:dir(ltr) { background-color: #151c19; transition-property: color, background; }
+
+treeview entry.flat, treeview entry { border: none; border-radius: 0; background-image: none; background-color: #151c19; }
+
+.entry-tag { padding: 5px; margin-top: 4px; margin-bottom: 4px; border-style: none; color: #151c19; background-color: #bbf1dd; }
+
+:dir(ltr) .entry-tag { margin-left: 8px; margin-right: -5px; }
+
+:dir(rtl) .entry-tag { margin-left: -5px; margin-right: 8px; }
+
+.entry-tag:hover { background-color: #e6faf2; }
+
+:backdrop .entry-tag { color: #131716; background-color: #bbf1dd; }
+
+.entry-tag.button { background-color: transparent; color: rgba(21, 28, 25, 0.7); }
+
+:not(:backdrop) .entry-tag.button:hover { border: 1px solid #bbf1dd; color: #151c19; }
+
+:not(:backdrop) .entry-tag.button:active { background-color: #bbf1dd; color: #151c19; }
+
+/*********** Buttons * */
+@keyframes needs_attention { from { background-image: -gtk-gradient(radial, center center, 0, center center, 0.01, to(#bbf1dd), to(transparent)); }
+  to { background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#bbf1dd), to(transparent)); } }
+
+button.titlebutton, notebook > header > tabs > arrow, button { min-height: 24px; min-width: 16px; margin: 1px; padding: 4px 9px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #27332f; background-image: none; }
+
+button.titlebutton, button.sidebar-button, notebook > header > tabs > arrow, notebook > header > tabs > arrow.flat, button.flat { background-color: transparent; background-image: none; background-image: none; transition: none; }
+
+button.titlebutton:hover, button.sidebar-button:hover, notebook > header > tabs > arrow:hover, button.flat:hover { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-duration: 500ms; }
+
+button.titlebutton:hover:active, button.sidebar-button:hover:active, notebook > header > tabs > arrow:hover:active, button.flat:hover:active { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header > tabs > arrow:hover, button:hover { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #33433d; background-image: none; }
+
+notebook > header > tabs > arrow:active, button:active { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #3b4d46; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #4b6159 10%, transparent 0%); background-size: 0% 0%; }
+
+notebook > header > tabs > arrow:checked, button:checked { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; background: image(#bbf1dd); box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); }
+
+notebook > header > tabs > arrow:checked:active, button:checked:active { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); }
+
+notebook > header > tabs > arrow:backdrop, button:backdrop.flat, button:backdrop { background-color: #1e2623; background-image: none; transition: 150ms ease-out; -gtk-icon-effect: none; }
+
+notebook > header > tabs > arrow:backdrop label, notebook > header > tabs > arrow:backdrop, button:backdrop.flat label, button:backdrop.flat, button:backdrop label, button:backdrop { color: #6e837b; }
+
+notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active, button:backdrop:active { background-color: #29322f; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:active label, notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active label, button:backdrop.flat:active, button:backdrop:active label, button:backdrop:active { color: #6e837b; }
+
+notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked, button:backdrop:checked { background-color: #7d998f; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:checked label, notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked label, button:backdrop.flat:checked, button:backdrop:checked label, button:backdrop:checked { color: #131716; }
+
+notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled, button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled label, notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled label, button:backdrop.flat:disabled, button:backdrop:disabled label, button:backdrop:disabled { color: #3a4944; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active, button:backdrop:disabled:checked { background-color: #242d2a; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active label, notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked label, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active label, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked label, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active label, button:backdrop:disabled:active, button:backdrop:disabled:checked label, button:backdrop:disabled:checked { color: #3a4944; }
+
+button.titlebutton:backdrop, button.sidebar-button:backdrop, notebook > header > tabs > arrow:backdrop, button.titlebutton:disabled, button.sidebar-button:disabled, notebook > header > tabs > arrow:disabled, button.flat:backdrop, button.flat:disabled, button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+notebook > header > tabs > arrow:disabled, button:disabled { color: #6b8a7f; background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:disabled:active, notebook > header > tabs > arrow:disabled:checked, button:disabled:active, button:disabled:checked { color: #6b8a7f; background-color: #1f2925; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow.image-button, button.image-button { min-width: 24px; padding-left: 5px; padding-right: 5px; }
+
+notebook > header > tabs > arrow.flat image, notebook > header > tabs > arrow.image-button image, button.flat image, button.image-button image { -gtk-icon-transform: scale(1); transition: -gtk-icon-transform 150ms ease; }
+
+notebook > header > tabs > arrow.flat:active image, notebook > header > tabs > arrow.image-button:active image, button.flat:active image, button.image-button:active image { -gtk-icon-transform: scale(0.85); }
+
+notebook > header > tabs > arrow.text-button, button.text-button { padding-left: 16px; padding-right: 16px; }
+
+notebook > header > tabs > arrow.text-button.image-button, button.text-button.image-button { padding-left: 8px; padding-right: 8px; }
+
+notebook > header > tabs > arrow.text-button.image-button label, button.text-button.image-button label { padding-left: 8px; padding-right: 8px; }
+
+combobox:drop(active) button.combo, notebook > header > tabs > arrow:drop(active), button:drop(active) { color: #151c19; border-color: transparent; background-color: #4cd9a4; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled), row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled) { color: #151c19; border-color: transparent; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled):backdrop, row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled):backdrop { color: #131716; }
+
+button.osd { min-width: 26px; min-height: 32px; border-radius: 8px; border: none; }
+
+button.osd.image-button { min-width: 34px; }
+
+button.suggested-action { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; background: image(#bbf1dd); font-weight: 700; }
+
+button.suggested-action.flat { background-color: transparent; background-image: none; background-image: none; color: #bbf1dd; }
+
+button.suggested-action:hover { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background: image(#cef8e5); background-color: #cef8e5; }
+
+button.suggested-action:active, button.suggested-action:checked { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-image: none; background-color: #91e8c8; box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); }
+
+button.suggested-action:backdrop, button.suggested-action.flat:backdrop { background-color: #bdf0dd; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop label, button.suggested-action:backdrop, button.suggested-action.flat:backdrop label, button.suggested-action.flat:backdrop { color: #131716; }
+
+button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked { background-color: #93e6c7; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop:active label, button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked label, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active label, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked label, button.suggested-action.flat:backdrop:checked { color: #131716; }
+
+button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.suggested-action:backdrop:disabled label, button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled label, button.suggested-action.flat:backdrop:disabled { color: #3a4944; }
+
+button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked { background-color: #b5e4d3; box-shadow: none; background-image: none; }
+
+button.suggested-action:backdrop:disabled:active label, button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked label, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active label, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked label, button.suggested-action.flat:backdrop:disabled:checked { color: #3a4944; }
+
+button.suggested-action.flat:backdrop, button.suggested-action.flat:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(187, 241, 221, 0.8); }
+
+button.suggested-action:disabled { color: #6b8a7f; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.suggested-action:disabled:active, button.suggested-action:disabled:checked { color: #6b8a7f; background-color: #b7ebd8; box-shadow: none; background-image: none; }
+
+button.destructive-action { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #fb7c7c; background: image(#fb7c7c); font-weight: 700; }
+
+button.destructive-action.flat { background-color: transparent; background-image: none; background-image: none; color: #fb7c7c; }
+
+button.destructive-action:hover { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background: image(#ff929b); background-color: #ff929b; }
+
+button.destructive-action:active, button.destructive-action:checked { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-image: none; background-color: #fa4a4a; box-shadow: 0 2px 4px rgba(251, 124, 124, 0.2); }
+
+button.destructive-action:backdrop, button.destructive-action.flat:backdrop { background-color: #f97e7e; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop label, button.destructive-action:backdrop, button.destructive-action.flat:backdrop label, button.destructive-action.flat:backdrop { color: #131716; }
+
+button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked { background-color: #f74d4d; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop:active label, button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked label, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active label, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked label, button.destructive-action.flat:backdrop:checked { color: #131716; }
+
+button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.destructive-action:backdrop:disabled label, button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled label, button.destructive-action.flat:backdrop:disabled { color: #3a4944; }
+
+button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked { background-color: #ee7979; box-shadow: none; background-image: none; }
+
+button.destructive-action:backdrop:disabled:active label, button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked label, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active label, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked label, button.destructive-action.flat:backdrop:disabled:checked { color: #3a4944; }
+
+button.destructive-action.flat:backdrop, button.destructive-action.flat:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(251, 124, 124, 0.8); }
+
+button.destructive-action:disabled { color: #6b8a7f; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.destructive-action:disabled:active, button.destructive-action:disabled:checked { color: #6b8a7f; background-color: #f67979; box-shadow: none; background-image: none; }
+
+.stack-switcher > button, stackswitcher > button { padding-top: 2px; padding-bottom: 2px; margin: 2px 1px; background-color: transparent; color: #9ac6b6; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; outline-offset: -3px; }
+
+.stack-switcher > button:first-child:dir(ltr), stackswitcher > button:first-child:dir(ltr) { margin-left: 2px; }
+
+.stack-switcher > button:first-child:dir(rtl), stackswitcher > button:first-child:dir(rtl) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(ltr), stackswitcher > button:last-child:dir(ltr) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(rtl), stackswitcher > button:last-child:dir(rtl) { margin-left: 2px; }
+
+.stack-switcher > button:hover, stackswitcher > button:hover { color: #bbf1dd; background-color: rgba(187, 241, 221, 0.05); }
+
+.stack-switcher > button:checked, stackswitcher > button:checked { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-image: none; background-color: #33433d; box-shadow: 0 2px 4px rgba(21, 28, 25, 0.075); }
+
+.stack-switcher > button:backdrop, stackswitcher > button:backdrop { color: #6e837b; }
+
+.stack-switcher > button:backdrop:hover, stackswitcher > button:backdrop:hover { background-color: transparent; }
+
+.stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked { background-image: none; background-color: #252d2a; box-shadow: 0 1px 2px rgba(19, 23, 22, 0.075); }
+
+.stack-switcher > button:backdrop:checked label, .stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked label, stackswitcher > button:backdrop:checked { color: #6e837b; }
+
+.stack-switcher > button > label, stackswitcher > button > label { padding-left: 6px; padding-right: 6px; }
+
+.stack-switcher > button > image, stackswitcher > button > image { padding-left: 6px; padding-right: 6px; padding-top: 3px; padding-bottom: 3px; }
+
+.stack-switcher > button.text-button, stackswitcher > button.text-button { padding-left: 10px; padding-right: 10px; }
+
+.stack-switcher > button.image-button, stackswitcher > button.image-button { padding-left: 2px; padding-right: 2px; }
+
+.stack-switcher > button.needs-attention:active > label, .stack-switcher > button.needs-attention:active > image, .stack-switcher > button.needs-attention:checked > label, .stack-switcher > button.needs-attention:checked > image, stackswitcher > button.needs-attention:active > label, stackswitcher > button.needs-attention:active > image, stackswitcher > button.needs-attention:checked > label, stackswitcher > button.needs-attention:checked > image { animation: none; background-image: none; }
+
+button.font separator, button.file separator { background-color: transparent; }
+
+button.font > box > box > label { font-weight: bold; }
+
+.primary-toolbar button { -gtk-icon-shadow: none; }
+
+button.circular { border-radius: 9999px; -gtk-outline-radius: 9999px; }
+
+button.circular label { padding: 0; }
+
+stacksidebar row.needs-attention > label, .stack-switcher > button.needs-attention > label, .stack-switcher > button.needs-attention > image, stackswitcher > button.needs-attention > label, stackswitcher > button.needs-attention > image { animation: needs_attention 150ms ease-in; background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#bbf1dd), to(transparent)), -gtk-gradient(radial, center center, 0, center center, 0.45, to(rgba(0, 0, 0, 0.901176)), to(transparent)); background-size: 6px 6px, 6px 6px; background-repeat: no-repeat; background-position: right 3px, right 2px; }
+
+stacksidebar row.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > image:backdrop, stackswitcher > button.needs-attention > label:backdrop, stackswitcher > button.needs-attention > image:backdrop { background-size: 6px 6px, 0 0; }
+
+stacksidebar row.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), stackswitcher > button.needs-attention > label:dir(rtl), stackswitcher > button.needs-attention > image:dir(rtl) { background-position: left 3px, left 2px; }
+
+.inline-toolbar toolbutton > button { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #27332f; background-image: none; }
+
+.inline-toolbar toolbutton > button:hover { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #33433d; background-image: none; }
+
+.inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #3b4d46; }
+
+.inline-toolbar toolbutton > button:disabled { color: #6b8a7f; background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:disabled:active, .inline-toolbar toolbutton > button:disabled:checked { color: #6b8a7f; background-color: #1f2925; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop { background-color: #1e2623; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop label, .inline-toolbar toolbutton > button:backdrop { color: #6e837b; }
+
+.inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked { background-color: #29322f; background-image: none; box-shadow: none; }
+
+.inline-toolbar toolbutton > button:backdrop:active label, .inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked label, .inline-toolbar toolbutton > button:backdrop:checked { color: #6e837b; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled label, .inline-toolbar toolbutton > button:backdrop:disabled { color: #3a4944; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked { background-color: #242d2a; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active label, .inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked label, .inline-toolbar toolbutton > button:backdrop:disabled:checked { color: #3a4944; }
+
+.linked:not(.vertical) > combobox > box > button.combo, filechooser .path-bar.linked > button, .linked:not(.vertical) > spinbutton:not(.vertical), .linked:not(.vertical) > entry, .inline-toolbar button, .linked > button, toolbar.inline-toolbar toolbutton > button.flat { border-right-style: none; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked:not(.vertical) > combobox:first-child > box > button.combo, combobox.linked button:nth-child(2):dir(rtl), filechooser .path-bar.linked > button:dir(rtl):last-child, filechooser .path-bar.linked > button:dir(ltr):first-child, .linked:not(.vertical) > spinbutton:first-child:not(.vertical), .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat { border-top-left-radius: 8px; border-bottom-left-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-bottom-left-radius: 8px; }
+
+.linked:not(.vertical) > combobox:last-child > box > button.combo, combobox.linked button:nth-child(2):dir(ltr), filechooser .path-bar.linked > button:dir(rtl):first-child, filechooser .path-bar.linked > button:dir(ltr):last-child, .linked:not(.vertical) > spinbutton:last-child:not(.vertical), .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat { border-right-style: solid; border-top-right-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-top-right-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked:not(.vertical) > combobox:only-child > box > button.combo, filechooser .path-bar.linked > button:only-child, .linked:not(.vertical) > spinbutton:only-child:not(.vertical), .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.linked.vertical > combobox > box > button.combo, .linked.vertical > spinbutton:not(.vertical), .linked.vertical > entry, .linked.vertical > button { border-style: solid solid none solid; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked.vertical > combobox:first-child > box > button.combo, .linked.vertical > spinbutton:first-child:not(.vertical), .linked.vertical > entry:first-child, .linked.vertical > button:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-top-right-radius: 8px; }
+
+.linked.vertical > combobox:last-child > box > button.combo, .linked.vertical > spinbutton:last-child:not(.vertical), .linked.vertical > entry:last-child, .linked.vertical > button:last-child { border-bottom-style: solid; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-bottom-left-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked.vertical > combobox:only-child > box > button.combo, .linked.vertical > spinbutton:only-child:not(.vertical), .linked.vertical > entry:only-child, .linked.vertical > button:only-child { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.scale-popup button:backdrop:hover, .scale-popup button:backdrop:disabled, .scale-popup button:backdrop, .scale-popup button:hover, calendar.button, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, button:link, button:visited, modelbutton.flat:backdrop, modelbutton.flat:backdrop:hover, modelbutton.flat, .menuitem.button.flat { background-color: transparent; background-image: none; border-color: transparent; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* menu buttons */
+modelbutton.flat, .menuitem.button.flat { min-height: 26px; padding-left: 5px; padding-right: 5px; border-radius: 8px; outline-offset: -2px; }
+
+modelbutton.flat:hover, .menuitem.button.flat:hover { background-color: #27332f; }
+
+modelbutton.flat arrow { background: none; }
+
+modelbutton.flat arrow:hover { background: none; }
+
+modelbutton.flat arrow.left { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+modelbutton.flat arrow.right { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+button.color { padding: 4px; box-shadow: none; }
+
+button.color colorswatch:only-child, button.color colorswatch:only-child overlay { border-radius: 0; }
+
+/********* Links * */
+button:link > label, button:visited > label, button:link, button:visited, *:link { color: #e6faf2; }
+
+button:link > label:visited, button:visited > label:visited, button:visited, *:link:visited { color: white; }
+
+*:selected button:link > label:visited, *:selected button:visited > label:visited, *:selected button:visited, *:selected *:link:visited { color: #737775; }
+
+button:link > label:hover, button:visited > label:hover, button:hover:link, button:hover:visited, *:link:hover { color: white; }
+
+*:selected button:link > label:hover, *:selected button:visited > label:hover, *:selected button:hover:link, *:selected button:hover:visited, *:selected *:link:hover { color: #2c3330; }
+
+button:link > label:active, button:visited > label:active, button:active:link, button:active:visited, *:link:active { color: #e6faf2; }
+
+*:selected button:link > label:active, *:selected button:visited > label:active, *:selected button:active:link, *:selected button:active:visited, *:selected *:link:active { color: #3f4844; }
+
+button:link > label:disabled, button:visited > label:disabled, button:disabled:link, button:disabled:visited, *:link:disabled, *:link:disabled:backdrop { color: rgba(240, 240, 240, 0.8); }
+
+button:link > label:backdrop, button:visited > label:backdrop, button:backdrop:link, button:backdrop:visited, *:link:backdrop:backdrop:hover, *:link:backdrop:backdrop:hover:selected, *:link:backdrop { color: rgba(230, 250, 242, 0.9); }
+
+.selection-mode .titlebar:not(headerbar) .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link, .selection-mode headerbar .subtitle:link, headerbar.selection-mode .subtitle:link, button:link > label:selected, button:visited > label:selected, button:selected:link, button:selected:visited, *:selected button:link > label, *:selected button:visited > label, *:selected button:link, *:selected button:visited, *:link:selected, *:selected *:link { color: #3f4844; }
+
+button:link, button:visited { text-shadow: none; }
+
+button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked { text-shadow: none; }
+
+button:link > label, button:visited > label { text-decoration-line: underline; }
+
+/****************** Stack Switcher * */
+stackswitcher, .stack-switcher { border-radius: 8px; background-color: #151c19; }
+
+stackswitcher:backdrop, .stack-switcher:backdrop { background-color: #131716; }
+
+stackswitcher > button, .stack-switcher > button { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+/***************** GtkSpinButton * */
+spinbutton { font-feature-settings: "tnum"; }
+
+spinbutton:not(.vertical) { padding: 0; }
+
+spinbutton:not(.vertical) entry { min-width: 28px; margin: 0; background: none; background-color: transparent; border: none; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) entry:backdrop:disabled { background-color: transparent; }
+
+spinbutton:not(.vertical) button { min-height: 16px; margin: 0; padding-bottom: 0; padding-top: 0; color: #bbf1dd; background-image: none; border-style: none none none solid; border-color: transparent; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) button:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:disabled { color: #6b8a7f; background-color: #1b2421; }
+
+spinbutton:not(.vertical) button:backdrop:disabled { color: #3a4944; background-color: #181e1c; background-image: none; border-style: none none none solid; }
+
+spinbutton:not(.vertical) button:backdrop:disabled:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:dir(ltr):last-child { border-radius: 0 7px 7px 0; }
+
+spinbutton:not(.vertical) button:dir(rtl):first-child { border-radius: 7px 0 0 7px; }
+
+spinbutton.vertical:disabled { color: #6b8a7f; }
+
+spinbutton.vertical:backdrop:disabled { color: #3a4944; }
+
+spinbutton.vertical:drop(active) { border-color: transparent; box-shadow: none; }
+
+spinbutton.vertical entry { min-height: 32px; min-width: 32px; padding: 0; border-radius: 0; }
+
+spinbutton.vertical button { min-height: 32px; min-width: 32px; padding: 0; }
+
+spinbutton.vertical button.up { border-radius: 8px 8px 0 0; border-style: solid solid none solid; }
+
+spinbutton.vertical button.down { border-radius: 0 0 8px 8px; border-style: none solid solid solid; }
+
+treeview spinbutton:not(.vertical) { min-height: 0; border-style: none; border-radius: 0; }
+
+treeview spinbutton:not(.vertical) entry { min-height: 0; padding: 1px 2px; }
+
+/************** ComboBoxes * */
+combobox arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); min-height: 16px; min-width: 16px; }
+
+combobox:drop(active) { box-shadow: none; }
+
+/************ Toolbars * */
+searchbar > revealer > box, .location-bar, .inline-toolbar, toolbar { -GtkWidget-window-dragging: true; padding: 4px; background-color: #1b2421; }
+
+searchbar > revealer > box:backdrop, .location-bar:backdrop, .inline-toolbar:backdrop, toolbar:backdrop { background-color: #181e1c; }
+
+toolbar { padding: 4px 3px 3px 4px; }
+
+.osd toolbar { background-color: transparent; }
+
+toolbar.osd { padding: 13px; border: none; border-radius: 8px; }
+
+toolbar.osd.left, toolbar.osd.right, toolbar.osd.top, toolbar.osd.bottom { border-radius: 0; }
+
+toolbar.horizontal separator { margin: 0 7px 1px 6px; }
+
+toolbar.vertical separator { margin: 6px 1px 7px 0; }
+
+toolbar:not(.inline-toolbar):not(.osd) > *:not(.toggle):not(.popup) > * { margin-right: 1px; margin-bottom: 1px; }
+
+.inline-toolbar { padding: 3px; border-width: 0 1px 1px; border-radius: 0 0 8px 8px; }
+
+.background.csd .inline-toolbar { border-radius: 0 0 10px 10px; }
+
+searchbar > revealer > box, .location-bar { border-width: 0 0 1px; padding: 3px; }
+
+searchbar > revealer > box { margin: -6px; padding: 6px; }
+
+revealer box.view { background-color: transparent; }
+
+.inline-toolbar, searchbar > revealer > box, .location-bar { border-style: none; background-color: #1b2421; }
+
+.inline-toolbar:backdrop, searchbar > revealer > box:backdrop, .location-bar:backdrop { background-color: #181e1c; }
+
+/*************** Header bars * */
+@keyframes header_ripple_effect { from { background-image: radial-gradient(circle farthest-corner at center, #1b2421 0%, transparent 0%); }
+  to { background-image: radial-gradient(circle farthest-corner at center, #bbf1dd 100%, transparent 0%); } }
+
+.titlebar:not(headerbar), headerbar { padding: 0 6px; min-height: 46px; border: none; border-radius: 0; background-color: #1b2421; /* hide the close button separator */ }
+
+.titlebar:backdrop:not(headerbar), headerbar:backdrop { background-color: #181e1c; background-image: none; }
+
+.titlebar:not(headerbar) .title, headerbar .title { padding-left: 12px; padding-right: 12px; font-weight: bold; }
+
+.titlebar:not(headerbar) .subtitle, headerbar .subtitle { font-size: smaller; padding-left: 12px; padding-right: 12px; }
+
+.selection-mode .titlebar:not(headerbar), .selection-mode.titlebar:not(headerbar), .selection-mode headerbar, headerbar.selection-mode { color: #151c19; border-color: transparent; background-color: #bbf1dd; transition: background-color 0.00001s 150ms, color 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); animation: header_ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+.selection-mode .titlebar:backdrop:not(headerbar), .selection-mode.titlebar:backdrop:not(headerbar), .selection-mode headerbar:backdrop, headerbar.selection-mode:backdrop { color: #151c19; background-color: #bbf1dd; background-image: none; }
+
+.selection-mode .titlebar:backdrop:not(headerbar) label, .selection-mode.titlebar:backdrop:not(headerbar) label, .selection-mode headerbar:backdrop label, headerbar.selection-mode:backdrop label { text-shadow: none; color: #151c19; }
+
+.selection-mode .titlebar:not(headerbar) button, .selection-mode.titlebar:not(headerbar) button, .selection-mode headerbar button, headerbar.selection-mode button { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #afe1ce; background-image: none; }
+
+.selection-mode button.titlebutton, .selection-mode .titlebar:not(headerbar) button.flat, .selection-mode.titlebar:not(headerbar) button.flat, .selection-mode headerbar button.flat, headerbar.selection-mode button.flat { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:hover, .selection-mode.titlebar:not(headerbar) button:hover, .selection-mode headerbar button:hover, headerbar.selection-mode button:hover { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #a2d1bf; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:active, .selection-mode .titlebar:not(headerbar) button:checked, .selection-mode.titlebar:not(headerbar) button:active, .selection-mode.titlebar:not(headerbar) button:checked, .selection-mode headerbar button:active, .selection-mode headerbar button:checked, .selection-mode headerbar button.toggle:checked, .selection-mode headerbar button.toggle:active, headerbar.selection-mode button:active, headerbar.selection-mode button:checked, headerbar.selection-mode button.toggle:checked, headerbar.selection-mode button.toggle:active { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #9ac6b6; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop { background-color: #1e2623; background-image: none; -gtk-icon-effect: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop label, .selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop label, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat label, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop label, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat label, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop label, headerbar.selection-mode button:backdrop { color: #6e837b; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked { background-color: #29322f; background-image: none; box-shadow: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active label, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked label, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active label, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked label, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active label, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked label, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active label, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked label, headerbar.selection-mode button:backdrop:checked { color: #6e837b; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled label, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled label, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled label, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled label, headerbar.selection-mode button:backdrop:disabled { color: #3a4944; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked { background-color: #b5e4d3; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active label, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked label, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active label, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked label, headerbar.selection-mode button:backdrop:disabled:checked { color: #3a4944; }
+
+.selection-mode button.titlebutton:backdrop, .selection-mode button.titlebutton:disabled, .selection-mode .titlebar:not(headerbar) button.flat:backdrop, .selection-mode .titlebar:not(headerbar) button.flat:disabled, .selection-mode.titlebar:not(headerbar) button.flat:backdrop, .selection-mode.titlebar:not(headerbar) button.flat:disabled, .selection-mode headerbar button.flat:backdrop, .selection-mode headerbar button.flat:disabled, .selection-mode headerbar button.flat:backdrop:disabled, headerbar.selection-mode button.flat:backdrop, headerbar.selection-mode button.flat:disabled, headerbar.selection-mode button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled, .selection-mode.titlebar:not(headerbar) button:disabled, .selection-mode headerbar button:disabled, headerbar.selection-mode button:disabled { color: #6b8a7f; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled:active, .selection-mode .titlebar:not(headerbar) button:disabled:checked, .selection-mode.titlebar:not(headerbar) button:disabled:active, .selection-mode.titlebar:not(headerbar) button:disabled:checked, .selection-mode headerbar button:disabled:active, .selection-mode headerbar button:disabled:checked, headerbar.selection-mode button:disabled:active, headerbar.selection-mode button:disabled:checked { color: #6b8a7f; background-color: #b7ebd8; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action, .selection-mode.titlebar:not(headerbar) button.suggested-action, .selection-mode headerbar button.suggested-action, headerbar.selection-mode button.suggested-action { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #27332f; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:hover, .selection-mode.titlebar:not(headerbar) button.suggested-action:hover, .selection-mode headerbar button.suggested-action:hover, headerbar.selection-mode button.suggested-action:hover { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #33433d; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:active, .selection-mode.titlebar:not(headerbar) button.suggested-action:active, .selection-mode headerbar button.suggested-action:active, headerbar.selection-mode button.suggested-action:active { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #3b4d46; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode headerbar button.suggested-action:disabled, headerbar.selection-mode button.suggested-action:disabled { color: #6b8a7f; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop { background-color: #1e2623; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop label, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop label, headerbar.selection-mode button.suggested-action:backdrop { color: #6e837b; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled label, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled label, headerbar.selection-mode button.suggested-action:backdrop:disabled { color: #3a4944; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu, .selection-mode.titlebar:not(headerbar) .selection-menu, .selection-mode headerbar .selection-menu:backdrop, .selection-mode headerbar .selection-menu, headerbar.selection-mode .selection-menu:backdrop, headerbar.selection-mode .selection-menu { border-color: rgba(187, 241, 221, 0); background-color: rgba(187, 241, 221, 0); background-image: none; box-shadow: none; min-height: 20px; padding: 6px 10px; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu arrow, .selection-mode.titlebar:not(headerbar) .selection-menu arrow, .selection-mode headerbar .selection-menu:backdrop arrow, .selection-mode headerbar .selection-menu arrow, headerbar.selection-mode .selection-menu:backdrop arrow, headerbar.selection-mode .selection-menu arrow { -GtkArrow-arrow-scaling: 1; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu .arrow, .selection-mode.titlebar:not(headerbar) .selection-menu .arrow, .selection-mode headerbar .selection-menu:backdrop .arrow, .selection-mode headerbar .selection-menu .arrow, headerbar.selection-mode .selection-menu:backdrop .arrow, headerbar.selection-mode .selection-menu .arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); color: rgba(21, 28, 25, 0.5); -gtk-icon-shadow: none; }
+
+.tiled .titlebar:not(headerbar), .tiled-top .titlebar:not(headerbar), .tiled-right .titlebar:not(headerbar), .tiled-bottom .titlebar:not(headerbar), .tiled-left .titlebar:not(headerbar), .maximized .titlebar:not(headerbar), .fullscreen .titlebar:not(headerbar), .tiled headerbar, .tiled-top headerbar, .tiled-right headerbar, .tiled-bottom headerbar, .tiled-left headerbar, .maximized headerbar, .fullscreen headerbar { border-radius: 0; }
+
+.default-decoration.titlebar:not(headerbar), headerbar.default-decoration { min-height: 28px; padding: 4px; border-color: transparent; }
+
+.default-decoration.titlebar:not(headerbar) button.titlebutton, headerbar.default-decoration button.titlebutton { min-height: 26px; min-width: 26px; margin: 0; padding: 0; }
+
+.titlebar:not(headerbar) separator.titlebutton, headerbar separator.titlebutton { opacity: 0; }
+
+.solid-csd .titlebar:dir(rtl):not(headerbar), .solid-csd .titlebar:dir(ltr):not(headerbar), .solid-csd headerbar:backdrop:dir(rtl), .solid-csd headerbar:backdrop:dir(ltr), .solid-csd headerbar:dir(rtl), .solid-csd headerbar:dir(ltr) { margin-left: -1px; margin-right: -1px; margin-top: -1px; border-radius: 0; box-shadow: none; }
+
+headerbar entry, headerbar spinbutton, headerbar separator:not(.sidebar), headerbar button { margin-top: 6px; margin-bottom: 6px; }
+
+headerbar switch { margin-top: 10px; margin-bottom: 10px; }
+
+headerbar stackswitcher button, headerbar .stack-switcher button { min-height: 24px; min-width: 80px; margin: 4px 2px; }
+
+headerbar stackswitcher button:first-child:dir(ltr), headerbar .stack-switcher button:first-child:dir(ltr) { margin-left: 4px; }
+
+headerbar stackswitcher button:first-child:dir(rtl), headerbar .stack-switcher button:first-child:dir(rtl) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(ltr), headerbar .stack-switcher button:last-child:dir(ltr) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(rtl), headerbar .stack-switcher button:last-child:dir(rtl) { margin-left: 4px; }
+
+#MozillaGtkWidget.background headerbar button.close:hover, headerbar button.close:hover { color: #fb7c7c; background-color: #3d312e; }
+
+#MozillaGtkWidget.background headerbar button.close:active, #MozillaGtkWidget.background headerbar button.close:checked, headerbar button.close:active, headerbar button.close:checked { color: #fb7c7c; background-color: #483533; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #483533 10%, transparent 0%); background-size: 0% 0%; }
+
+headerbar.titlebar headerbar:not(.titlebar) { background: none; box-shadow: none; }
+
+.background .titlebar:backdrop, .background .titlebar { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+.background.tiled .titlebar:backdrop, .background.tiled .titlebar, .background.tiled-top .titlebar:backdrop, .background.tiled-top .titlebar, .background.tiled-right .titlebar:backdrop, .background.tiled-right .titlebar, .background.tiled-bottom .titlebar:backdrop, .background.tiled-bottom .titlebar, .background.tiled-left .titlebar:backdrop, .background.tiled-left .titlebar, .background.maximized .titlebar:backdrop, .background.maximized .titlebar, .background.solid-csd .titlebar:backdrop, .background.solid-csd .titlebar { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window separator:first-child + headerbar:backdrop, window separator:first-child + headerbar, window headerbar:first-child:backdrop, window headerbar:first-child { border-top-left-radius: 10px; }
+
+window headerbar:last-child:backdrop, window headerbar:last-child { border-top-right-radius: 10px; }
+
+window stack headerbar:first-child:backdrop, window stack headerbar:first-child, window stack headerbar:last-child:backdrop, window stack headerbar:last-child { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+window.tiled headerbar, window.tiled headerbar:first-child, window.tiled headerbar:last-child, window.tiled headerbar:only-child, window.tiled headerbar:backdrop, window.tiled headerbar:backdrop:first-child, window.tiled headerbar:backdrop:last-child, window.tiled headerbar:backdrop:only-child, window.tiled-top headerbar, window.tiled-top headerbar:first-child, window.tiled-top headerbar:last-child, window.tiled-top headerbar:only-child, window.tiled-top headerbar:backdrop, window.tiled-top headerbar:backdrop:first-child, window.tiled-top headerbar:backdrop:last-child, window.tiled-top headerbar:backdrop:only-child, window.tiled-right headerbar, window.tiled-right headerbar:first-child, window.tiled-right headerbar:last-child, window.tiled-right headerbar:only-child, window.tiled-right headerbar:backdrop, window.tiled-right headerbar:backdrop:first-child, window.tiled-right headerbar:backdrop:last-child, window.tiled-right headerbar:backdrop:only-child, window.tiled-bottom headerbar, window.tiled-bottom headerbar:first-child, window.tiled-bottom headerbar:last-child, window.tiled-bottom headerbar:only-child, window.tiled-bottom headerbar:backdrop, window.tiled-bottom headerbar:backdrop:first-child, window.tiled-bottom headerbar:backdrop:last-child, window.tiled-bottom headerbar:backdrop:only-child, window.tiled-left headerbar, window.tiled-left headerbar:first-child, window.tiled-left headerbar:last-child, window.tiled-left headerbar:only-child, window.tiled-left headerbar:backdrop, window.tiled-left headerbar:backdrop:first-child, window.tiled-left headerbar:backdrop:last-child, window.tiled-left headerbar:backdrop:only-child, window.maximized headerbar, window.maximized headerbar:first-child, window.maximized headerbar:last-child, window.maximized headerbar:only-child, window.maximized headerbar:backdrop, window.maximized headerbar:backdrop:first-child, window.maximized headerbar:backdrop:last-child, window.maximized headerbar:backdrop:only-child, window.fullscreen headerbar, window.fullscreen headerbar:first-child, window.fullscreen headerbar:last-child, window.fullscreen headerbar:only-child, window.fullscreen headerbar:backdrop, window.fullscreen headerbar:backdrop:first-child, window.fullscreen headerbar:backdrop:last-child, window.fullscreen headerbar:backdrop:only-child, window.solid-csd headerbar, window.solid-csd headerbar:first-child, window.solid-csd headerbar:last-child, window.solid-csd headerbar:only-child, window.solid-csd headerbar:backdrop, window.solid-csd headerbar:backdrop:first-child, window.solid-csd headerbar:backdrop:last-child, window.solid-csd headerbar:backdrop:only-child { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window.csd > .titlebar:not(headerbar) { padding: 0; background-color: transparent; background-image: none; border-style: none; border-color: transparent; box-shadow: none; }
+
+.titlebar:not(headerbar) separator { background-color: #1b2421; }
+
+.titlebar:not(headerbar) separator:backdrop { background-color: #181e1c; }
+
+window.devel headerbar.titlebar:not(.selection-mode) { background: #1b2421 cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, linear-gradient(to right, transparent 65%, rgba(187, 241, 221, 0.15)); }
+
+window.devel headerbar.titlebar:not(.selection-mode):backdrop { background: #1b2421 cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, image(#1b2421); /* background-color would flash */ }
+
+/************ Pathbars * */
+.path-bar button.text-button, .path-bar button.image-button, .path-bar button { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.text-button.image-button label { padding-left: 0; padding-right: 0; }
+
+.path-bar button.text-button.image-button label:last-child, .path-bar button label:last-child { padding-right: 8px; }
+
+.path-bar button.text-button.image-button label:first-child, .path-bar button label:first-child { padding-left: 8px; }
+
+.path-bar button image { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.slider-button { padding-left: 0; padding-right: 0; }
+
+/************** Tree Views * */
+treeview.view { border-left-color: rgba(187, 241, 221, 0.15); border-top-color: #1b2421; border-radius: 0px; }
+
+* { -GtkTreeView-horizontal-separator: 4; -GtkTreeView-grid-line-width: 1; -GtkTreeView-grid-line-pattern: ''; -GtkTreeView-tree-line-width: 1; -GtkTreeView-tree-line-pattern: ''; -GtkTreeView-expander-size: 16; }
+
+treeview.view:selected:focus, treeview.view:selected { border-radius: 0; }
+
+treeview.view:selected:backdrop, treeview.view:selected { border-left-color: #495a54; border-top-color: rgba(110, 131, 123, 0.1); }
+
+treeview.view:disabled { color: #6b8a7f; }
+
+treeview.view:disabled:selected { color: #799c8f; }
+
+treeview.view:disabled:selected:backdrop { color: #5e726b; }
+
+treeview.view:disabled:backdrop { color: #3a4944; }
+
+treeview.view.separator { min-height: 2px; color: #1b2421; }
+
+treeview.view.separator:backdrop { color: #181e1c; }
+
+treeview.view:backdrop { border-left-color: #43514c; border-top: #181e1c; }
+
+treeview.view:drop(active) { border-style: solid none; border-width: 1px; border-color: #addfcc; }
+
+treeview.view:drop(active).after { border-top-style: none; }
+
+treeview.view:drop(active).before { border-bottom-style: none; }
+
+treeview.view.expander { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); color: #89b1a2; }
+
+treeview.view.expander:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+treeview.view.expander:hover { color: #bbf1dd; }
+
+treeview.view.expander:selected { color: #475c54; }
+
+treeview.view.expander:selected:hover { color: #151c19; }
+
+treeview.view.expander:selected:backdrop { color: #333e3a; }
+
+treeview.view.expander:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+treeview.view.expander:backdrop { color: #52635d; }
+
+treeview.view.progressbar { color: #151c19; background-color: #bbf1dd; background: image(#bbf1dd); box-shadow: none; border-radius: 8px; }
+
+treeview.view.progressbar:backdrop { color: #131716; background-color: #7d998f; background-image: none; }
+
+treeview.view.progressbar:selected:focus, treeview.view.progressbar:selected { border-radius: 8px; color: #bbf1dd; background-color: #151c19; background-image: none; }
+
+treeview.view.progressbar:selected:backdrop { color: #7d998f; background-color: #131716; }
+
+treeview.view.trough { background-color: rgba(187, 241, 221, 0.1); border-radius: 8px; }
+
+treeview.view.trough:backdrop { background-color: rgba(110, 131, 123, 0.1); }
+
+treeview.view.trough:selected { border-radius: 8px; }
+
+treeview.view.trough:selected:focus, treeview.view.trough:selected { background-color: rgba(21, 28, 25, 0.3); }
+
+treeview.view.trough:selected:backdrop { background-color: rgba(21, 28, 25, 0.3); }
+
+treeview.view header button { color: #68867b; background-color: #151c19; font-weight: bold; text-shadow: none; box-shadow: none; margin: 0 1px 1px 0; }
+
+treeview.view header button:last-child { margin-right: 0; }
+
+treeview.view header button:hover { color: #92bbac; box-shadow: none; transition: none; }
+
+treeview.view header button:active { color: #bbf1dd; transition: none; }
+
+treeview.view button.dnd:active, treeview.view button.dnd:selected, treeview.view button.dnd:hover, treeview.view button.dnd, treeview.view header.button.dnd:active, treeview.view header.button.dnd:selected, treeview.view header.button.dnd:hover, treeview.view header.button.dnd { padding: 0 6px; color: #151c19; background-image: none; background-color: #bbf1dd; border-style: none; border-radius: 0; box-shadow: inset 0 0 0 1px #151c19; text-shadow: none; transition: none; }
+
+treeview.view acceleditor > label { background-color: #bbf1dd; }
+
+treeview.view header button, treeview.view header button:hover, treeview.view header button:active { padding: 0 6px; background-image: none; border-style: none solid solid none; border-color: #1b2421; border-radius: 0; text-shadow: none; }
+
+treeview.view header button:disabled { border-color: #1b2421; background-image: none; }
+
+treeview.view header button:backdrop { color: #43514c; border-color: #181e1c; border-style: none solid solid none; background-image: none; background-color: #131716; }
+
+treeview.view header button:backdrop:disabled { border-color: #181e1c; background-image: none; }
+
+treeview.view header button:last-child { border-right-style: none; }
+
+/********* Menus * */
+menubar, .menubar { -GtkWidget-window-dragging: true; padding: 0px; }
+
+menubar:backdrop, .menubar:backdrop { background-color: #181e1c; }
+
+menubar > menuitem, .menubar > menuitem { min-height: 16px; padding: 4px 8px; }
+
+menubar > menuitem menu:dir(rtl), menubar > menuitem menu:dir(ltr), .menubar > menuitem menu:dir(rtl), .menubar > menuitem menu:dir(ltr) { border-radius: 0; padding: 0; }
+
+menubar > menuitem:hover, .menubar > menuitem:hover { box-shadow: inset 0 -3px #bbf1dd; color: #e6faf2; }
+
+menubar > menuitem:disabled, .menubar > menuitem:disabled { color: #6b8a7f; box-shadow: none; }
+
+menubar .csd.popup decoration, .menubar .csd.popup decoration { border-radius: 0; }
+
+.background.popup { background-color: transparent; }
+
+menu, .menu, .context-menu { margin: 8px; padding: 8px 0px; background-color: #151c19; border: 1px solid rgba(39, 51, 47, 0.75); }
+
+.csd menu, .csd .menu, .csd .context-menu { border: none; border-radius: 8px; }
+
+menu:backdrop, .menu:backdrop, .context-menu:backdrop { background-color: #131716; border-color: rgba(37, 46, 43, 0.75); }
+
+menu menuitem, .menu menuitem, .context-menu menuitem { min-height: 16px; min-width: 40px; padding: 4px 6px; text-shadow: none; }
+
+menu menuitem:hover, .menu menuitem:hover, .context-menu menuitem:hover { color: #151c19; background-color: #bbf1dd; background: image(#bbf1dd); }
+
+menu menuitem:disabled, .menu menuitem:disabled, .context-menu menuitem:disabled { color: #6b8a7f; }
+
+menu menuitem:disabled:backdrop, .menu menuitem:disabled:backdrop, .context-menu menuitem:disabled:backdrop { color: #3a4944; }
+
+menu menuitem:backdrop, menu menuitem:backdrop:hover, .menu menuitem:backdrop, .menu menuitem:backdrop:hover, .context-menu menuitem:backdrop, .context-menu menuitem:backdrop:hover { color: #6e837b; background-color: transparent; }
+
+menu menuitem arrow, .menu menuitem arrow, .context-menu menuitem arrow { min-height: 16px; min-width: 16px; }
+
+menu menuitem arrow:dir(ltr), .menu menuitem arrow:dir(ltr), .context-menu menuitem arrow:dir(ltr) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); margin-left: 10px; }
+
+menu menuitem arrow:dir(rtl), .menu menuitem arrow:dir(rtl), .context-menu menuitem arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); margin-right: 10px; }
+
+menu menuitem label:dir(rtl), menu menuitem label:dir(ltr), .menu menuitem label:dir(rtl), .menu menuitem label:dir(ltr), .context-menu menuitem label:dir(rtl), .context-menu menuitem label:dir(ltr) { color: inherit; }
+
+menu separator, .menu separator, .context-menu separator { margin: 3px 16px; }
+
+menu > arrow, .menu > arrow, .context-menu > arrow { background-color: transparent; background-image: none; background-image: none; min-height: 16px; min-width: 16px; padding: 4px; background-color: #151c19; border-radius: 0; }
+
+menu > arrow.top, .menu > arrow.top, .context-menu > arrow.top { margin-top: -8px; border-bottom: 1px solid #26312d; border-top-right-radius: 8px; border-top-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+menu > arrow.bottom, .menu > arrow.bottom, .context-menu > arrow.bottom { margin-top: 16px; margin-bottom: -24px; border-top: 1px solid #26312d; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+menu > arrow:hover, .menu > arrow:hover, .context-menu > arrow:hover { background-color: #2e3c36; }
+
+menu > arrow:backdrop, .menu > arrow:backdrop, .context-menu > arrow:backdrop { background-color: #131716; }
+
+menu > arrow:disabled, .menu > arrow:disabled, .context-menu > arrow:disabled { color: transparent; background-color: transparent; border-color: transparent; }
+
+menuitem accelerator { color: alpha(currentColor,0.55); }
+
+menuitem check, menuitem radio { min-height: 16px; min-width: 16px; }
+
+menuitem check:dir(ltr), menuitem radio:dir(ltr) { margin-right: 7px; }
+
+menuitem check:dir(rtl), menuitem radio:dir(rtl) { margin-left: 7px; }
+
+/*************** Popovers   * */
+popover.background { padding: 2px; background-color: #151c19; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.csd popover.background, popover.background { border: 1px solid rgba(39, 51, 47, 0.75); border-radius: 10px; }
+
+.csd popover.background { background-clip: padding-box; }
+
+popover.background:backdrop { background-color: #131716; box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); border-color: rgba(37, 46, 43, 0.75); }
+
+popover.background > list, popover.background > .view, popover.background > iconview, popover.background > toolbar { border-style: none; background-color: transparent; }
+
+popover.background separator { margin: 3px; }
+
+popover.background list separator { margin: 0px; }
+
+/************* Notebooks * */
+notebook > header { padding: 2px; border-style: none; background-color: #151c19; }
+
+notebook > header:backdrop { background-color: #131716; }
+
+notebook > header.top { border-radius: 8px 8px 0 0; }
+
+notebook > header.bottom { border-radius: 0 0 8px 8px; }
+
+notebook > header.left { border-radius: 8px 0 0 8px; }
+
+notebook > header.right { border-radius: 0 8px 8px 0; }
+
+notebook > header > button { padding: 2px 9px; margin: 2px; }
+
+notebook > header.left > tabs > arrow, notebook > header.right > tabs > arrow { margin-top: -5px; margin-bottom: -5px; padding-top: 4px; padding-bottom: 4px; }
+
+notebook > header.left > tabs > arrow.down, notebook > header.right > tabs > arrow.down { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+notebook > header.left > tabs > arrow.up, notebook > header.right > tabs > arrow.up { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+notebook > header > tabs > arrow { transition: none; min-height: 16px; min-width: 16px; }
+
+notebook > header > tabs > arrow:hover:not(:active):not(:backdrop) { background-clip: padding-box; background-image: none; border-color: transparent; box-shadow: none; transition: none; }
+
+notebook > header > tabs > arrow:disabled { color: #6b8a7f; background-color: transparent; background-image: none; }
+
+notebook > header tab { min-height: 24px; min-width: 30px; padding: 2px 9px; margin: 2px; outline-offset: -3px; border-radius: 8px; color: #9ac6b6; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header tab:hover { color: #bbf1dd; background-color: rgba(187, 241, 221, 0.05); }
+
+notebook > header tab:backdrop { color: #6e837b; }
+
+notebook > header tab:backdrop.reorderable-page { background-color: transparent; }
+
+notebook > header tab:checked { color: #bbf1dd; background-color: #33433d; box-shadow: 0 2px 4px rgba(21, 28, 25, 0.075); }
+
+notebook > header tab:backdrop:checked { color: #6e837b; background-color: #252d2a; box-shadow: 0 1px 2px rgba(19, 23, 22, 0.075); }
+
+notebook > header tab:backdrop:checked.reorderable-page { background-color: #252d2a; }
+
+notebook > header tab button.flat { border-radius: 999px; padding: 0; margin-top: 2px; margin-bottom: 2px; min-width: 20px; min-height: 20px; }
+
+notebook > header tab button.flat:hover { color: currentColor; }
+
+notebook > header tab button.flat, notebook > header tab button.flat:backdrop { color: alpha(currentColor,0.3); }
+
+notebook > header tab button.flat:last-child { margin-left: 4px; margin-right: -4px; }
+
+notebook > header tab button.flat:first-child { margin-left: -4px; margin-right: 4px; }
+
+notebook > stack:not(:only-child) { background-color: transparent; }
+
+notebook > stack:not(:only-child):backdrop { background-color: transparent; }
+
+/************** Scrollbars * */
+scrollbar { background-color: transparent; transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border-radius: 8px; }
+
+* { -GtkScrollbar-has-backward-stepper: false; -GtkScrollbar-has-forward-stepper: false; }
+
+scrollbar:backdrop { border-color: #252e2b; transition: 150ms ease-out; }
+
+scrollbar slider { min-width: 6px; min-height: 6px; margin: -1px; border: 4px solid transparent; border-radius: 8px; background-clip: padding-box; background-color: #7b9f92; }
+
+scrollbar slider:hover { background-color: #9bc8b7; }
+
+scrollbar slider:hover:active { background-color: #bbf1dd; }
+
+scrollbar slider:backdrop { background-color: #54655f; }
+
+scrollbar slider:disabled { background-color: transparent; }
+
+scrollbar.fine-tune slider { min-width: 4px; min-height: 4px; }
+
+scrollbar.fine-tune.horizontal slider { border-width: 5px 4px; }
+
+scrollbar.fine-tune.vertical slider { border-width: 4px 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) { border-color: transparent; opacity: 0.4; background-color: transparent; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider { margin: 0; min-width: 3px; min-height: 3px; background-color: #bbf1dd; border: 1px solid black; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) button { min-width: 5px; min-height: 5px; background-color: #bbf1dd; background-clip: padding-box; border-radius: 100%; border: 1px solid black; -gtk-icon-source: none; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider { margin: 0 2px; min-width: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal button { margin: 1px 2px; min-width: 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider { margin: 2px 0; min-height: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical button { margin: 2px 1px; min-height: 5px; }
+
+scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering { opacity: 0.8; }
+
+scrollbar.horizontal slider { min-width: 40px; }
+
+scrollbar.vertical slider { min-height: 40px; }
+
+scrollbar button { padding: 0; min-width: 12px; min-height: 12px; border-style: none; border-radius: 0; transition-property: min-height, min-width, color; background-color: transparent; background-image: none; background-image: none; color: #7b9f92; }
+
+scrollbar button:hover { background-color: transparent; background-image: none; background-image: none; color: #9bc8b7; }
+
+scrollbar button:active, scrollbar button:checked { background-color: transparent; background-image: none; background-image: none; color: #bbf1dd; }
+
+scrollbar button:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(123, 159, 146, 0.2); }
+
+scrollbar button:backdrop { background-color: transparent; background-image: none; background-image: none; color: #54655f; }
+
+scrollbar button:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(84, 101, 95, 0.2); }
+
+scrollbar.vertical button.down { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+scrollbar.vertical button.up { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+scrollbar.horizontal button.down { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+scrollbar.horizontal button.up { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+/********** Switch * */
+switch { font-size: 0; outline-offset: -4px; min-width: 36px; min-height: 18px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border: none; padding: 2px; border-radius: 999px; background-color: #3b4d46; background-image: none; color: transparent; }
+
+switch:checked { background-color: #bbf1dd; background: image(#bbf1dd); }
+
+switch:disabled { background-color: #27332f; background-image: none; }
+
+switch:disabled:checked { background-color: #546c63; background-image: none; }
+
+switch:backdrop { background-color: #36423d; background-image: none; transition: 150ms ease-out; }
+
+switch:backdrop:checked { background-color: #7d998f; background-image: none; }
+
+switch:backdrop:disabled { background-color: #252e2b; background-image: none; }
+
+switch:backdrop:disabled:checked { background-color: #3b4843; background-image: none; }
+
+switch slider { margin: 2px; min-width: 18px; min-height: 18px; border: none; border-radius: 999px; -gtk-outline-radius: 999px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-color: #151c19; box-shadow: 0 2px 4px rgba(21, 28, 25, 0.075); }
+
+switch:disabled slider { background-color: #1b2421; box-shadow: none; }
+
+switch:backdrop slider { transition: 150ms ease-out; background-color: #181e1c; box-shadow: 0 2px 4px rgba(19, 23, 22, 0.075); }
+
+switch:checked slider { background-color: #151c19; box-shadow: none; }
+
+switch:backdrop:checked slider { background-color: #131716; }
+
+row:selected switch { box-shadow: none; box-shadow: inset 0 0 0 1px #151c19; }
+
+/************************* Check and Radio items * */
+.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view:not(list) check { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view:not(list) check:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view:not(list) check:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view:not(list) check:backdrop { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view:not(list) check:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view:not(list) check:checked:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view:not(list) check:checked:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view:not(list) check:backdrop:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+checkbutton.text-button, radiobutton.text-button { padding: 2px 0; outline-offset: 0; }
+
+checkbutton.text-button label:not(:only-child):first-child, radiobutton.text-button label:not(:only-child):first-child { margin-left: 4px; }
+
+checkbutton.text-button label:not(:only-child):last-child, radiobutton.text-button label:not(:only-child):last-child { margin-right: 4px; }
+
+check, radio { margin: 0 4px; min-height: 14px; min-width: 14px; padding: 1px; border: none; -gtk-icon-source: none; }
+
+check:only-child, radio:only-child { margin: 0; }
+
+popover check.left:dir(rtl), popover radio.left:dir(rtl) { margin-left: 0; margin-right: 12px; }
+
+popover check.right:dir(ltr), popover radio.right:dir(ltr) { margin-left: 12px; margin-right: 0; }
+
+check, radio { background-clip: padding-box; background: image(#151c19); box-shadow: inset 0 0 0 1px #3b4d46; color: #bbf1dd; }
+
+check:hover, radio:hover { background: image(#1d2723); }
+
+check:active, radio:active { background: image(#26312d); }
+
+check:disabled, radio:disabled { box-shadow: none; background-image: none; background-color: #18201d; color: rgba(187, 241, 221, 0.7); }
+
+check:backdrop, radio:backdrop { background-image: none; background-color: #171c1a; box-shadow: inset 0 0 0 1px #3d4b46; color: #bbf1dd; }
+
+check:backdrop:disabled, radio:backdrop:disabled { box-shadow: none; background-image: none; background-color: #191f1d; color: rgba(187, 241, 221, 0.7); }
+
+check:checked, radio:checked { background-clip: border-box; background: image(#bbf1dd); box-shadow: none; color: #151c19; }
+
+check:checked:hover, radio:checked:hover { background: image(#bbf1dd); }
+
+check:checked:active, radio:checked:active { background: image(#bbf1dd); }
+
+check:checked:disabled, radio:checked:disabled { box-shadow: none; background-image: none; background-color: #6b8a7f; color: rgba(21, 28, 25, 0.7); }
+
+check:checked:backdrop, radio:checked:backdrop { background-image: none; background-color: #8dafa2; box-shadow: none; color: #151c19; }
+
+check:checked:backdrop:disabled, radio:checked:backdrop:disabled { box-shadow: none; background-image: none; background-color: #6f867e; color: rgba(21, 28, 25, 0.7); }
+
+check:indeterminate, radio:indeterminate { background-clip: border-box; background: image(#bbf1dd); box-shadow: none; color: #151c19; }
+
+check:indeterminate:hover, radio:indeterminate:hover { background: image(#bbf1dd); }
+
+check:indeterminate:active, radio:indeterminate:active { background: image(#bbf1dd); }
+
+check:indeterminate:disabled, radio:indeterminate:disabled { box-shadow: none; background-image: none; background-color: #6b8a7f; color: rgba(21, 28, 25, 0.7); }
+
+check:indeterminate:backdrop, radio:indeterminate:backdrop { background-image: none; background-color: #8dafa2; box-shadow: none; color: #151c19; }
+
+check:indeterminate:backdrop:disabled, radio:indeterminate:backdrop:disabled { box-shadow: none; background-image: none; background-color: #6f867e; color: rgba(21, 28, 25, 0.7); }
+
+check:backdrop, radio:backdrop { transition: 150ms ease-out; }
+
+menu menuitem check, menu menuitem radio { margin: 0; }
+
+menu menuitem check, menu menuitem check:hover, menu menuitem check:disabled, menu menuitem check:checked, menu menuitem check:checked:hover, menu menuitem check:checked:disabled, menu menuitem check:indeterminate, menu menuitem check:indeterminate:hover, menu menuitem check:indeterminate:disabled, menu menuitem radio, menu menuitem radio:hover, menu menuitem radio:disabled, menu menuitem radio:checked, menu menuitem radio:checked:hover, menu menuitem radio:checked:disabled, menu menuitem radio:indeterminate, menu menuitem radio:indeterminate:hover, menu menuitem radio:indeterminate:disabled { min-height: 14px; min-width: 14px; background-image: none; background-color: transparent; box-shadow: none; -gtk-icon-shadow: none; color: inherit; border: 1px solid currentColor; padding: 0; }
+
+check { border-radius: 4px; }
+
+check:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/check-symbolic.svg")), -gtk-recolor(url("assets/check-symbolic.symbolic.png"))); }
+
+check:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+treeview.view radio:selected:focus, treeview.view radio:selected, radio { border-radius: 100%; }
+
+treeview.view radio:checked:selected, radio:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/bullet-symbolic.svg")), -gtk-recolor(url("assets/bullet-symbolic.symbolic.png"))); }
+
+treeview.view radio:indeterminate:selected, radio:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+radio:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: scale(0); }
+
+check:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: translate(6px, -3px) rotate(-45deg) scaleY(0.2) rotate(45deg) scaleX(0); }
+
+radio:active, check:active { -gtk-icon-transform: scale(0, 1); }
+
+radio:checked:not(:backdrop), radio:indeterminate:not(:backdrop), check:checked:not(:backdrop), check:indeterminate:not(:backdrop) { -gtk-icon-transform: unset; transition: 400ms; }
+
+menu menuitem radio:checked:not(:backdrop), menu menuitem radio:indeterminate:not(:backdrop), menu menuitem check:checked:not(:backdrop), menu menuitem check:indeterminate:not(:backdrop) { transition: none; }
+
+treeview.view check:selected:focus, treeview.view check:selected, treeview.view radio:selected:focus, treeview.view radio:selected { color: #151c19; border: 1px solid #addfcc; }
+
+treeview.view check:selected:focus:backdrop, treeview.view check:selected:backdrop, treeview.view radio:selected:focus:backdrop, treeview.view radio:selected:backdrop { border-color: #91b7a8; }
+
+/************ GtkScale * */
+levelbar block.empty, progressbar trough, scale fill, scale trough { border: none; border-radius: 8px; background-color: #27332f; }
+
+levelbar block.empty:disabled, progressbar trough:disabled, scale fill:disabled, scale trough:disabled { background-color: #27332f; }
+
+levelbar block.empty:backdrop, progressbar trough:backdrop, scale fill:backdrop, scale trough:backdrop { background-color: #252e2b; transition: 150ms ease-out; }
+
+levelbar block.empty:backdrop:disabled, progressbar trough:backdrop:disabled, scale fill:backdrop:disabled, scale trough:backdrop:disabled { background-color: #252e2b; }
+
+row:selected levelbar block.empty, levelbar row:selected block.empty, row:selected progressbar trough, progressbar row:selected trough, row:selected scale fill, scale row:selected fill, row:selected scale trough, scale row:selected trough { border: 1px solid #151c19; }
+
+progressbar progress, scale highlight { border: none; border-radius: 8px; background-color: #bbf1dd; background: image(#bbf1dd); }
+
+scale.vertical progressbar progress, progressbar scale.vertical progress, scale.vertical highlight, progressbar.vertical progress, progressbar.vertical scale highlight, scale progressbar.vertical highlight { background: image(#bbf1dd); }
+
+progressbar progress:disabled, scale highlight:disabled { background-image: none; background-color: #3b4d46; }
+
+progressbar progress:backdrop, scale highlight:backdrop { background-image: none; background-color: #7d998f; }
+
+progressbar progress:backdrop:disabled, scale highlight:backdrop:disabled { background-image: none; background-color: #36423d; }
+
+row:selected progressbar progress, progressbar row:selected progress, row:selected scale highlight, scale row:selected highlight { border: 1px solid #151c19; }
+
+scale { min-height: 10px; min-width: 10px; padding: 12px; }
+
+scale slider { min-height: 16px; min-width: 16px; margin: -8px; }
+
+scale.fine-tune.horizontal { padding-top: 9px; padding-bottom: 9px; min-height: 16px; }
+
+scale.fine-tune.vertical { padding-left: 9px; padding-right: 9px; min-width: 16px; }
+
+scale.fine-tune slider { margin: -6px; }
+
+scale.fine-tune fill, scale.fine-tune highlight, scale.fine-tune trough { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+scale trough { outline-offset: 2px; -gtk-outline-radius: 8px; }
+
+scale fill:backdrop, scale fill { background-color: #27332f; }
+
+scale fill:disabled:backdrop, scale fill:disabled { border-color: transparent; background-color: transparent; }
+
+scale slider { border: 2px solid #bbf1dd; border-radius: 100%; background-color: #1b2421; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-property: background, border, box-shadow; }
+
+row scale slider, popover scale slider { background-color: #151c19; }
+
+scale slider:hover { background-color: #151c19; }
+
+row scale slider:hover, popover scale slider:hover { background-color: #1b2421; }
+
+scale slider:active, row scale slider:active, popover scale slider:active { background-color: #bbf1dd; }
+
+scale slider:disabled { border-color: #3b4d46; }
+
+scale slider:backdrop { background-color: #181e1c; border-color: #7d998f; transition: 150ms ease-out; }
+
+scale slider:backdrop:disabled { border-color: #36423d; }
+
+row:selected scale slider:disabled, row:selected scale slider { border-color: #addfcc; }
+
+scale marks, scale value { color: alpha(currentColor,0.55); font-feature-settings: "tnum"; }
+
+scale.horizontal marks.top { margin-bottom: 6px; margin-top: -12px; }
+
+scale.horizontal.fine-tune marks.top { margin-bottom: 6px; margin-top: -9px; }
+
+scale.horizontal marks.bottom { margin-top: 6px; margin-bottom: -12px; }
+
+scale.horizontal.fine-tune marks.bottom { margin-top: 6px; margin-bottom: -9px; }
+
+scale.vertical marks.top { margin-right: 6px; margin-left: -12px; }
+
+scale.vertical.fine-tune marks.top { margin-right: 6px; margin-left: -9px; }
+
+scale.vertical marks.bottom { margin-left: 6px; margin-right: -12px; }
+
+scale.vertical.fine-tune marks.bottom { margin-left: 6px; margin-right: -9px; }
+
+scale.horizontal indicator { min-height: 6px; min-width: 1px; }
+
+scale.horizontal.fine-tune indicator { min-height: 3px; }
+
+scale.vertical indicator { min-height: 1px; min-width: 6px; }
+
+scale.vertical.fine-tune indicator { min-width: 3px; }
+
+scale.horizontal.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #bbf1dd; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-top: -13px; background-position: top; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:hover { color: #d0f5e7; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:active { color: #bbf1dd; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:disabled { color: #3b4d46; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop { color: #7d998f; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop:disabled { color: #36423d; }
+
+scale.horizontal.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-top: -11px; }
+
+scale.horizontal.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #bbf1dd; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-bottom: -13px; background-position: bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:hover { color: #d0f5e7; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:active { color: #bbf1dd; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:disabled { color: #3b4d46; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop { color: #7d998f; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop:disabled { color: #36423d; }
+
+scale.horizontal.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-bottom: -11px; }
+
+scale.vertical.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #bbf1dd; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-left: -13px; background-position: left bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-before:not(.marks-after) slider:hover { color: #d0f5e7; }
+
+scale.vertical.marks-before:not(.marks-after) slider:active { color: #bbf1dd; }
+
+scale.vertical.marks-before:not(.marks-after) slider:disabled { color: #3b4d46; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop { color: #7d998f; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop:disabled { color: #36423d; }
+
+scale.vertical.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-left: -11px; }
+
+scale.vertical.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #bbf1dd; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-right: -13px; background-position: right bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-after:not(.marks-before) slider:hover { color: #d0f5e7; }
+
+scale.vertical.marks-after:not(.marks-before) slider:active { color: #bbf1dd; }
+
+scale.vertical.marks-after:not(.marks-before) slider:disabled { color: #3b4d46; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop { color: #7d998f; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop:disabled { color: #36423d; }
+
+scale.vertical.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-right: -11px; }
+
+scale.color { min-height: 0; min-width: 0; }
+
+scale.color trough { background-color: transparent; }
+
+scale.color.horizontal { padding: 0 0 15px 0; }
+
+scale.color.horizontal trough { padding-bottom: 4px; background-position: 0 -3px; border-top-left-radius: 0; border-top-right-radius: 0; }
+
+scale.color.horizontal slider:dir(ltr):hover, scale.color.horizontal slider:dir(ltr):backdrop, scale.color.horizontal slider:dir(ltr):disabled, scale.color.horizontal slider:dir(ltr):backdrop:disabled, scale.color.horizontal slider:dir(ltr), scale.color.horizontal slider:dir(rtl):hover, scale.color.horizontal slider:dir(rtl):backdrop, scale.color.horizontal slider:dir(rtl):disabled, scale.color.horizontal slider:dir(rtl):backdrop:disabled, scale.color.horizontal slider:dir(rtl) { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.vertical:dir(ltr) { padding: 0 0 0 15px; }
+
+scale.color.vertical:dir(ltr) trough { padding-left: 4px; background-position: 3px 0; border-bottom-right-radius: 0; border-top-right-radius: 0; }
+
+scale.color.vertical:dir(ltr) slider:hover, scale.color.vertical:dir(ltr) slider:backdrop, scale.color.vertical:dir(ltr) slider:disabled, scale.color.vertical:dir(ltr) slider:backdrop:disabled, scale.color.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.vertical:dir(rtl) { padding: 0 15px 0 0; }
+
+scale.color.vertical:dir(rtl) trough { padding-right: 4px; background-position: -3px 0; border-bottom-left-radius: 0; border-top-left-radius: 0; }
+
+scale.color.vertical:dir(rtl) slider:hover, scale.color.vertical:dir(rtl) slider:backdrop, scale.color.vertical:dir(rtl) slider:disabled, scale.color.vertical:dir(rtl) slider:backdrop:disabled, scale.color.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr), scale.color.fine-tune.horizontal:dir(rtl) { padding: 0 0 12px 0; }
+
+scale.color.fine-tune.horizontal:dir(ltr) trough, scale.color.fine-tune.horizontal:dir(rtl) trough { padding-bottom: 7px; background-position: 0 -6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr) slider, scale.color.fine-tune.horizontal:dir(rtl) slider { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.fine-tune.vertical:dir(ltr) { padding: 0 0 0 12px; }
+
+scale.color.fine-tune.vertical:dir(ltr) trough { padding-left: 7px; background-position: 6px 0; }
+
+scale.color.fine-tune.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.fine-tune.vertical:dir(rtl) { padding: 0 12px 0 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) trough { padding-right: 7px; background-position: -6px 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+/***************** Progress bars * */
+@keyframes progress { from { background-position: 0, calc(0% - 64px), 0%; }
+  to { background-position: 0, calc(100% + 64px), 0%; } }
+
+progressbar { font-size: smaller; color: rgba(187, 241, 221, 0.4); font-feature-settings: "tnum"; }
+
+progressbar.horizontal trough, progressbar.horizontal progress { min-height: 4px; }
+
+progressbar.vertical trough, progressbar.vertical progress { min-width: 4px; }
+
+progressbar:backdrop { box-shadow: none; transition: 150ms ease-out; }
+
+progressbar trough { border-radius: 999px; }
+
+progressbar progress { background-image: none; background-color: #bbf1dd; border-radius: 999px; }
+
+progressbar progress, progressbar progress:backdrop, .horizontal progressbar progress { animation: none; }
+
+progressbar.horizontal progress { margin: 0 -1px; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled) { animation: progress 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite; background-size: cover, 64px 100%; background-repeat: no-repeat; background-image: linear-gradient(to bottom, alpha(@progress_bg_color, 0.2), rgba(155, 200, 183, 0)), linear-gradient(to right, rgba(155, 200, 183, 0), #9bc8b7 60%, rgba(155, 200, 183, 0)); }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled).right { animation-direction: reverse; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled):backdrop { animation: none; background-image: none; }
+
+progressbar.vertical progress { margin: -1px 0; }
+
+progressbar.osd { min-width: 4px; min-height: 4px; background-color: transparent; }
+
+progressbar.osd trough { border-style: none; border-radius: 0; background-color: transparent; box-shadow: none; }
+
+progressbar.osd progress { border-style: none; border-radius: 0; }
+
+progressbar trough.empty progress { all: unset; }
+
+/************* Level Bar * */
+levelbar.horizontal block { min-height: 4px; }
+
+levelbar.horizontal.discrete block { margin: 0 2px; min-width: 32px; }
+
+levelbar.horizontal.discrete block:first-child { margin-left: 0; }
+
+levelbar.horizontal.discrete block:last-child { margin-right: 0; }
+
+levelbar.vertical block { min-width: 4px; }
+
+levelbar.vertical.discrete block { margin: 2px 0; min-height: 32px; }
+
+levelbar.vertical.discrete block:first-child { margin-top: 0; }
+
+levelbar.vertical.discrete block:last-child { margin-bottom: 0; }
+
+levelbar:backdrop { transition: 150ms ease-out; }
+
+levelbar trough { border: none; padding: 0; background-color: transparent; }
+
+levelbar block { border: none; border-radius: 999px; }
+
+levelbar block.warning-battery-offset { background-color: #fb7c7c; background: image(#fb7c7c); }
+
+levelbar block.warning-battery-offset:backdrop { background-image: none; background-color: #7d998f; }
+
+levelbar block.low, levelbar block.low-battery-offset { background-color: #faa483; background: image(#faa483); }
+
+levelbar block.low:backdrop, levelbar block.low-battery-offset:backdrop { background-image: none; background-color: #7d998f; }
+
+levelbar block.high, levelbar block:not(.empty) { background-color: #bbf1dd; background: image(#bbf1dd); }
+
+levelbar block.high:backdrop, levelbar block:not(.empty):backdrop { background-image: none; background-color: #7d998f; }
+
+levelbar block.full, levelbar block.high-battery-offset { background-color: #6ee1b6; background: image(#6ee1b6); }
+
+levelbar block.full:backdrop, levelbar block.high-battery-offset:backdrop { background-image: none; background-color: #7d998f; }
+
+levelbar block.empty { background-image: none; }
+
+levelbar block:disabled { background-image: none; background-color: #3b4d46; }
+
+levelbar block:disabled:backdrop { background-image: none; background-color: #36423d; }
+
+/**************** Print dialog * */
+printdialog paper { color: black; border: 1px solid #595959; background: white; padding: 0; }
+
+printdialog paper:backdrop { color: #595959; border: 1px solid #262626; }
+
+printdialog .dialog-action-box { margin: 12px; }
+
+/********** Frames * */
+frame > border, .frame { box-shadow: none; margin: 0; padding: 0; border-radius: 10px; border: 1px solid #1b2421; }
+
+frame > border.flat, .frame.flat { border-style: none; }
+
+frame > border:backdrop, .frame:backdrop { border-color: #181e1c; }
+
+.background.csd revealer > actionbar { border-radius: 0 0 10px 10px; }
+
+actionbar > revealer > box { padding: 6px; border-top: 1px solid #27332f; }
+
+actionbar > revealer > box:backdrop { border-color: #252e2b; }
+
+scrolledwindow { background-color: transparent; border-radius: 0 0 8px 8px; }
+
+scrolledwindow viewport.frame { border-style: none; }
+
+scrolledwindow overshoot.top { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(rgba(187, 241, 221, 0.5)), to(rgba(187, 241, 221, 0))), -gtk-gradient(radial, center top, 0, center top, 0.6, from(rgba(187, 241, 221, 0.1)), to(rgba(187, 241, 221, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.top:backdrop { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(#252e2b), to(rgba(37, 46, 43, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(rgba(187, 241, 221, 0.5)), to(rgba(187, 241, 221, 0))), -gtk-gradient(radial, center bottom, 0, center bottom, 0.6, from(rgba(187, 241, 221, 0.1)), to(rgba(187, 241, 221, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom:backdrop { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(#252e2b), to(rgba(37, 46, 43, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(rgba(187, 241, 221, 0.5)), to(rgba(187, 241, 221, 0))), -gtk-gradient(radial, left center, 0, left center, 0.6, from(rgba(187, 241, 221, 0.1)), to(rgba(187, 241, 221, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left:backdrop { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(#252e2b), to(rgba(37, 46, 43, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(rgba(187, 241, 221, 0.5)), to(rgba(187, 241, 221, 0))), -gtk-gradient(radial, right center, 0, right center, 0.6, from(rgba(187, 241, 221, 0.1)), to(rgba(187, 241, 221, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right:backdrop { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(#252e2b), to(rgba(37, 46, 43, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+scrolledwindow junction { border-color: transparent; border-image: linear-gradient(to bottom, #27332f 1px, transparent 1px) 0 0 0 1/0 1px stretch; background-color: transparent; }
+
+scrolledwindow junction:dir(rtl) { border-image-slice: 0 1 0 0; }
+
+scrolledwindow junction:backdrop { border-image-source: linear-gradient(to bottom, #252e2b 1px, transparent 1px); background-color: transparent; transition: 150ms ease-out; }
+
+separator { background: #27332f; min-width: 1px; min-height: 1px; }
+
+/********* Lists * */
+list { color: #bbf1dd; background-color: #151c19; border-color: transparent; border-radius: 10px; }
+
+list, list.frame { padding-top: 4px; padding-bottom: 4px; }
+
+list.content, list.content list { background-color: transparent; padding: 0; }
+
+list:backdrop { background-color: #131716; color: #6e837b; border-color: transparent; }
+
+list separator.horizontal { margin: 1px 16px; }
+
+list separator.vertical { margin: 16px 1px; }
+
+list row { padding: 2px; }
+
+row { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+list:not(.content) row { border-radius: 8px; margin: 1px 6px; }
+
+list.content row { background-color: #151c19; }
+
+list.content row:backdrop { background-color: #131716; }
+
+list.content row:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+list.content row:last-child { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+row.expander { padding: 0px; }
+
+row:hover { transition: none; }
+
+row:backdrop { transition: 150ms ease-out; }
+
+row.activatable { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+row.activatable.has-open-popup, row.activatable:hover { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #27332f; background-image: none; background-color: rgba(187, 241, 221, 0.05); }
+
+row.activatable:active { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #33433d; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, rgba(187, 241, 221, 0.15) 10%, transparent 0%); background-size: 0% 0%; }
+
+row.activatable:backdrop:hover { background-color: transparent; background-image: none; background-image: none; color: #6e837b; }
+
+row.activatable:selected { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; background: image(#bbf1dd); box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); }
+
+row.activatable:selected label { color: #151c19; }
+
+row.activatable:selected:active { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); }
+
+row.activatable:selected:backdrop { background-color: #7d998f; background-image: none; box-shadow: none; }
+
+row.activatable:selected:backdrop label, row.activatable:selected:backdrop { color: #131716; }
+
+/********************* App Notifications * */
+.app-notification, .app-notification.frame { padding: 10px; margin: 8px; border-radius: 30px; border: 1px solid rgba(39, 51, 47, 0.75); box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification:backdrop, .app-notification.frame:backdrop { background-color: #131716; transition: 150ms ease-out; border-color: rgba(37, 46, 43, 0.75); box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification border, .app-notification.frame border { border: none; }
+
+.app-notification button:not(.linked), .app-notification.frame button:not(.linked) { border-radius: 999px; -gtk-outline-radius: 999px; }
+
+/************* Expanders * */
+expander title > arrow { min-width: 16px; min-height: 16px; -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+expander title > arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+expander title > arrow:hover { color: white; }
+
+expander title > arrow:disabled { color: #6b8a7f; }
+
+expander title > arrow:disabled:backdrop { color: #3a4944; }
+
+expander title > arrow:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+/************ Calendar * */
+calendar { color: #bbf1dd; }
+
+calendar:selected { border-radius: 8px; }
+
+calendar.header { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.header:backdrop { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.button { color: rgba(187, 241, 221, 0.45); }
+
+calendar.button:hover { color: #bbf1dd; }
+
+calendar.button:backdrop { color: rgba(110, 131, 123, 0.45); }
+
+calendar.button:disabled { color: rgba(107, 138, 127, 0.45); }
+
+calendar.highlight { color: #6b8a7f; }
+
+calendar.highlight:backdrop { color: #3a4944; }
+
+calendar:backdrop { color: #6e837b; border-color: #252e2b; }
+
+calendar:indeterminate { color: alpha(currentColor,0.1); }
+
+/*********** Dialogs * */
+messagedialog .titlebar { min-height: 20px; background-image: none; background-color: #1b2421; border-style: none; border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+messagedialog.csd.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button { padding: 10px 14px; border-right-style: none; border-bottom-style: none; border-radius: 0; margin: 0 2px 0 0; -gtk-outline-radius: 0; }
+
+messagedialog.csd .dialog-action-area button:first-child { border-left-style: none; border-bottom-left-radius: 10px; -gtk-outline-bottom-left-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button:last-child { border-bottom-right-radius: 10px; margin-right: 0; -gtk-outline-bottom-right-radius: 10px; }
+
+filechooser .dialog-action-box { border-top: 1px solid #27332f; }
+
+filechooser .dialog-action-box:backdrop { border-top-color: #252e2b; }
+
+filechooser #pathbarbox { border: none; }
+
+filechooser #pathbarbox:backdrop { background-color: #181e1c; }
+
+filechooserbutton:drop(active) { box-shadow: none; border-color: transparent; }
+
+/*********** Sidebar * */
+.sidebar { border-style: none; background-color: transparent; border-radius: 0 0 10px 10px; }
+
+stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:not(separator):dir(ltr), .sidebar:not(separator).left { border-right: 1px solid #27332f; border-left-style: none; }
+
+stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:not(separator):dir(rtl), .sidebar:not(separator).right { border-left: 1px solid #27332f; border-right-style: none; }
+
+.sidebar:backdrop { border-color: #252e2b; transition: 150ms ease-out; }
+
+.sidebar list { background-color: transparent; }
+
+paned .sidebar.left, paned .sidebar.right, paned .sidebar.left:dir(rtl), paned .sidebar:dir(rtl), paned .sidebar:dir(ltr), paned .sidebar { border-style: none; }
+
+stacksidebar row { padding: 10px 4px; }
+
+stacksidebar row > label { padding-left: 6px; padding-right: 6px; }
+
+stacksidebar row.needs-attention > label { background-size: 6px 6px, 0 0; }
+
+separator.sidebar { background-color: #27332f; }
+
+separator.sidebar:backdrop { background-color: #252e2b; }
+
+separator.sidebar.selection-mode, .selection-mode separator.sidebar { background-color: #addfcc; }
+
+/**************** File chooser * */
+row image.sidebar-icon { opacity: 0.7; }
+
+placessidebar > viewport.frame { border-style: none; background-color: transparent; }
+
+placessidebar undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+placessidebar list { padding-top: 0; }
+
+placessidebar row { min-height: 36px; padding: 0px; margin-top: 0; margin-bottom: 0; }
+
+placessidebar row:first-child { margin-top: 0; }
+
+placessidebar row > revealer { padding: 0 8px; }
+
+placessidebar row:selected { color: #151c19; }
+
+placessidebar row:disabled { color: #6b8a7f; }
+
+placessidebar row:backdrop { color: #6e837b; }
+
+placessidebar row:backdrop:selected { color: #131716; }
+
+placessidebar row:backdrop:disabled { color: #3a4944; }
+
+placessidebar row image.sidebar-icon:dir(ltr) { padding-right: 8px; }
+
+placessidebar row image.sidebar-icon:dir(rtl) { padding-left: 8px; }
+
+placessidebar row label.sidebar-label:dir(ltr) { padding-right: 2px; }
+
+placessidebar row label.sidebar-label:dir(rtl) { padding-left: 2px; }
+
+button.sidebar-button { min-height: 26px; min-width: 26px; margin: 0; padding: 0; border-radius: 100%; -gtk-outline-radius: 100%; }
+
+button.sidebar-button:not(:hover):not(:active) > image, button.sidebar-button:backdrop > image { opacity: 0.7; }
+
+placessidebar row:selected:active { box-shadow: none; }
+
+placessidebar row.sidebar-placeholder-row { padding: 0 8px; min-height: 2px; background-image: image(#4cd9a4); background-clip: content-box; }
+
+placessidebar row.sidebar-new-bookmark-row { color: #bbf1dd; }
+
+placessidebar row:drop(active):not(:disabled) { color: #4cd9a4; box-shadow: inset 0 0 0 2px #4cd9a4; }
+
+placessidebar row:drop(active):not(:disabled):selected { color: #151c19; background-color: #4cd9a4; }
+
+placesview list { background-color: #1b2421; border-radius: 0 0 10px 0; }
+
+placesview list:backdrop { background-color: #181e1c; }
+
+placesview .server-list-button > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(0turn); }
+
+placesview .server-list-button:checked > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(-0.5turn); }
+
+placesview row.activatable:hover { background-color: transparent; }
+
+placesview > actionbar > revealer > box > label { padding-left: 8px; padding-right: 8px; }
+
+/********* Paned * */
+paned > separator { min-width: 1px; min-height: 1px; -gtk-icon-source: none; border-style: none; background-color: transparent; background-image: image(#27332f); background-size: 1px 1px; }
+
+paned > separator:selected { background-image: image(#bbf1dd); }
+
+paned > separator:backdrop { background-image: image(#252e2b); }
+
+paned > separator.wide { min-width: 5px; min-height: 5px; background-color: #1b2421; background-image: image(#27332f), image(#27332f); background-size: 1px 1px, 1px 1px; }
+
+paned > separator.wide:backdrop { background-color: #181e1c; background-image: image(#252e2b), image(#252e2b); }
+
+paned.horizontal > separator { background-repeat: repeat-y; }
+
+paned.horizontal > separator:dir(ltr) { margin: 0 -8px 0 0; padding: 0 8px 0 0; background-position: left; }
+
+paned.horizontal > separator:dir(rtl) { margin: 0 0 0 -8px; padding: 0 0 0 8px; background-position: right; }
+
+paned.horizontal > separator.wide { margin: 0; padding: 0; background-repeat: repeat-y, repeat-y; background-position: left, right; }
+
+paned.vertical > separator { margin: 0 0 -8px 0; padding: 0 0 8px 0; background-repeat: repeat-x; background-position: top; }
+
+paned.vertical > separator.wide { margin: 0; padding: 0; background-repeat: repeat-x, repeat-x; background-position: bottom, top; }
+
+/************** GtkInfoBar * */
+infobar { border-style: none; }
+
+infobar.action:hover > revealer > box { background-color: #2c1d17; border-bottom: 1px solid #1b2421; }
+
+infobar.info, infobar.question, infobar.warning, infobar.error { text-shadow: none; }
+
+infobar.info:backdrop > revealer > box, infobar.info > revealer > box, infobar.question:backdrop > revealer > box, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box, infobar.error > revealer > box { background-color: #32211a; border-bottom: 1px solid #1b2421; }
+
+infobar.info:backdrop > revealer > box label, infobar.info:backdrop > revealer > box, infobar.info > revealer > box label, infobar.info > revealer > box, infobar.question:backdrop > revealer > box label, infobar.question:backdrop > revealer > box, infobar.question > revealer > box label, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box label, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box label, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box label, infobar.error:backdrop > revealer > box, infobar.error > revealer > box label, infobar.error > revealer > box { color: #faa483; }
+
+infobar.info:backdrop, infobar.question:backdrop, infobar.warning:backdrop, infobar.error:backdrop { text-shadow: none; }
+
+infobar.info button, infobar.question button, infobar.warning button, infobar.error button { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #412b22; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #50352a; background-image: none; }
+
+infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #5a3b2f; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #6e483a 10%, transparent 0%); background-size: 0% 0%; }
+
+infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; background: image(#bbf1dd); box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); }
+
+infobar.info button:checked:active, infobar.question button:checked:active, infobar.warning button:checked:active, infobar.error button:checked:active { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); }
+
+infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled { color: #6b8a7f; background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop, infobar.question button:backdrop, infobar.warning button:backdrop, infobar.error button:backdrop { background-color: #1e2623; background-image: none; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.error button:backdrop label, infobar.error button:backdrop { color: #6e837b; }
+
+infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop:disabled label, infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled label, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled label, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled label, infobar.error button:backdrop:disabled { color: #3a4944; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.info button label, infobar.info button, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.question button label, infobar.question button, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.warning button label, infobar.warning button, infobar.error button:backdrop label, infobar.error button:backdrop, infobar.error button label, infobar.error button { color: #faa483; }
+
+infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection { background-color: #050706; }
+
+infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link { color: #e6faf2; }
+
+/************ Tooltips * */
+tooltip { padding: 4px; /* not working */ border-radius: 10px; box-shadow: none; }
+
+tooltip.background, tooltip.background.csd { border-radius: 10px; background-color: rgba(0, 0, 0, 0.8); background-clip: padding-box; border: 1px solid rgba(255, 255, 255, 0.1); }
+
+tooltip decoration { background-color: transparent; }
+
+tooltip * { padding: 4px; background-color: transparent; color: white; }
+
+/***************** Color Chooser * */
+colorswatch:drop(active), colorswatch { border-style: none; }
+
+colorswatch.top { border-top-left-radius: 8.5px; border-top-right-radius: 8.5px; }
+
+colorswatch.top overlay { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+colorswatch.bottom { border-bottom-left-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.bottom overlay { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.left, colorswatch:first-child:not(.top) { border-top-left-radius: 8.5px; border-bottom-left-radius: 8.5px; }
+
+colorswatch.left overlay, colorswatch:first-child:not(.top) overlay { border-top-left-radius: 8px; border-bottom-left-radius: 8px; }
+
+colorswatch.right, colorswatch:last-child:not(.bottom) { border-top-right-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.right overlay, colorswatch:last-child:not(.bottom) overlay { border-top-right-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.dark { outline-color: rgba(255, 255, 255, 0.6); }
+
+colorswatch.dark overlay { color: white; }
+
+colorswatch.dark overlay:backdrop { color: rgba(255, 255, 255, 0.5); }
+
+colorswatch.light { outline-color: rgba(0, 0, 0, 0.6); }
+
+colorswatch.light overlay { color: black; }
+
+colorswatch.light overlay:backdrop { color: rgba(0, 0, 0, 0.5); }
+
+colorswatch:drop(active) { box-shadow: none; }
+
+colorswatch:drop(active).light overlay { border-color: #4cd9a4; }
+
+colorswatch:drop(active).dark overlay { border-color: #4cd9a4; }
+
+colorswatch overlay { border: 1px solid transparent; }
+
+colorswatch#add-color-button { border-radius: 8px 8px 0 0; }
+
+colorswatch#add-color-button:only-child { border-radius: 8px; }
+
+colorswatch#add-color-button overlay { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #27332f; background-image: none; }
+
+colorswatch#add-color-button overlay:hover { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-color: #33433d; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop { background-color: #1e2623; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop label, colorswatch#add-color-button overlay:backdrop { color: #6e837b; }
+
+colorswatch:disabled { opacity: 0.5; }
+
+colorswatch:disabled overlay { border-color: rgba(0, 0, 0, 0.6); box-shadow: none; }
+
+row:selected colorswatch { box-shadow: 0 0 0 2px #151c19; }
+
+colorswatch#editor-color-sample { border-radius: 8px; }
+
+colorswatch#editor-color-sample overlay { border-radius: 8.5px; }
+
+colorchooser .popover.osd { border-radius: 8px; }
+
+/******** Misc * */
+.content-view { background-color: #161d1a; }
+
+.content-view:hover { -gtk-icon-effect: highlight; }
+
+.content-view:backdrop { background-color: #121715; }
+
+.osd .scale-popup button.flat { border-style: none; border-radius: 8px; }
+
+.scale-popup button:hover { background-color: rgba(187, 241, 221, 0.15); border-radius: 8px; }
+
+/********************** Window Decorations * */
+decoration { border-radius: 10px; border-width: 0px; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(187, 241, 221, 0.1); margin: 10px; }
+
+decoration:backdrop { box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(110, 131, 123, 0.125); transition: 150ms ease-out; }
+
+.maximized decoration, .fullscreen decoration, .tiled decoration, .tiled-top decoration, .tiled-right decoration, .tiled-bottom decoration, .tiled-left decoration { border-radius: 0; }
+
+.popup decoration { box-shadow: none; }
+
+.ssd decoration { box-shadow: 0 0 0 1px rgba(187, 241, 221, 0.1); }
+
+.csd.popup decoration { border-radius: 8px; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(187, 241, 221, 0.1); }
+
+.csd.popup decoration:backdrop { box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(110, 131, 123, 0.125); }
+
+tooltip.csd decoration { border-radius: 10px; box-shadow: none; }
+
+messagedialog.csd decoration { border-radius: 10px; box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(187, 241, 221, 0.1); }
+
+messagedialog.csd decoration:backdrop { box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(110, 131, 123, 0.125); }
+
+.solid-csd decoration { margin: 0; padding: 4px; background-color: #27332f; border: solid 1px #27332f; border-radius: 0; box-shadow: none; }
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized), window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration, window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration-overlay { border-radius: 10px; }
+
+button.titlebutton:not(.appmenu) { border-radius: 9999px; padding: 6px; margin: 0 2px; min-width: 0; min-height: 0; }
+
+button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.selection-mode headerbar button.titlebutton:backdrop, .selection-mode .titlebar button.titlebutton:backdrop, headerbar.selection-mode button.titlebutton:backdrop, .titlebar.selection-mode button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { background-color: #bbf1dd; }
+
+.selection-mode button.titlebutton, .view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { color: #151c19; }
+
+.selection-mode button.titlebutton:disabled, .view:disabled:selected, textview text:disabled:selected:focus, .view text:disabled:selected, textview text:disabled:selected, iconview:disabled:selected:focus, iconview:disabled:selected, flowbox flowboxchild:disabled:selected, modelbutton.flat:disabled:selected, .menuitem.button.flat:disabled:selected, treeview.view:disabled:selected, row:disabled:selected, calendar:disabled:selected { color: #68867b; }
+
+.selection-mode button.titlebutton:backdrop, .view:backdrop:selected, textview text:backdrop:selected:focus, .view text:backdrop:selected, textview text:backdrop:selected, iconview:backdrop:selected:focus, iconview:backdrop:selected, flowbox flowboxchild:backdrop:selected, modelbutton.flat:backdrop:selected, .menuitem.button.flat:backdrop:selected, treeview.view:backdrop:selected, row:backdrop:selected, calendar:backdrop:selected { color: #131716; background-color: #7d998f; }
+
+.selection-mode button.titlebutton:backdrop:disabled, .view:backdrop:disabled:selected, .view text:backdrop:disabled:selected, textview text:backdrop:disabled:selected, iconview:backdrop:disabled:selected, flowbox flowboxchild:backdrop:disabled:selected, modelbutton.flat:backdrop:disabled:selected, .menuitem.button.flat:backdrop:disabled:selected, row:backdrop:disabled:selected, calendar:backdrop:disabled:selected { color: #89afa1; }
+
+.view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { background-color: #3f524b; }
+
+label:selected, .view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { color: #bbf1dd; }
+
+label:disabled selection, label:disabled:selected, .view text selection:disabled, textview text selection:disabled:focus, textview text selection:disabled, iconview text selection:disabled:focus, iconview text selection:disabled, label selection:disabled, entry selection:disabled, spinbutton:not(.vertical) selection:disabled { color: #739488; }
+
+label:backdrop selection, label:backdrop:selected, .view text selection:backdrop, textview text selection:backdrop:focus, textview text selection:backdrop, iconview text selection:backdrop:focus, iconview text selection:backdrop, label selection:backdrop, entry selection:backdrop, spinbutton:not(.vertical) selection:backdrop { background-color: #2f3a36; color: #6f857d; }
+
+label:backdrop selection:disabled, label:backdrop:disabled:selected, .view text selection:backdrop:disabled, textview text selection:backdrop:disabled, iconview text selection:backdrop:disabled, label selection:backdrop:disabled, entry selection:backdrop:disabled, spinbutton:not(.vertical) selection:backdrop:disabled { color: #41514b; }
+
+.monospace { font-family: monospace; }
+
+/********************** Touch Copy & Paste * */
+cursor-handle { background-color: transparent; background-image: none; box-shadow: none; border-style: none; color: #bbf1dd; }
+
+cursor-handle:hover { color: #fbfefd; }
+
+cursor-handle:active { color: #bbf1dd; }
+
+cursor-handle.top:dir(ltr), cursor-handle.bottom:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-start-symbolic.svg")), -gtk-recolor(url("assets/text-select-start-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.bottom:dir(ltr), cursor-handle.top:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-end-symbolic.svg")), -gtk-recolor(url("assets/text-select-end-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); }
+
+.context-menu { font: initial; }
+
+.keycap { min-width: 20px; min-height: 25px; margin-top: 2px; padding-bottom: 3px; padding-left: 6px; padding-right: 6px; color: #bbf1dd; background-color: #151c19; border: 1px solid; border-color: #27332f; border-radius: 4px; box-shadow: inset 0 -3px #202a26; font-size: smaller; }
+
+.keycap:backdrop { background-color: #131716; color: #6e837b; transition: 150ms ease-out; }
+
+:not(decoration):not(window):drop(active):focus, :not(decoration):not(window):drop(active) { border-color: #4cd9a4; box-shadow: inset 0 0 0 1px #4cd9a4; caret-color: #4cd9a4; }
+
+stackswitcher button.text-button { min-width: 100px; }
+
+stackswitcher button.circular, stackswitcher button.text-button.circular { min-width: 32px; min-height: 32px; padding: 0; }
+
+/************* App Icons * */
+/* Outline for low res icons */
+.lowres-icon { -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/* Dropshadow for large icons */
+.icon-dropshadow { -gtk-icon-shadow: 0 1px 12px rgba(0, 0, 0, 0.05), 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/********* Emoji * */
+popover.emoji-picker { padding-left: 0; padding-right: 0; }
+
+popover.emoji-picker entry.search { margin: 3px 5px 5px 5px; }
+
+button.emoji-section { border-color: transparent; border-width: 3px; border-style: none none solid; border-radius: 0; margin: 2px 4px 2px 4px; padding: 3px 0 0; min-width: 32px; min-height: 28px; /* reset props inherited from the button style */ background: none; box-shadow: none; text-shadow: none; outline-offset: -5px; }
+
+button.emoji-section:first-child { margin-left: 7px; }
+
+button.emoji-section:last-child { margin-right: 7px; }
+
+button.emoji-section:backdrop:not(:checked) { border-color: transparent; }
+
+button.emoji-section:hover { border-color: #27332f; }
+
+button.emoji-section:checked { color: #bbf1dd; border-color: #bbf1dd; }
+
+button.emoji-section:checked:backdrop { color: #6e837b; background-color: transparent; }
+
+button.emoji-section label { padding: 0; opacity: 0.55; }
+
+button.emoji-section:hover label { opacity: 0.775; }
+
+button.emoji-section:checked label { opacity: 1; }
+
+popover.emoji-picker .emoji { font-size: x-large; padding: 6px; }
+
+popover.emoji-picker .emoji :hover { background: #bbf1dd; border-radius: 8px; }
+
+popover.emoji-completion arrow { border: none; background: none; }
+
+popover.emoji-completion contents row box { padding: 2px 10px; }
+
+popover.emoji-completion .emoji:hover { background: #27332f; }
+
+/***************** View Switcher * */
+viewswitcher button { margin: 0; padding: 0; border-radius: 0; border: none; box-shadow: none; }
+
+viewswitcher button:checked { box-shadow: none; }
+
+viewswitcher button stack > box.narrow { font-size: smaller; padding-top: 6px; padding-bottom: 6px; }
+
+viewswitcher button stack > box.narrow image, viewswitcher button stack > box.narrow label { padding-left: 6px; padding-right: 6px; }
+
+viewswitcher button stack > box.wide { padding: 0 12px; }
+
+viewswitcherbar > actionbar > revealer > box { padding: 0; }
+
+viewswitcherbar > actionbar > revealer > box viewswitcher button:not(:checked):not(:hover) { background: transparent; }
+
+headerbar viewswitcher > box > button:first-child { border-bottom-left-radius: 8px; }
+
+headerbar viewswitcher > box > button:last-child { border-bottom-right-radius: 8px; }
+
+/*********** Chromium * */
+window.background.chromium { background-color: #151c19; }
+
+window.background.chromium headerbar.titlebar button.toggle, window.background.chromium headerbar.titlebar button.titlebutton { border: none; }
+
+window.background.chromium headerbar.titlebar button.titlebutton { background-image: none; }
+
+window.background.chromium button { border-style: solid; border-width: 1px; border-color: #27332f; }
+
+window.background.chromium > textview.view { background-color: #1b2421; }
+
+/*********** Firefox * */
+#MozillaGtkWidget.background { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+
+#MozillaGtkWidget.background scrollbar { background-color: transparent; border-color: transparent; }
+
+/****************** Gnome Calendar * */
+window.background.csd.org-gnome-Calendar > overlay > box.vertical > stack.view { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > button.text-button { margin: 0; border-bottom-right-radius: 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > stack > .sidebar.vertical { border-radius: 0; }
+
+window.background.csd.org-gnome-Calendar.maximized calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.tiled calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.fullscreen calendar-view.year-view > box.vertical > button.text-button { border-bottom-right-radius: 0; }
+
+/*************** LibreOffice * */
+toolbutton > button.image-button.text-button.flat button { background-color: transparent; background-image: none; background-image: none; }
+
+toolbutton > button.image-button.text-button.flat button:hover { background-color: #27332f; }
+
+toolbutton > button.image-button.text-button.flat button:active, toolbutton > button.image-button.text-button.flat button:checked { background-color: #33433d; box-shadow: none; }
+
+window.background:not(.solid-csd) > notebook:not(.frame) tab { margin-bottom: 4px; }
+
+/************ Nautilus * */
+.nautilus-window .floating-bar { min-height: 32px; padding: 0; border-radius: 10px 10px 0 0; background-color: #151c19; background-clip: padding-box; }
+
+.nautilus-window .floating-bar.bottom.left { margin-right: 7px; border-top-left-radius: 0; border-bottom-left-radius: 10px; }
+
+.nautilus-window .floating-bar.bottom.right { margin-left: 7px; border-top-right-radius: 0; border-bottom-right-radius: 10px; }
+
+.nautilus-window .floating-bar button { padding: 0; }
+
+.nautilus-window .nautilus-list-view { background-color: #151c19; border-radius: 0 0 10px 10px; }
+
+.nautilus-window .nautilus-list-view treeview.view:not(:hover):not(:active):not(:selected) { background-color: transparent; border-radius: 0; }
+
+.nautilus-window.maximized .floating-bar, .nautilus-window.maximized .nautilus-list-view, .nautilus-window.tiled .floating-bar, .nautilus-window.tiled .nautilus-list-view, .nautilus-window.fullscreen .floating-bar, .nautilus-window.fullscreen .nautilus-list-view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.nautilus-window headerbar .path-bar-box { color: transparent; background: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; background: image(#bbf1dd); box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child:active { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { background-color: #7d998f; background-image: none; box-shadow: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child label, .nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { color: #131716; }
+
+.nautilus-window notebook > header.top:dir(ltr) { border-top-left-radius: 0; }
+
+.nautilus-window notebook > header.top:dir(rtl) { border-top-right-radius: 0; }
+
+.nautilus-canvas-item { border-radius: 8px; }
+
+.nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator, headerbar .nautilus-canvas-item.subtitle, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle, popover.background label.nautilus-canvas-item.separator, .nautilus-list-dim-label { color: #739588; }
+
+.nautilus-canvas-item.dim-label:backdrop, label.nautilus-canvas-item.separator:backdrop, headerbar .nautilus-canvas-item.subtitle:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:backdrop, popover.background label.nautilus-canvas-item.separator:backdrop, .nautilus-list-dim-label:backdrop { color: #475650; }
+
+.nautilus-canvas-item.dim-label:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected, label.nautilus-canvas-item.separator:selected:focus, headerbar .nautilus-canvas-item.subtitle:selected, headerbar .nautilus-canvas-item.subtitle:selected:focus, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus, popover.background label.nautilus-canvas-item.separator:selected, popover.background label.nautilus-canvas-item.separator:selected:focus, .nautilus-list-dim-label:selected, .nautilus-list-dim-label:selected:focus { color: rgba(21, 28, 25, 0.45); }
+
+.nautilus-canvas-item.dim-label:selected:backdrop, .nautilus-canvas-item.dim-label:selected:focus:backdrop, label.nautilus-canvas-item.separator:selected:backdrop, label.nautilus-canvas-item.separator:selected:focus:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:focus:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus:backdrop, popover.background label.nautilus-canvas-item.separator:selected:backdrop, popover.background label.nautilus-canvas-item.separator:selected:focus:backdrop, .nautilus-list-dim-label:selected:backdrop, .nautilus-list-dim-label:selected:focus:backdrop { color: rgba(19, 23, 22, 0.45); }
+
+.disk-space-display.unknown { background-color: rgba(187, 241, 221, 0.4); color: rgba(187, 241, 221, 0.4); }
+
+.disk-space-display.used { background-color: #bbf1dd; color: #bbf1dd; }
+
+.disk-space-display.free { background-color: rgba(187, 241, 221, 0.1); color: rgba(187, 241, 221, 0.1); }
+
+dialog > box > grid > scrolledwindow > viewport > box > list { padding: 0; background-color: transparent; border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list:backdrop { background-color: transparent; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list > row { border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list separator.horizontal { margin: 0; }
+
+/**************************************************** documents-scrolledwin (Totem, Documents, EvView) * */
+.documents-scrolledwin:backdrop, .documents-scrolledwin { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover), .documents-scrolledwin .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin .content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:hover, .documents-scrolledwin .content-view:hover { background-color: rgba(187, 241, 221, 0.075); }
+
+.documents-scrolledwin:backdrop viewport.frame, .documents-scrolledwin viewport.frame { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover), .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover) border, .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) border { border: none; }
+
+/******************* Document Viewer * */
+window.background.csd > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { background-color: transparent; border-radius: 10px; }
+
+window.background.csd > box.vertical > paned.horizontal > box.vertical > scrolledwindow > treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+window.background.csd evview.view.content-view { background-color: transparent; border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.maximized > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { border-radius: 0; }
+
+window.background.csd.maximized evview.view.content-view, window.background.csd.tiled evview.view.content-view, window.background.csd.fullscreen evview.view.content-view { border-radius: 0; }
+
+/******************* Archive Manager * */
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow { border-radius: 0 0 10px 10px; background-color: #151c19; }
+
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-radius: 0 0 0 10px; background-color: #1b2421; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/********* Geary * */
+frame.geary-conversation-frame scrolledwindow treeview.view:not(:selected) { background: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected { color: #151c19; outline-color: rgba(21, 28, 25, 0.3); background-color: #bbf1dd; background: image(#bbf1dd); box-shadow: 0 2px 4px rgba(187, 241, 221, 0.2); box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { background-color: #7d998f; background-image: none; box-shadow: none; box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop label, frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { color: #131716; }
+
+.geary_email { padding-bottom: 6px; border-radius: 8px; }
+
+.geary_email .geary-message { border-radius: 8px; }
+
+.geary-attachment-pane > separator.horizontal { margin: 0; }
+
+.geary-attachment-pane flowboxchild { border-radius: 8px; }
+
+.geary-attachment-pane > actionbar { background-color: #151c19; }
+
+.geary-attachment-pane > actionbar:backdrop { background-color: #131716; }
+
+/********* Gedit * */
+window.org-gnome-gedit stack scrolledwindow viewport.frame list.gedit-document-panel { background-color: transparent; }
+
+window.org-gnome-gedit .gedit-search-entry-occurrences-tag { border: none; box-shadow: none; margin: 2px; padding: 2px; }
+
+/******************** Gnome Calculator * */
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list { padding: 0; border-radius: 0; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry { margin: 0; border-radius: 0; background-color: #1b2421; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry:backdrop { background-color: #181e1c; }
+
+grid > viewport > box > scrolledwindow.display-scrolled > .sourceview.view > text, grid > viewport > box > scrolledwindow.display-scrolled > iconview.sourceview > text { border-radius: 10px 10px 0 0; }
+
+grid > viewport > box box > textview.view.info-view > text { border-radius: 0 0 10px 10px; }
+
+/************************ Gnome Control Center * */
+window.background.csd > leaflet > stack.background, window.background.csd > hdyleaflet > stack.background, window.background.csd > box.horizontal > stack.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-left-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+window.background.csd.maximized > leaflet > stack.background, window.background.csd.maximized > hdyleaflet > stack.background, window.background.csd.maximized > box.horizontal > stack.background, window.background.csd.maximized > leaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.tiled > leaflet > stack.background, window.background.csd.tiled > hdyleaflet > stack.background, window.background.csd.tiled > box.horizontal > stack.background, window.background.csd.tiled > leaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > leaflet > stack.background, window.background.csd.fullscreen > hdyleaflet > stack.background, window.background.csd.fullscreen > box.horizontal > stack.background, window.background.csd.fullscreen > leaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+window.background.csd > leaflet > stack.background > widget > box > box > scrolledwindow > viewport.frame > box.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+/************** Gnome Maps * */
+popover.maps-popover > grid > button.radio.layer-radio-button { border-radius: 4px; color: transparent; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:active { color: #bbf1dd; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:checked { color: #bbf1dd; }
+
+/*************** Gnome Music * */
+window.background.csd > box.vertical > overlay > stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > overlay > stack.background, window.background.csd.tiled > box.vertical > overlay > stack.background, window.background.csd.fullscreen > box.vertical > overlay > stack.background { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/****************** Gnome Software * */
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal { border-radius: 8px; background-color: #151c19; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal:backdrop { background-color: #131716; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal list.app-updates-section { border: none; border-radius: 10px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software { padding-top: 2px; padding-bottom: 2px; margin: 4px 2px; min-height: 24px; min-width: 54px; border-radius: 8px; -gtk-outline-radius: 8px; background-color: transparent; color: #9ac6b6; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(ltr) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(rtl) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(ltr) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(rtl) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:hover { color: #bbf1dd; background-color: rgba(187, 241, 221, 0.05); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:checked { color: #bbf1dd; outline-color: rgba(187, 241, 221, 0.3); background-image: none; background-color: #33433d; box-shadow: 0 2px 4px rgba(21, 28, 25, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop { color: #6e837b; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:hover { background-color: transparent; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { background-image: none; background-color: #252d2a; box-shadow: 0 1px 2px rgba(19, 23, 22, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked label, window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { color: #6e837b; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal button:checked + button { border-image: none; }
+
+window.background.csd button.text-button.content-rating { color: #151c19; }
+
+window.background.csd button.text-button.content-rating:backdrop { color: #131716; }
+
+/****************** Gnome Terminal * */
+terminal-window.background.csd { border-radius: 0; }
+
+terminal-window decoration { background-color: #1b2421; border-radius: 10px 10px 0 0; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(187, 241, 221, 0.1), 0 0 0 1px #1b2421; }
+
+terminal-window decoration:backdrop { background-color: #181e1c; box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(110, 131, 123, 0.125), 0 0 0 1px #181e1c; }
+
+terminal-window .terminal-screen { background-color: #1b2421; color: #bbf1dd; }
+
+terminal-window .terminal-screen:backdrop { background-color: #181e1c; color: #6e837b; }
+
+/*************** Gnome Todo * */
+window.background.csd.org-gnome-Todo > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Todo.maximized > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.maximized stack.background, window.background.csd.org-gnome-Todo.tiled > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.tiled stack.background, window.background.csd.org-gnome-Todo.fullscreen > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.fullscreen stack.background { border-radius: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row { box-shadow: none; padding: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row entry, window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row button { margin: 0; border-radius: 2.5px; }
+
+/**************** Gnome Tweaks * */
+hdyleaflet list.tweak-categories, leaflet list.tweak-categories { background-color: transparent; }
+
+hdyleaflet list.tweak-categories > separator, leaflet list.tweak-categories > separator { background-color: transparent; min-height: 0; }
+
+row#AutostartTitle.tweak { padding: 8px 8px 0 8px; }
+
+.tweak-group-startup { background-color: #151c19; }
+
+.tweak-group-startup:backdrop { background-color: #131716; }
+
+/***************** Gnome Weather * */
+#weather-page, #weekly-forecast-frame { border-bottom-right-radius: 10px; }
+
+#weather-page-content-view { border-bottom-right-radius: 10px; border-bottom-left-radius: 10px; }
+
+/************ Ubiquity * */
+#live_installer #stepPartAuto #partition_container #resizewidget separator { background-image: none; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > * { background-color: transparent; border-radius: 0; border-color: #27332f; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > *:backdrop { border-color: #252e2b; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box { background-color: #151c19; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box:backdrop { background-color: #131716; }
+
+/******************** Zorin Appearance * */
+stacksidebar.sidebar > scrolledwindow > viewport.frame > list { border-radius: 0; }
+
+/********** Thunar * */
+.thunar .sidebar.frame { border: none; }
+
+.thunar .sidebar .view, .thunar .sidebar iconview { background-color: #1b2421; border: none; }
+
+.thunar .sidebar .view:selected, .thunar .sidebar iconview:selected { background-color: #33433d; color: #bbf1dd; }
+
+.thunar .sidebar .view:backdrop, .thunar .sidebar iconview:backdrop { background-color: #181e1c; }
+
+.thunar .sidebar .view:backdrop:selected, .thunar .sidebar iconview:backdrop:selected { background-color: #252d2a; color: #6e837b; }
+
+.thunar .standard-view > .view, .thunar .standard-view > iconview { border-radius: 0; }
+
+/*********************** LightDM Gtk Greeter * */
+.lightdm-gtk-greeter #panel_window { border-radius: 0; border: none; background-color: #1b2421; }
+
+.lightdm-gtk-greeter #panel_window menubar { font-weight: bold; }
+
+.lightdm-gtk-greeter #panel_window menubar menu menuitem { font-weight: normal; }
+
+.lightdm-gtk-greeter #buttonbox_frame { padding-top: 20px; }
+
+.lightdm-gtk-greeter #login_window, .lightdm-gtk-greeter #shutdown_dialog, .lightdm-gtk-greeter #restart_dialog { border-style: none; border-radius: 10px; background-color: #1b2421; color: #bbf1dd; box-shadow: none; }
+
+.lightdm-gtk-greeter #login_window menu { border-radius: 0; }
+
+/******** XFCE * */
+.xfce4-panel.background { background-color: #151c19; }
+
+.xfce4-panel.background button { border-radius: 0; margin: 0; font-weight: bold; }
+
+.xfce4-panel.background button menuitem { font-weight: normal; }
+
+.xfce4-panel.background button:hover { background-color: #27332f; }
+
+.xfce4-panel.background button:active, .xfce4-panel.background button:checked { color: #bbf1dd; background-color: #33433d; background-image: none; }
+
+.xfce4-panel.background button.flat image, .xfce4-panel.background button.image-button image { -gtk-icon-transform: scale(1); transition: none; }
+
+.xfce4-panel.background button.flat:active image, .xfce4-panel.background button.image-button:active image { -gtk-icon-transform: scale(1); }
+
+.tasklist button.toggle { background-color: transparent; border-top-width: 0; border-bottom-width: 0; }
+
+.tasklist button.toggle:checked { background: none; box-shadow: inset 0 -3px #bbf1dd; }
+
+wnck-pager { background-color: #212c28; }
+
+wnck-pager:hover { background-color: #2e3c36; }
+
+wnck-pager:selected { background-color: #364740; }
+
+XfdesktopIconView.view { background: transparent; color: white; }
+
+XfdesktopIconView.view:active { background: #bbf1dd; color: #151c19; text-shadow: none; }
+
+XfdesktopIconView.view .label { text-shadow: 1px 1px 2px black; }
+
+#XfceNotifyWindow { background-color: #151c19; border: none; box-shadow: inset 0 0 0 1px rgba(39, 51, 47, 0.75); border-radius: 10px; }
+
+#XfceNotifyWindow label#summary { font-weight: bold; }
+
+#XfceNotifyWindow progressbar progress { animation: none; background-image: none; background: image(#bbf1dd); }
+
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin { border-radius: 10px; }
+
+/* GTK NAMED COLORS ---------------- use responsibly! */
+/*
+widget text/foreground color */
+@define-color theme_fg_color #bbf1dd;
+/*
+text color for entries, views and content in general */
+@define-color theme_text_color #bbf1dd;
+/*
+widget base background color */
+@define-color theme_bg_color #1b2421;
+/*
+text widgets and the like base background color */
+@define-color theme_base_color #151c19;
+/*
+base background color of selections */
+@define-color theme_selected_bg_color #abdcca;
+/* Tinting in dark variant to avoid a white selection on white page background when highlighting text in Evince when using Grey-Dark theme */
+/*
+text/foreground color of selections */
+@define-color theme_selected_fg_color #151c19;
+/*
+base background color of insensitive widgets */
+@define-color insensitive_bg_color #1b2421;
+/*
+text foreground color of insensitive widgets */
+@define-color insensitive_fg_color #6b8a7f;
+/*
+insensitive text widgets and the like base background color */
+@define-color insensitive_base_color #151c19;
+/*
+widget text/foreground color on backdrop windows */
+@define-color theme_unfocused_fg_color #6e837b;
+/*
+text color for entries, views and content in general on backdrop windows */
+@define-color theme_unfocused_text_color #bbf1dd;
+/*
+widget base background color on backdrop windows */
+@define-color theme_unfocused_bg_color #181e1c;
+/*
+text widgets and the like base background color on backdrop windows */
+@define-color theme_unfocused_base_color #131716;
+/*
+base background color of selections on backdrop windows */
+@define-color theme_unfocused_selected_bg_color #bbf1dd;
+/*
+text/foreground color of selections on backdrop windows */
+@define-color theme_unfocused_selected_fg_color #151c19;
+/*
+insensitive color on backdrop windows*/
+@define-color unfocused_insensitive_color #3a4944;
+/*
+widgets main borders color */
+@define-color borders #27332f;
+/*
+widgets main borders color on backdrop windows */
+@define-color unfocused_borders #252e2b;
+/*
+these are pretty self explicative */
+@define-color placeholder_text_color #68867b;
+@define-color warning_color #faa483;
+@define-color error_color #fb7c7c;
+@define-color success_color #6ee1b6;
+/*
+these colors are exported for the window manager and shouldn't be used in applications,
+read if you used those and something break with a version upgrade you're on your own... */
+@define-color wm_title shade(#bbf1dd, 1.8);
+@define-color wm_unfocused_title #6e837b;
+@define-color wm_highlight transparent;
+@define-color wm_borders_edge rgba(187, 241, 221, 0.07);
+@define-color wm_bg_a shade(#1b2421, 1.2);
+@define-color wm_bg_b #1b2421;
+@define-color wm_shadow alpha(black, 0.35);
+@define-color wm_border alpha(black, 0.18);
+@define-color wm_button_hover_color_a shade(#1b2421, 1.3);
+@define-color wm_button_hover_color_b #1b2421;
+@define-color wm_button_active_color_a shade(#1b2421, 0.85);
+@define-color wm_button_active_color_b shade(#1b2421, 0.89);
+@define-color wm_button_active_color_c shade(#1b2421, 0.9);
+/* content view background such as thumbnails view in Photos or Boxes */
+@define-color content_view_bg #151c19;
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #151c19;

--- a/ZorinGrey-Dark/gtk-3.0/gtk-dark.css
+++ b/ZorinGrey-Dark/gtk-3.0/gtk-dark.css
@@ -1,0 +1,2308 @@
+/*************************** Check and Radio buttons * */
+@keyframes ripple_effect { to { background-size: 1000% 1000%; } }
+
+* { padding: 0; -GtkToolButton-icon-spacing: 4; -GtkTextView-error-underline-color: #fb7c7c; -GtkScrolledWindow-scrollbar-spacing: 0; -GtkToolItemGroup-expander-size: 11; -GtkWidget-text-handle-width: 20; -GtkWidget-text-handle-height: 24; -GtkDialog-button-spacing: 4; -GtkDialog-action-area-border: 0; outline-color: alpha(currentColor,0.3); outline-style: dashed; outline-offset: -3px; outline-width: 1px; -gtk-outline-radius: 8px; -gtk-secondary-caret-color: #ffffff; }
+
+/*************** Base States * */
+.background { color: #ffffff; background-color: #202020; }
+
+.background.csd { border-radius: 0 0 10px 10px; }
+
+.background.maximized, .background.solid-csd, .background.fullscreen, .background.tiled, .background.tiled-top, .background.tiled-right, .background.tiled-bottom, .background.tiled-left { border-radius: 0; }
+
+.background:backdrop { color: #8d8d8d; background-color: #1b1b1b; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* These wildcard seems unavoidable, need to investigate. Wildcards are bad and troublesome, use them with care, or better, just don't. Everytime a wildcard is used a kitten dies, painfully. */
+*:disabled { -gtk-icon-effect: dim; }
+
+.gtkstyle-fallback { color: #ffffff; background-color: #202020; }
+
+.gtkstyle-fallback:hover { color: #ffffff; background-color: #3a3a3a; }
+
+.gtkstyle-fallback:active { color: #ffffff; background-color: #070707; }
+
+.gtkstyle-fallback:disabled { color: #909090; background-color: #202020; }
+
+.gtkstyle-fallback:selected { color: #191919; background-color: #ffffff; }
+
+.view, iconview, .view text, iconview text, textview text { color: #ffffff; background-color: #191919; border-radius: 10px; }
+
+.view:disabled, iconview:disabled, .view text:disabled, iconview text:disabled, textview text:disabled { color: #909090; background-color: #202020; }
+
+.view:backdrop, iconview:backdrop, .view text:backdrop, iconview text:backdrop, textview text:backdrop { color: #8d8d8d; background-color: #151515; }
+
+.view:backdrop:disabled, iconview:backdrop:disabled, .view text:backdrop:disabled, iconview text:backdrop:disabled, textview text:backdrop:disabled { color: #414141; background-color: #1b1b1b; }
+
+.view:selected:focus, iconview:selected:focus, .view:selected, iconview:selected, .view text:selected:focus, iconview text:selected:focus, textview text:selected:focus, .view text:selected, iconview text:selected, textview text:selected { border-radius: 8px; }
+
+.view.sourceview, iconview.sourceview, .view.sourceview > *, iconview.sourceview > *, textview.sourceview, textview.sourceview > * { border-radius: 0; }
+
+textview border { background-color: #1d1d1d; }
+
+iconview { border-radius: 0 0 10px 10px; }
+
+iconview, iconview:hover, iconview:selected { border-radius: 8px; }
+
+.rubberband, rubberband, XfdesktopIconView.view .rubberband, .content-view rubberband, .content-view .rubberband, treeview.view rubberband, flowbox rubberband { border: 1px solid #e6e6e6; background-color: rgba(230, 230, 230, 0.2); border-radius: 0; }
+
+flowbox flowboxchild { padding: 3px; }
+
+flowbox flowboxchild:selected { outline-offset: -2px; }
+
+.content-view .tile { margin: 2px; background-color: transparent; border-radius: 0; padding: 0; }
+
+label { caret-color: currentColor; }
+
+label:disabled { color: #909090; }
+
+button label:disabled { color: inherit; }
+
+label:disabled:backdrop { color: #414141; }
+
+button label:disabled:backdrop { color: inherit; }
+
+label.error { color: #fb7c7c; }
+
+label.error:disabled { color: rgba(251, 124, 124, 0.5); }
+
+label.error:disabled:backdrop { color: rgba(251, 124, 124, 0.4); }
+
+.accent { color: #ffffff; }
+
+.dim-label, .titlebar:not(headerbar) .subtitle, headerbar .subtitle, label.separator { opacity: 0.55; text-shadow: none; }
+
+assistant .sidebar { background-color: #202020; border-top: 1px solid #313131; }
+
+assistant .sidebar:backdrop { background-color: #1b1b1b; border-color: #2d2d2d; }
+
+assistant.csd .sidebar { border-top-style: none; }
+
+assistant .sidebar label { padding: 6px 12px; }
+
+assistant .sidebar label.highlight { background-color: #4d4d4d; }
+
+.osd .scale-popup, .app-notification, .app-notification.frame, .osd { border: none; background-color: #191919; background-clip: padding-box; border-radius: 8px; box-shadow: inset 0 0 0 1px rgba(49, 49, 49, 0.75); }
+
+.osd .scale-popup:backdrop, .app-notification:backdrop, .osd:backdrop { background-color: #151515; box-shadow: inset 0 0 0 1px rgba(45, 45, 45, 0.75); }
+
+.osd .scale-popup:disabled, .app-notification:disabled, .osd:disabled { box-shadow: none; }
+
+/********************* Spinner Animation * */
+@keyframes spin { to { -gtk-icon-transform: rotate(1turn); } }
+
+spinner { background: none; opacity: 0; -gtk-icon-source: -gtk-icontheme("process-working-symbolic"); }
+
+spinner:backdrop { color: #8d8d8d; }
+
+spinner:checked { opacity: 1; animation: spin 1s linear infinite; }
+
+spinner:checked:disabled { opacity: 0.5; }
+
+/********************** General Typography * */
+.large-title { font-weight: 300; font-size: 24pt; }
+
+.title-1, .h1 { font-weight: 800; font-size: 20pt; }
+
+.title-2, .h2 { font-weight: 800; font-size: 15pt; }
+
+.title-3, .h3 { font-weight: 700; font-size: 15pt; }
+
+.title-4, .h4 { font-weight: 700; font-size: 13pt; }
+
+.heading { font-weight: 700; font-size: 11pt; }
+
+.body { font-weight: 400; font-size: 11pt; }
+
+.caption-heading { font-weight: 700; font-size: 9pt; }
+
+.caption { font-weight: 400; font-size: 9pt; }
+
+.category-label { color: rgba(255, 255, 255, 0.8); font-weight: 700; }
+
+/**************** Text Entries * */
+spinbutton:not(.vertical), entry { min-height: 32px; padding-left: 8px; padding-right: 8px; margin: 1px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); color: #ffffff; background-color: #191919; box-shadow: inset 0 0 0 1px #313131; }
+
+spinbutton:not(.vertical) image.left, entry image.left { margin-right: 6px; }
+
+spinbutton:not(.vertical) image.right, entry image.right { margin-left: 6px; }
+
+spinbutton.flat:not(.vertical), entry.flat:focus, entry.flat:backdrop, entry.flat:disabled, entry.flat { min-height: 0; padding: 2px; background-color: transparent; border-color: transparent; border-radius: 0; }
+
+spinbutton:focus:not(.vertical), entry:focus { color: #ffffff; background-color: #191919; box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2), inset 0 0 0 2px #ffffff; }
+
+spinbutton:disabled:not(.vertical), entry:disabled { color: #909090; background-color: transparent; box-shadow: none; }
+
+spinbutton:backdrop:not(.vertical), entry:backdrop { color: #8d8d8d; background-color: #151515; box-shadow: inset 0 0 0 1px #2d2d2d; border-color: #1b1b1b; transition: 150ms ease-out; }
+
+spinbutton:backdrop:disabled:not(.vertical), entry:backdrop:disabled { color: #414141; background-color: transparent; box-shadow: none; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; border-color: transparent; }
+
+spinbutton.error:focus:not(.vertical), entry.error:focus { color: #fb7c7c; background-color: #191919; box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2), inset 0 0 0 2px #ffffff; }
+
+spinbutton.error:not(.vertical) selection, entry.error selection { color: #191919; background-color: #fb7c7c; }
+
+spinbutton.warning:not(.vertical), entry.warning { color: #faa483; border-color: transparent; }
+
+spinbutton.warning:focus:not(.vertical), entry.warning:focus { color: #faa483; background-color: #191919; box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2), inset 0 0 0 2px #ffffff; }
+
+spinbutton.warning:not(.vertical) selection, entry.warning selection { color: #191919; background-color: #faa483; }
+
+spinbutton:not(.vertical) image, entry image { color: #d1d1d1; }
+
+spinbutton:not(.vertical) image:hover, entry image:hover { color: #ffffff; }
+
+spinbutton:not(.vertical) image:active, entry image:active { color: #ffffff; }
+
+spinbutton:not(.vertical) image:backdrop, entry image:backdrop { color: #757575; }
+
+spinbutton:drop(active):not(.vertical), entry:drop(active):focus, entry:drop(active) { color: #4cd9a4; border-color: transparent; background-color: #29453a; }
+
+spinbutton:not(.vertical) progress, entry progress { margin: 1px -6px; background-color: transparent; background-image: none; border-radius: 3px; border-width: 0 0 3px; border-color: #ffffff; border-style: solid; box-shadow: none; }
+
+spinbutton:not(.vertical) progress:backdrop, entry progress:backdrop { background-color: transparent; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; }
+
+treeview entry:focus:dir(rtl), treeview entry:focus:dir(ltr) { background-color: #191919; transition-property: color, background; }
+
+treeview entry.flat, treeview entry { border: none; border-radius: 0; background-image: none; background-color: #191919; }
+
+.entry-tag { padding: 5px; margin-top: 4px; margin-bottom: 4px; border-style: none; color: #191919; background-color: #ffffff; }
+
+:dir(ltr) .entry-tag { margin-left: 8px; margin-right: -5px; }
+
+:dir(rtl) .entry-tag { margin-left: -5px; margin-right: 8px; }
+
+.entry-tag:hover { background-color: white; }
+
+:backdrop .entry-tag { color: #151515; background-color: #ffffff; }
+
+.entry-tag.button { background-color: transparent; color: rgba(25, 25, 25, 0.7); }
+
+:not(:backdrop) .entry-tag.button:hover { border: 1px solid #ffffff; color: #191919; }
+
+:not(:backdrop) .entry-tag.button:active { background-color: #ffffff; color: #191919; }
+
+/*********** Buttons * */
+@keyframes needs_attention { from { background-image: -gtk-gradient(radial, center center, 0, center center, 0.01, to(#ffffff), to(transparent)); }
+  to { background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#ffffff), to(transparent)); } }
+
+button.titlebutton, notebook > header > tabs > arrow, button { min-height: 24px; min-width: 16px; margin: 1px; padding: 4px 9px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #313131; background-image: none; }
+
+button.titlebutton, button.sidebar-button, notebook > header > tabs > arrow, notebook > header > tabs > arrow.flat, button.flat { background-color: transparent; background-image: none; background-image: none; transition: none; }
+
+button.titlebutton:hover, button.sidebar-button:hover, notebook > header > tabs > arrow:hover, button.flat:hover { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-duration: 500ms; }
+
+button.titlebutton:hover:active, button.sidebar-button:hover:active, notebook > header > tabs > arrow:hover:active, button.flat:hover:active { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header > tabs > arrow:hover, button:hover { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #414141; background-image: none; }
+
+notebook > header > tabs > arrow:active, button:active { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #4d4d4d; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #636363 10%, transparent 0%); background-size: 0% 0%; }
+
+notebook > header > tabs > arrow:checked, button:checked { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; background: image(#ffffff); box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); }
+
+notebook > header > tabs > arrow:checked:active, button:checked:active { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); }
+
+notebook > header > tabs > arrow:backdrop, button:backdrop.flat, button:backdrop { background-color: #242424; background-image: none; transition: 150ms ease-out; -gtk-icon-effect: none; }
+
+notebook > header > tabs > arrow:backdrop label, notebook > header > tabs > arrow:backdrop, button:backdrop.flat label, button:backdrop.flat, button:backdrop label, button:backdrop { color: #8d8d8d; }
+
+notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active, button:backdrop:active { background-color: #323232; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:active label, notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active label, button:backdrop.flat:active, button:backdrop:active label, button:backdrop:active { color: #8d8d8d; }
+
+notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked, button:backdrop:checked { background-color: #a4a4a4; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:checked label, notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked label, button:backdrop.flat:checked, button:backdrop:checked label, button:backdrop:checked { color: #151515; }
+
+notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled, button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled label, notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled label, button:backdrop.flat:disabled, button:backdrop:disabled label, button:backdrop:disabled { color: #414141; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active, button:backdrop:disabled:checked { background-color: #2b2b2b; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active label, notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked label, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active label, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked label, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active label, button:backdrop:disabled:active, button:backdrop:disabled:checked label, button:backdrop:disabled:checked { color: #414141; }
+
+button.titlebutton:backdrop, button.sidebar-button:backdrop, notebook > header > tabs > arrow:backdrop, button.titlebutton:disabled, button.sidebar-button:disabled, notebook > header > tabs > arrow:disabled, button.flat:backdrop, button.flat:disabled, button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+notebook > header > tabs > arrow:disabled, button:disabled { color: #909090; background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:disabled:active, notebook > header > tabs > arrow:disabled:checked, button:disabled:active, button:disabled:checked { color: #909090; background-color: #262626; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow.image-button, button.image-button { min-width: 24px; padding-left: 5px; padding-right: 5px; }
+
+notebook > header > tabs > arrow.flat image, notebook > header > tabs > arrow.image-button image, button.flat image, button.image-button image { -gtk-icon-transform: scale(1); transition: -gtk-icon-transform 150ms ease; }
+
+notebook > header > tabs > arrow.flat:active image, notebook > header > tabs > arrow.image-button:active image, button.flat:active image, button.image-button:active image { -gtk-icon-transform: scale(0.85); }
+
+notebook > header > tabs > arrow.text-button, button.text-button { padding-left: 16px; padding-right: 16px; }
+
+notebook > header > tabs > arrow.text-button.image-button, button.text-button.image-button { padding-left: 8px; padding-right: 8px; }
+
+notebook > header > tabs > arrow.text-button.image-button label, button.text-button.image-button label { padding-left: 8px; padding-right: 8px; }
+
+combobox:drop(active) button.combo, notebook > header > tabs > arrow:drop(active), button:drop(active) { color: #191919; border-color: transparent; background-color: #4cd9a4; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled), row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled) { color: #191919; border-color: transparent; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled):backdrop, row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled):backdrop { color: #151515; }
+
+button.osd { min-width: 26px; min-height: 32px; border-radius: 8px; border: none; }
+
+button.osd.image-button { min-width: 34px; }
+
+button.suggested-action { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; background: image(#ffffff); font-weight: 700; }
+
+button.suggested-action.flat { background-color: transparent; background-image: none; background-image: none; color: #ffffff; }
+
+button.suggested-action:hover { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background: image(white); background-color: white; }
+
+button.suggested-action:active, button.suggested-action:checked { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-image: none; background-color: #e6e6e6; box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); }
+
+button.suggested-action:backdrop, button.suggested-action.flat:backdrop { background-color: white; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop label, button.suggested-action:backdrop, button.suggested-action.flat:backdrop label, button.suggested-action.flat:backdrop { color: #151515; }
+
+button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked { background-color: #e6e6e6; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop:active label, button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked label, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active label, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked label, button.suggested-action.flat:backdrop:checked { color: #151515; }
+
+button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.suggested-action:backdrop:disabled label, button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled label, button.suggested-action.flat:backdrop:disabled { color: #414141; }
+
+button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked { background-color: #f3f3f3; box-shadow: none; background-image: none; }
+
+button.suggested-action:backdrop:disabled:active label, button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked label, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active label, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked label, button.suggested-action.flat:backdrop:disabled:checked { color: #414141; }
+
+button.suggested-action.flat:backdrop, button.suggested-action.flat:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(255, 255, 255, 0.8); }
+
+button.suggested-action:disabled { color: #909090; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.suggested-action:disabled:active, button.suggested-action:disabled:checked { color: #909090; background-color: #f9f9f9; box-shadow: none; background-image: none; }
+
+button.destructive-action { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #fb7c7c; background: image(#fb7c7c); font-weight: 700; }
+
+button.destructive-action.flat { background-color: transparent; background-image: none; background-image: none; color: #fb7c7c; }
+
+button.destructive-action:hover { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background: image(#ff929b); background-color: #ff929b; }
+
+button.destructive-action:active, button.destructive-action:checked { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-image: none; background-color: #fa4a4a; box-shadow: 0 2px 4px rgba(251, 124, 124, 0.2); }
+
+button.destructive-action:backdrop, button.destructive-action.flat:backdrop { background-color: #f97e7e; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop label, button.destructive-action:backdrop, button.destructive-action.flat:backdrop label, button.destructive-action.flat:backdrop { color: #151515; }
+
+button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked { background-color: #f74d4d; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop:active label, button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked label, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active label, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked label, button.destructive-action.flat:backdrop:checked { color: #151515; }
+
+button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.destructive-action:backdrop:disabled label, button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled label, button.destructive-action.flat:backdrop:disabled { color: #414141; }
+
+button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked { background-color: #ee7979; box-shadow: none; background-image: none; }
+
+button.destructive-action:backdrop:disabled:active label, button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked label, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active label, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked label, button.destructive-action.flat:backdrop:disabled:checked { color: #414141; }
+
+button.destructive-action.flat:backdrop, button.destructive-action.flat:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(251, 124, 124, 0.8); }
+
+button.destructive-action:disabled { color: #909090; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.destructive-action:disabled:active, button.destructive-action:disabled:checked { color: #909090; background-color: #f67979; box-shadow: none; background-image: none; }
+
+.stack-switcher > button, stackswitcher > button { padding-top: 2px; padding-bottom: 2px; margin: 2px 1px; background-color: transparent; color: #d1d1d1; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; outline-offset: -3px; }
+
+.stack-switcher > button:first-child:dir(ltr), stackswitcher > button:first-child:dir(ltr) { margin-left: 2px; }
+
+.stack-switcher > button:first-child:dir(rtl), stackswitcher > button:first-child:dir(rtl) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(ltr), stackswitcher > button:last-child:dir(ltr) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(rtl), stackswitcher > button:last-child:dir(rtl) { margin-left: 2px; }
+
+.stack-switcher > button:hover, stackswitcher > button:hover { color: #ffffff; background-color: rgba(255, 255, 255, 0.05); }
+
+.stack-switcher > button:checked, stackswitcher > button:checked { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-image: none; background-color: #414141; box-shadow: 0 2px 4px rgba(25, 25, 25, 0.075); }
+
+.stack-switcher > button:backdrop, stackswitcher > button:backdrop { color: #8d8d8d; }
+
+.stack-switcher > button:backdrop:hover, stackswitcher > button:backdrop:hover { background-color: transparent; }
+
+.stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked { background-image: none; background-color: #2c2c2c; box-shadow: 0 1px 2px rgba(21, 21, 21, 0.075); }
+
+.stack-switcher > button:backdrop:checked label, .stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked label, stackswitcher > button:backdrop:checked { color: #8d8d8d; }
+
+.stack-switcher > button > label, stackswitcher > button > label { padding-left: 6px; padding-right: 6px; }
+
+.stack-switcher > button > image, stackswitcher > button > image { padding-left: 6px; padding-right: 6px; padding-top: 3px; padding-bottom: 3px; }
+
+.stack-switcher > button.text-button, stackswitcher > button.text-button { padding-left: 10px; padding-right: 10px; }
+
+.stack-switcher > button.image-button, stackswitcher > button.image-button { padding-left: 2px; padding-right: 2px; }
+
+.stack-switcher > button.needs-attention:active > label, .stack-switcher > button.needs-attention:active > image, .stack-switcher > button.needs-attention:checked > label, .stack-switcher > button.needs-attention:checked > image, stackswitcher > button.needs-attention:active > label, stackswitcher > button.needs-attention:active > image, stackswitcher > button.needs-attention:checked > label, stackswitcher > button.needs-attention:checked > image { animation: none; background-image: none; }
+
+button.font separator, button.file separator { background-color: transparent; }
+
+button.font > box > box > label { font-weight: bold; }
+
+.primary-toolbar button { -gtk-icon-shadow: none; }
+
+button.circular { border-radius: 9999px; -gtk-outline-radius: 9999px; }
+
+button.circular label { padding: 0; }
+
+stacksidebar row.needs-attention > label, .stack-switcher > button.needs-attention > label, .stack-switcher > button.needs-attention > image, stackswitcher > button.needs-attention > label, stackswitcher > button.needs-attention > image { animation: needs_attention 150ms ease-in; background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#ffffff), to(transparent)), -gtk-gradient(radial, center center, 0, center center, 0.45, to(rgba(0, 0, 0, 0.899608)), to(transparent)); background-size: 6px 6px, 6px 6px; background-repeat: no-repeat; background-position: right 3px, right 2px; }
+
+stacksidebar row.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > image:backdrop, stackswitcher > button.needs-attention > label:backdrop, stackswitcher > button.needs-attention > image:backdrop { background-size: 6px 6px, 0 0; }
+
+stacksidebar row.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), stackswitcher > button.needs-attention > label:dir(rtl), stackswitcher > button.needs-attention > image:dir(rtl) { background-position: left 3px, left 2px; }
+
+.inline-toolbar toolbutton > button { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #313131; background-image: none; }
+
+.inline-toolbar toolbutton > button:hover { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #414141; background-image: none; }
+
+.inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #4d4d4d; }
+
+.inline-toolbar toolbutton > button:disabled { color: #909090; background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:disabled:active, .inline-toolbar toolbutton > button:disabled:checked { color: #909090; background-color: #262626; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop { background-color: #242424; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop label, .inline-toolbar toolbutton > button:backdrop { color: #8d8d8d; }
+
+.inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked { background-color: #323232; background-image: none; box-shadow: none; }
+
+.inline-toolbar toolbutton > button:backdrop:active label, .inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked label, .inline-toolbar toolbutton > button:backdrop:checked { color: #8d8d8d; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled label, .inline-toolbar toolbutton > button:backdrop:disabled { color: #414141; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked { background-color: #2b2b2b; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active label, .inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked label, .inline-toolbar toolbutton > button:backdrop:disabled:checked { color: #414141; }
+
+.linked:not(.vertical) > combobox > box > button.combo, filechooser .path-bar.linked > button, .linked:not(.vertical) > spinbutton:not(.vertical), .linked:not(.vertical) > entry, .inline-toolbar button, .linked > button, toolbar.inline-toolbar toolbutton > button.flat { border-right-style: none; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked:not(.vertical) > combobox:first-child > box > button.combo, combobox.linked button:nth-child(2):dir(rtl), filechooser .path-bar.linked > button:dir(rtl):last-child, filechooser .path-bar.linked > button:dir(ltr):first-child, .linked:not(.vertical) > spinbutton:first-child:not(.vertical), .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat { border-top-left-radius: 8px; border-bottom-left-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-bottom-left-radius: 8px; }
+
+.linked:not(.vertical) > combobox:last-child > box > button.combo, combobox.linked button:nth-child(2):dir(ltr), filechooser .path-bar.linked > button:dir(rtl):first-child, filechooser .path-bar.linked > button:dir(ltr):last-child, .linked:not(.vertical) > spinbutton:last-child:not(.vertical), .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat { border-right-style: solid; border-top-right-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-top-right-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked:not(.vertical) > combobox:only-child > box > button.combo, filechooser .path-bar.linked > button:only-child, .linked:not(.vertical) > spinbutton:only-child:not(.vertical), .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.linked.vertical > combobox > box > button.combo, .linked.vertical > spinbutton:not(.vertical), .linked.vertical > entry, .linked.vertical > button { border-style: solid solid none solid; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked.vertical > combobox:first-child > box > button.combo, .linked.vertical > spinbutton:first-child:not(.vertical), .linked.vertical > entry:first-child, .linked.vertical > button:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-top-right-radius: 8px; }
+
+.linked.vertical > combobox:last-child > box > button.combo, .linked.vertical > spinbutton:last-child:not(.vertical), .linked.vertical > entry:last-child, .linked.vertical > button:last-child { border-bottom-style: solid; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-bottom-left-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked.vertical > combobox:only-child > box > button.combo, .linked.vertical > spinbutton:only-child:not(.vertical), .linked.vertical > entry:only-child, .linked.vertical > button:only-child { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.scale-popup button:backdrop:hover, .scale-popup button:backdrop:disabled, .scale-popup button:backdrop, .scale-popup button:hover, calendar.button, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, button:link, button:visited, modelbutton.flat:backdrop, modelbutton.flat:backdrop:hover, modelbutton.flat, .menuitem.button.flat { background-color: transparent; background-image: none; border-color: transparent; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* menu buttons */
+modelbutton.flat, .menuitem.button.flat { min-height: 26px; padding-left: 5px; padding-right: 5px; border-radius: 8px; outline-offset: -2px; }
+
+modelbutton.flat:hover, .menuitem.button.flat:hover { background-color: #313131; }
+
+modelbutton.flat arrow { background: none; }
+
+modelbutton.flat arrow:hover { background: none; }
+
+modelbutton.flat arrow.left { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+modelbutton.flat arrow.right { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+button.color { padding: 4px; box-shadow: none; }
+
+button.color colorswatch:only-child, button.color colorswatch:only-child overlay { border-radius: 0; }
+
+/********* Links * */
+button:link > label, button:visited > label, button:link, button:visited, *:link { color: white; }
+
+button:link > label:visited, button:visited > label:visited, button:visited, *:link:visited { color: white; }
+
+*:selected button:link > label:visited, *:selected button:visited > label:visited, *:selected button:visited, *:selected *:link:visited { color: #757575; }
+
+button:link > label:hover, button:visited > label:hover, button:hover:link, button:hover:visited, *:link:hover { color: white; }
+
+*:selected button:link > label:hover, *:selected button:visited > label:hover, *:selected button:hover:link, *:selected button:hover:visited, *:selected *:link:hover { color: #303030; }
+
+button:link > label:active, button:visited > label:active, button:active:link, button:active:visited, *:link:active { color: white; }
+
+*:selected button:link > label:active, *:selected button:visited > label:active, *:selected button:active:link, *:selected button:active:visited, *:selected *:link:active { color: #474747; }
+
+button:link > label:disabled, button:visited > label:disabled, button:disabled:link, button:disabled:visited, *:link:disabled, *:link:disabled:backdrop { color: rgba(255, 255, 255, 0.8); }
+
+button:link > label:backdrop, button:visited > label:backdrop, button:backdrop:link, button:backdrop:visited, *:link:backdrop:backdrop:hover, *:link:backdrop:backdrop:hover:selected, *:link:backdrop { color: rgba(255, 255, 255, 0.9); }
+
+.selection-mode .titlebar:not(headerbar) .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link, .selection-mode headerbar .subtitle:link, headerbar.selection-mode .subtitle:link, button:link > label:selected, button:visited > label:selected, button:selected:link, button:selected:visited, *:selected button:link > label, *:selected button:visited > label, *:selected button:link, *:selected button:visited, *:link:selected, *:selected *:link { color: #474747; }
+
+button:link, button:visited { text-shadow: none; }
+
+button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked { text-shadow: none; }
+
+button:link > label, button:visited > label { text-decoration-line: underline; }
+
+/****************** Stack Switcher * */
+stackswitcher, .stack-switcher { border-radius: 8px; background-color: #191919; }
+
+stackswitcher:backdrop, .stack-switcher:backdrop { background-color: #151515; }
+
+stackswitcher > button, .stack-switcher > button { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+/***************** GtkSpinButton * */
+spinbutton { font-feature-settings: "tnum"; }
+
+spinbutton:not(.vertical) { padding: 0; }
+
+spinbutton:not(.vertical) entry { min-width: 28px; margin: 0; background: none; background-color: transparent; border: none; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) entry:backdrop:disabled { background-color: transparent; }
+
+spinbutton:not(.vertical) button { min-height: 16px; margin: 0; padding-bottom: 0; padding-top: 0; color: #ffffff; background-image: none; border-style: none none none solid; border-color: transparent; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) button:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:disabled { color: #909090; background-color: #202020; }
+
+spinbutton:not(.vertical) button:backdrop:disabled { color: #414141; background-color: #1b1b1b; background-image: none; border-style: none none none solid; }
+
+spinbutton:not(.vertical) button:backdrop:disabled:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:dir(ltr):last-child { border-radius: 0 7px 7px 0; }
+
+spinbutton:not(.vertical) button:dir(rtl):first-child { border-radius: 7px 0 0 7px; }
+
+spinbutton.vertical:disabled { color: #909090; }
+
+spinbutton.vertical:backdrop:disabled { color: #414141; }
+
+spinbutton.vertical:drop(active) { border-color: transparent; box-shadow: none; }
+
+spinbutton.vertical entry { min-height: 32px; min-width: 32px; padding: 0; border-radius: 0; }
+
+spinbutton.vertical button { min-height: 32px; min-width: 32px; padding: 0; }
+
+spinbutton.vertical button.up { border-radius: 8px 8px 0 0; border-style: solid solid none solid; }
+
+spinbutton.vertical button.down { border-radius: 0 0 8px 8px; border-style: none solid solid solid; }
+
+treeview spinbutton:not(.vertical) { min-height: 0; border-style: none; border-radius: 0; }
+
+treeview spinbutton:not(.vertical) entry { min-height: 0; padding: 1px 2px; }
+
+/************** ComboBoxes * */
+combobox arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); min-height: 16px; min-width: 16px; }
+
+combobox:drop(active) { box-shadow: none; }
+
+/************ Toolbars * */
+searchbar > revealer > box, .location-bar, .inline-toolbar, toolbar { -GtkWidget-window-dragging: true; padding: 4px; background-color: #202020; }
+
+searchbar > revealer > box:backdrop, .location-bar:backdrop, .inline-toolbar:backdrop, toolbar:backdrop { background-color: #1b1b1b; }
+
+toolbar { padding: 4px 3px 3px 4px; }
+
+.osd toolbar { background-color: transparent; }
+
+toolbar.osd { padding: 13px; border: none; border-radius: 8px; }
+
+toolbar.osd.left, toolbar.osd.right, toolbar.osd.top, toolbar.osd.bottom { border-radius: 0; }
+
+toolbar.horizontal separator { margin: 0 7px 1px 6px; }
+
+toolbar.vertical separator { margin: 6px 1px 7px 0; }
+
+toolbar:not(.inline-toolbar):not(.osd) > *:not(.toggle):not(.popup) > * { margin-right: 1px; margin-bottom: 1px; }
+
+.inline-toolbar { padding: 3px; border-width: 0 1px 1px; border-radius: 0 0 8px 8px; }
+
+.background.csd .inline-toolbar { border-radius: 0 0 10px 10px; }
+
+searchbar > revealer > box, .location-bar { border-width: 0 0 1px; padding: 3px; }
+
+searchbar > revealer > box { margin: -6px; padding: 6px; }
+
+revealer box.view { background-color: transparent; }
+
+.inline-toolbar, searchbar > revealer > box, .location-bar { border-style: none; background-color: #202020; }
+
+.inline-toolbar:backdrop, searchbar > revealer > box:backdrop, .location-bar:backdrop { background-color: #1b1b1b; }
+
+/*************** Header bars * */
+@keyframes header_ripple_effect { from { background-image: radial-gradient(circle farthest-corner at center, #202020 0%, transparent 0%); }
+  to { background-image: radial-gradient(circle farthest-corner at center, #ffffff 100%, transparent 0%); } }
+
+.titlebar:not(headerbar), headerbar { padding: 0 6px; min-height: 46px; border: none; border-radius: 0; background-color: #202020; /* hide the close button separator */ }
+
+.titlebar:backdrop:not(headerbar), headerbar:backdrop { background-color: #1b1b1b; background-image: none; }
+
+.titlebar:not(headerbar) .title, headerbar .title { padding-left: 12px; padding-right: 12px; font-weight: bold; }
+
+.titlebar:not(headerbar) .subtitle, headerbar .subtitle { font-size: smaller; padding-left: 12px; padding-right: 12px; }
+
+.selection-mode .titlebar:not(headerbar), .selection-mode.titlebar:not(headerbar), .selection-mode headerbar, headerbar.selection-mode { color: #191919; border-color: transparent; background-color: #ffffff; transition: background-color 0.00001s 150ms, color 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); animation: header_ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+.selection-mode .titlebar:backdrop:not(headerbar), .selection-mode.titlebar:backdrop:not(headerbar), .selection-mode headerbar:backdrop, headerbar.selection-mode:backdrop { color: #191919; background-color: #ffffff; background-image: none; }
+
+.selection-mode .titlebar:backdrop:not(headerbar) label, .selection-mode.titlebar:backdrop:not(headerbar) label, .selection-mode headerbar:backdrop label, headerbar.selection-mode:backdrop label { text-shadow: none; color: #191919; }
+
+.selection-mode .titlebar:not(headerbar) button, .selection-mode.titlebar:not(headerbar) button, .selection-mode headerbar button, headerbar.selection-mode button { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #eeeeee; background-image: none; }
+
+.selection-mode button.titlebutton, .selection-mode .titlebar:not(headerbar) button.flat, .selection-mode.titlebar:not(headerbar) button.flat, .selection-mode headerbar button.flat, headerbar.selection-mode button.flat { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:hover, .selection-mode.titlebar:not(headerbar) button:hover, .selection-mode headerbar button:hover, headerbar.selection-mode button:hover { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #dddddd; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:active, .selection-mode .titlebar:not(headerbar) button:checked, .selection-mode.titlebar:not(headerbar) button:active, .selection-mode.titlebar:not(headerbar) button:checked, .selection-mode headerbar button:active, .selection-mode headerbar button:checked, .selection-mode headerbar button.toggle:checked, .selection-mode headerbar button.toggle:active, headerbar.selection-mode button:active, headerbar.selection-mode button:checked, headerbar.selection-mode button.toggle:checked, headerbar.selection-mode button.toggle:active { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #d1d1d1; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop { background-color: #242424; background-image: none; -gtk-icon-effect: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop label, .selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop label, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat label, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop label, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat label, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop label, headerbar.selection-mode button:backdrop { color: #8d8d8d; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked { background-color: #323232; background-image: none; box-shadow: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active label, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked label, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active label, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked label, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active label, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked label, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active label, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked label, headerbar.selection-mode button:backdrop:checked { color: #8d8d8d; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled label, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled label, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled label, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled label, headerbar.selection-mode button:backdrop:disabled { color: #414141; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked { background-color: #f4f4f4; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active label, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked label, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active label, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked label, headerbar.selection-mode button:backdrop:disabled:checked { color: #414141; }
+
+.selection-mode button.titlebutton:backdrop, .selection-mode button.titlebutton:disabled, .selection-mode .titlebar:not(headerbar) button.flat:backdrop, .selection-mode .titlebar:not(headerbar) button.flat:disabled, .selection-mode.titlebar:not(headerbar) button.flat:backdrop, .selection-mode.titlebar:not(headerbar) button.flat:disabled, .selection-mode headerbar button.flat:backdrop, .selection-mode headerbar button.flat:disabled, .selection-mode headerbar button.flat:backdrop:disabled, headerbar.selection-mode button.flat:backdrop, headerbar.selection-mode button.flat:disabled, headerbar.selection-mode button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled, .selection-mode.titlebar:not(headerbar) button:disabled, .selection-mode headerbar button:disabled, headerbar.selection-mode button:disabled { color: #909090; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled:active, .selection-mode .titlebar:not(headerbar) button:disabled:checked, .selection-mode.titlebar:not(headerbar) button:disabled:active, .selection-mode.titlebar:not(headerbar) button:disabled:checked, .selection-mode headerbar button:disabled:active, .selection-mode headerbar button:disabled:checked, headerbar.selection-mode button:disabled:active, headerbar.selection-mode button:disabled:checked { color: #909090; background-color: #f9f9f9; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action, .selection-mode.titlebar:not(headerbar) button.suggested-action, .selection-mode headerbar button.suggested-action, headerbar.selection-mode button.suggested-action { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #313131; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:hover, .selection-mode.titlebar:not(headerbar) button.suggested-action:hover, .selection-mode headerbar button.suggested-action:hover, headerbar.selection-mode button.suggested-action:hover { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #414141; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:active, .selection-mode.titlebar:not(headerbar) button.suggested-action:active, .selection-mode headerbar button.suggested-action:active, headerbar.selection-mode button.suggested-action:active { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #4d4d4d; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode headerbar button.suggested-action:disabled, headerbar.selection-mode button.suggested-action:disabled { color: #909090; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop { background-color: #242424; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop label, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop label, headerbar.selection-mode button.suggested-action:backdrop { color: #8d8d8d; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled label, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled label, headerbar.selection-mode button.suggested-action:backdrop:disabled { color: #414141; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu, .selection-mode.titlebar:not(headerbar) .selection-menu, .selection-mode headerbar .selection-menu:backdrop, .selection-mode headerbar .selection-menu, headerbar.selection-mode .selection-menu:backdrop, headerbar.selection-mode .selection-menu { border-color: rgba(255, 255, 255, 0); background-color: rgba(255, 255, 255, 0); background-image: none; box-shadow: none; min-height: 20px; padding: 6px 10px; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu arrow, .selection-mode.titlebar:not(headerbar) .selection-menu arrow, .selection-mode headerbar .selection-menu:backdrop arrow, .selection-mode headerbar .selection-menu arrow, headerbar.selection-mode .selection-menu:backdrop arrow, headerbar.selection-mode .selection-menu arrow { -GtkArrow-arrow-scaling: 1; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu .arrow, .selection-mode.titlebar:not(headerbar) .selection-menu .arrow, .selection-mode headerbar .selection-menu:backdrop .arrow, .selection-mode headerbar .selection-menu .arrow, headerbar.selection-mode .selection-menu:backdrop .arrow, headerbar.selection-mode .selection-menu .arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); color: rgba(25, 25, 25, 0.5); -gtk-icon-shadow: none; }
+
+.tiled .titlebar:not(headerbar), .tiled-top .titlebar:not(headerbar), .tiled-right .titlebar:not(headerbar), .tiled-bottom .titlebar:not(headerbar), .tiled-left .titlebar:not(headerbar), .maximized .titlebar:not(headerbar), .fullscreen .titlebar:not(headerbar), .tiled headerbar, .tiled-top headerbar, .tiled-right headerbar, .tiled-bottom headerbar, .tiled-left headerbar, .maximized headerbar, .fullscreen headerbar { border-radius: 0; }
+
+.default-decoration.titlebar:not(headerbar), headerbar.default-decoration { min-height: 28px; padding: 4px; border-color: transparent; }
+
+.default-decoration.titlebar:not(headerbar) button.titlebutton, headerbar.default-decoration button.titlebutton { min-height: 26px; min-width: 26px; margin: 0; padding: 0; }
+
+.titlebar:not(headerbar) separator.titlebutton, headerbar separator.titlebutton { opacity: 0; }
+
+.solid-csd .titlebar:dir(rtl):not(headerbar), .solid-csd .titlebar:dir(ltr):not(headerbar), .solid-csd headerbar:backdrop:dir(rtl), .solid-csd headerbar:backdrop:dir(ltr), .solid-csd headerbar:dir(rtl), .solid-csd headerbar:dir(ltr) { margin-left: -1px; margin-right: -1px; margin-top: -1px; border-radius: 0; box-shadow: none; }
+
+headerbar entry, headerbar spinbutton, headerbar separator:not(.sidebar), headerbar button { margin-top: 6px; margin-bottom: 6px; }
+
+headerbar switch { margin-top: 10px; margin-bottom: 10px; }
+
+headerbar stackswitcher button, headerbar .stack-switcher button { min-height: 24px; min-width: 80px; margin: 4px 2px; }
+
+headerbar stackswitcher button:first-child:dir(ltr), headerbar .stack-switcher button:first-child:dir(ltr) { margin-left: 4px; }
+
+headerbar stackswitcher button:first-child:dir(rtl), headerbar .stack-switcher button:first-child:dir(rtl) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(ltr), headerbar .stack-switcher button:last-child:dir(ltr) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(rtl), headerbar .stack-switcher button:last-child:dir(rtl) { margin-left: 4px; }
+
+#MozillaGtkWidget.background headerbar button.close:hover, headerbar button.close:hover { color: #fb7c7c; background-color: #412e2e; }
+
+#MozillaGtkWidget.background headerbar button.close:active, #MozillaGtkWidget.background headerbar button.close:checked, headerbar button.close:active, headerbar button.close:checked { color: #fb7c7c; background-color: #4c3232; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #4c3232 10%, transparent 0%); background-size: 0% 0%; }
+
+headerbar.titlebar headerbar:not(.titlebar) { background: none; box-shadow: none; }
+
+.background .titlebar:backdrop, .background .titlebar { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+.background.tiled .titlebar:backdrop, .background.tiled .titlebar, .background.tiled-top .titlebar:backdrop, .background.tiled-top .titlebar, .background.tiled-right .titlebar:backdrop, .background.tiled-right .titlebar, .background.tiled-bottom .titlebar:backdrop, .background.tiled-bottom .titlebar, .background.tiled-left .titlebar:backdrop, .background.tiled-left .titlebar, .background.maximized .titlebar:backdrop, .background.maximized .titlebar, .background.solid-csd .titlebar:backdrop, .background.solid-csd .titlebar { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window separator:first-child + headerbar:backdrop, window separator:first-child + headerbar, window headerbar:first-child:backdrop, window headerbar:first-child { border-top-left-radius: 10px; }
+
+window headerbar:last-child:backdrop, window headerbar:last-child { border-top-right-radius: 10px; }
+
+window stack headerbar:first-child:backdrop, window stack headerbar:first-child, window stack headerbar:last-child:backdrop, window stack headerbar:last-child { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+window.tiled headerbar, window.tiled headerbar:first-child, window.tiled headerbar:last-child, window.tiled headerbar:only-child, window.tiled headerbar:backdrop, window.tiled headerbar:backdrop:first-child, window.tiled headerbar:backdrop:last-child, window.tiled headerbar:backdrop:only-child, window.tiled-top headerbar, window.tiled-top headerbar:first-child, window.tiled-top headerbar:last-child, window.tiled-top headerbar:only-child, window.tiled-top headerbar:backdrop, window.tiled-top headerbar:backdrop:first-child, window.tiled-top headerbar:backdrop:last-child, window.tiled-top headerbar:backdrop:only-child, window.tiled-right headerbar, window.tiled-right headerbar:first-child, window.tiled-right headerbar:last-child, window.tiled-right headerbar:only-child, window.tiled-right headerbar:backdrop, window.tiled-right headerbar:backdrop:first-child, window.tiled-right headerbar:backdrop:last-child, window.tiled-right headerbar:backdrop:only-child, window.tiled-bottom headerbar, window.tiled-bottom headerbar:first-child, window.tiled-bottom headerbar:last-child, window.tiled-bottom headerbar:only-child, window.tiled-bottom headerbar:backdrop, window.tiled-bottom headerbar:backdrop:first-child, window.tiled-bottom headerbar:backdrop:last-child, window.tiled-bottom headerbar:backdrop:only-child, window.tiled-left headerbar, window.tiled-left headerbar:first-child, window.tiled-left headerbar:last-child, window.tiled-left headerbar:only-child, window.tiled-left headerbar:backdrop, window.tiled-left headerbar:backdrop:first-child, window.tiled-left headerbar:backdrop:last-child, window.tiled-left headerbar:backdrop:only-child, window.maximized headerbar, window.maximized headerbar:first-child, window.maximized headerbar:last-child, window.maximized headerbar:only-child, window.maximized headerbar:backdrop, window.maximized headerbar:backdrop:first-child, window.maximized headerbar:backdrop:last-child, window.maximized headerbar:backdrop:only-child, window.fullscreen headerbar, window.fullscreen headerbar:first-child, window.fullscreen headerbar:last-child, window.fullscreen headerbar:only-child, window.fullscreen headerbar:backdrop, window.fullscreen headerbar:backdrop:first-child, window.fullscreen headerbar:backdrop:last-child, window.fullscreen headerbar:backdrop:only-child, window.solid-csd headerbar, window.solid-csd headerbar:first-child, window.solid-csd headerbar:last-child, window.solid-csd headerbar:only-child, window.solid-csd headerbar:backdrop, window.solid-csd headerbar:backdrop:first-child, window.solid-csd headerbar:backdrop:last-child, window.solid-csd headerbar:backdrop:only-child { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window.csd > .titlebar:not(headerbar) { padding: 0; background-color: transparent; background-image: none; border-style: none; border-color: transparent; box-shadow: none; }
+
+.titlebar:not(headerbar) separator { background-color: #202020; }
+
+.titlebar:not(headerbar) separator:backdrop { background-color: #1b1b1b; }
+
+window.devel headerbar.titlebar:not(.selection-mode) { background: #202020 cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, linear-gradient(to right, transparent 65%, rgba(255, 255, 255, 0.15)); }
+
+window.devel headerbar.titlebar:not(.selection-mode):backdrop { background: #202020 cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, image(#202020); /* background-color would flash */ }
+
+/************ Pathbars * */
+.path-bar button.text-button, .path-bar button.image-button, .path-bar button { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.text-button.image-button label { padding-left: 0; padding-right: 0; }
+
+.path-bar button.text-button.image-button label:last-child, .path-bar button label:last-child { padding-right: 8px; }
+
+.path-bar button.text-button.image-button label:first-child, .path-bar button label:first-child { padding-left: 8px; }
+
+.path-bar button image { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.slider-button { padding-left: 0; padding-right: 0; }
+
+/************** Tree Views * */
+treeview.view { border-left-color: rgba(255, 255, 255, 0.15); border-top-color: #202020; border-radius: 0px; }
+
+* { -GtkTreeView-horizontal-separator: 4; -GtkTreeView-grid-line-width: 1; -GtkTreeView-grid-line-pattern: ''; -GtkTreeView-tree-line-width: 1; -GtkTreeView-tree-line-pattern: ''; -GtkTreeView-expander-size: 16; }
+
+treeview.view:selected:focus, treeview.view:selected { border-radius: 0; }
+
+treeview.view:selected:backdrop, treeview.view:selected { border-left-color: #5f5f5f; border-top-color: rgba(141, 141, 141, 0.1); }
+
+treeview.view:disabled { color: #909090; }
+
+treeview.view:disabled:selected { color: #a3a3a3; }
+
+treeview.view:disabled:selected:backdrop { color: #797979; }
+
+treeview.view:disabled:backdrop { color: #414141; }
+
+treeview.view.separator { min-height: 2px; color: #202020; }
+
+treeview.view.separator:backdrop { color: #1b1b1b; }
+
+treeview.view:backdrop { border-left-color: #545454; border-top: #1b1b1b; }
+
+treeview.view:drop(active) { border-style: solid none; border-width: 1px; border-color: #ececec; }
+
+treeview.view:drop(active).after { border-top-style: none; }
+
+treeview.view:drop(active).before { border-bottom-style: none; }
+
+treeview.view.expander { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); color: #bababa; }
+
+treeview.view.expander:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+treeview.view.expander:hover { color: #ffffff; }
+
+treeview.view.expander:selected { color: #5e5e5e; }
+
+treeview.view.expander:selected:hover { color: #191919; }
+
+treeview.view.expander:selected:backdrop { color: #404040; }
+
+treeview.view.expander:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+treeview.view.expander:backdrop { color: dimgray; }
+
+treeview.view.progressbar { color: #191919; background-color: #ffffff; background: image(#ffffff); box-shadow: none; border-radius: 8px; }
+
+treeview.view.progressbar:backdrop { color: #151515; background-color: #a4a4a4; background-image: none; }
+
+treeview.view.progressbar:selected:focus, treeview.view.progressbar:selected { border-radius: 8px; color: #ffffff; background-color: #191919; background-image: none; }
+
+treeview.view.progressbar:selected:backdrop { color: #a4a4a4; background-color: #151515; }
+
+treeview.view.trough { background-color: rgba(255, 255, 255, 0.1); border-radius: 8px; }
+
+treeview.view.trough:backdrop { background-color: rgba(141, 141, 141, 0.1); }
+
+treeview.view.trough:selected { border-radius: 8px; }
+
+treeview.view.trough:selected:focus, treeview.view.trough:selected { background-color: rgba(25, 25, 25, 0.3); }
+
+treeview.view.trough:selected:backdrop { background-color: rgba(25, 25, 25, 0.3); }
+
+treeview.view header button { color: #8c8c8c; background-color: #191919; font-weight: bold; text-shadow: none; box-shadow: none; margin: 0 1px 1px 0; }
+
+treeview.view header button:last-child { margin-right: 0; }
+
+treeview.view header button:hover { color: #c6c6c6; box-shadow: none; transition: none; }
+
+treeview.view header button:active { color: #ffffff; transition: none; }
+
+treeview.view button.dnd:active, treeview.view button.dnd:selected, treeview.view button.dnd:hover, treeview.view button.dnd, treeview.view header.button.dnd:active, treeview.view header.button.dnd:selected, treeview.view header.button.dnd:hover, treeview.view header.button.dnd { padding: 0 6px; color: #191919; background-image: none; background-color: #ffffff; border-style: none; border-radius: 0; box-shadow: inset 0 0 0 1px #191919; text-shadow: none; transition: none; }
+
+treeview.view acceleditor > label { background-color: #ffffff; }
+
+treeview.view header button, treeview.view header button:hover, treeview.view header button:active { padding: 0 6px; background-image: none; border-style: none solid solid none; border-color: #202020; border-radius: 0; text-shadow: none; }
+
+treeview.view header button:disabled { border-color: #202020; background-image: none; }
+
+treeview.view header button:backdrop { color: #545454; border-color: #1b1b1b; border-style: none solid solid none; background-image: none; background-color: #151515; }
+
+treeview.view header button:backdrop:disabled { border-color: #1b1b1b; background-image: none; }
+
+treeview.view header button:last-child { border-right-style: none; }
+
+/********* Menus * */
+menubar, .menubar { -GtkWidget-window-dragging: true; padding: 0px; }
+
+menubar:backdrop, .menubar:backdrop { background-color: #1b1b1b; }
+
+menubar > menuitem, .menubar > menuitem { min-height: 16px; padding: 4px 8px; }
+
+menubar > menuitem menu:dir(rtl), menubar > menuitem menu:dir(ltr), .menubar > menuitem menu:dir(rtl), .menubar > menuitem menu:dir(ltr) { border-radius: 0; padding: 0; }
+
+menubar > menuitem:hover, .menubar > menuitem:hover { box-shadow: inset 0 -3px #ffffff; color: white; }
+
+menubar > menuitem:disabled, .menubar > menuitem:disabled { color: #909090; box-shadow: none; }
+
+menubar .csd.popup decoration, .menubar .csd.popup decoration { border-radius: 0; }
+
+.background.popup { background-color: transparent; }
+
+menu, .menu, .context-menu { margin: 8px; padding: 8px 0px; background-color: #191919; border: 1px solid rgba(49, 49, 49, 0.75); }
+
+.csd menu, .csd .menu, .csd .context-menu { border: none; border-radius: 8px; }
+
+menu:backdrop, .menu:backdrop, .context-menu:backdrop { background-color: #151515; border-color: rgba(45, 45, 45, 0.75); }
+
+menu menuitem, .menu menuitem, .context-menu menuitem { min-height: 16px; min-width: 40px; padding: 4px 6px; text-shadow: none; }
+
+menu menuitem:hover, .menu menuitem:hover, .context-menu menuitem:hover { color: #191919; background-color: #ffffff; background: image(#ffffff); }
+
+menu menuitem:disabled, .menu menuitem:disabled, .context-menu menuitem:disabled { color: #909090; }
+
+menu menuitem:disabled:backdrop, .menu menuitem:disabled:backdrop, .context-menu menuitem:disabled:backdrop { color: #414141; }
+
+menu menuitem:backdrop, menu menuitem:backdrop:hover, .menu menuitem:backdrop, .menu menuitem:backdrop:hover, .context-menu menuitem:backdrop, .context-menu menuitem:backdrop:hover { color: #8d8d8d; background-color: transparent; }
+
+menu menuitem arrow, .menu menuitem arrow, .context-menu menuitem arrow { min-height: 16px; min-width: 16px; }
+
+menu menuitem arrow:dir(ltr), .menu menuitem arrow:dir(ltr), .context-menu menuitem arrow:dir(ltr) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); margin-left: 10px; }
+
+menu menuitem arrow:dir(rtl), .menu menuitem arrow:dir(rtl), .context-menu menuitem arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); margin-right: 10px; }
+
+menu menuitem label:dir(rtl), menu menuitem label:dir(ltr), .menu menuitem label:dir(rtl), .menu menuitem label:dir(ltr), .context-menu menuitem label:dir(rtl), .context-menu menuitem label:dir(ltr) { color: inherit; }
+
+menu separator, .menu separator, .context-menu separator { margin: 3px 16px; }
+
+menu > arrow, .menu > arrow, .context-menu > arrow { background-color: transparent; background-image: none; background-image: none; min-height: 16px; min-width: 16px; padding: 4px; background-color: #191919; border-radius: 0; }
+
+menu > arrow.top, .menu > arrow.top, .context-menu > arrow.top { margin-top: -8px; border-bottom: 1px solid #303030; border-top-right-radius: 8px; border-top-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+menu > arrow.bottom, .menu > arrow.bottom, .context-menu > arrow.bottom { margin-top: 16px; margin-bottom: -24px; border-top: 1px solid #303030; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+menu > arrow:hover, .menu > arrow:hover, .context-menu > arrow:hover { background-color: #3c3c3c; }
+
+menu > arrow:backdrop, .menu > arrow:backdrop, .context-menu > arrow:backdrop { background-color: #151515; }
+
+menu > arrow:disabled, .menu > arrow:disabled, .context-menu > arrow:disabled { color: transparent; background-color: transparent; border-color: transparent; }
+
+menuitem accelerator { color: alpha(currentColor,0.55); }
+
+menuitem check, menuitem radio { min-height: 16px; min-width: 16px; }
+
+menuitem check:dir(ltr), menuitem radio:dir(ltr) { margin-right: 7px; }
+
+menuitem check:dir(rtl), menuitem radio:dir(rtl) { margin-left: 7px; }
+
+/*************** Popovers   * */
+popover.background { padding: 2px; background-color: #191919; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.csd popover.background, popover.background { border: 1px solid rgba(49, 49, 49, 0.75); border-radius: 10px; }
+
+.csd popover.background { background-clip: padding-box; }
+
+popover.background:backdrop { background-color: #151515; box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); border-color: rgba(45, 45, 45, 0.75); }
+
+popover.background > list, popover.background > .view, popover.background > iconview, popover.background > toolbar { border-style: none; background-color: transparent; }
+
+popover.background separator { margin: 3px; }
+
+popover.background list separator { margin: 0px; }
+
+/************* Notebooks * */
+notebook > header { padding: 2px; border-style: none; background-color: #191919; }
+
+notebook > header:backdrop { background-color: #151515; }
+
+notebook > header.top { border-radius: 8px 8px 0 0; }
+
+notebook > header.bottom { border-radius: 0 0 8px 8px; }
+
+notebook > header.left { border-radius: 8px 0 0 8px; }
+
+notebook > header.right { border-radius: 0 8px 8px 0; }
+
+notebook > header > button { padding: 2px 9px; margin: 2px; }
+
+notebook > header.left > tabs > arrow, notebook > header.right > tabs > arrow { margin-top: -5px; margin-bottom: -5px; padding-top: 4px; padding-bottom: 4px; }
+
+notebook > header.left > tabs > arrow.down, notebook > header.right > tabs > arrow.down { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+notebook > header.left > tabs > arrow.up, notebook > header.right > tabs > arrow.up { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+notebook > header > tabs > arrow { transition: none; min-height: 16px; min-width: 16px; }
+
+notebook > header > tabs > arrow:hover:not(:active):not(:backdrop) { background-clip: padding-box; background-image: none; border-color: transparent; box-shadow: none; transition: none; }
+
+notebook > header > tabs > arrow:disabled { color: #909090; background-color: transparent; background-image: none; }
+
+notebook > header tab { min-height: 24px; min-width: 30px; padding: 2px 9px; margin: 2px; outline-offset: -3px; border-radius: 8px; color: #d1d1d1; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header tab:hover { color: #ffffff; background-color: rgba(255, 255, 255, 0.05); }
+
+notebook > header tab:backdrop { color: #8d8d8d; }
+
+notebook > header tab:backdrop.reorderable-page { background-color: transparent; }
+
+notebook > header tab:checked { color: #ffffff; background-color: #414141; box-shadow: 0 2px 4px rgba(25, 25, 25, 0.075); }
+
+notebook > header tab:backdrop:checked { color: #8d8d8d; background-color: #2c2c2c; box-shadow: 0 1px 2px rgba(21, 21, 21, 0.075); }
+
+notebook > header tab:backdrop:checked.reorderable-page { background-color: #2c2c2c; }
+
+notebook > header tab button.flat { border-radius: 999px; padding: 0; margin-top: 2px; margin-bottom: 2px; min-width: 20px; min-height: 20px; }
+
+notebook > header tab button.flat:hover { color: currentColor; }
+
+notebook > header tab button.flat, notebook > header tab button.flat:backdrop { color: alpha(currentColor,0.3); }
+
+notebook > header tab button.flat:last-child { margin-left: 4px; margin-right: -4px; }
+
+notebook > header tab button.flat:first-child { margin-left: -4px; margin-right: 4px; }
+
+notebook > stack:not(:only-child) { background-color: transparent; }
+
+notebook > stack:not(:only-child):backdrop { background-color: transparent; }
+
+/************** Scrollbars * */
+scrollbar { background-color: transparent; transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border-radius: 8px; }
+
+* { -GtkScrollbar-has-backward-stepper: false; -GtkScrollbar-has-forward-stepper: false; }
+
+scrollbar:backdrop { border-color: #2d2d2d; transition: 150ms ease-out; }
+
+scrollbar slider { min-width: 6px; min-height: 6px; margin: -1px; border: 4px solid transparent; border-radius: 8px; background-clip: padding-box; background-color: #a6a6a6; }
+
+scrollbar slider:hover { background-color: #d2d2d2; }
+
+scrollbar slider:hover:active { background-color: #ffffff; }
+
+scrollbar slider:backdrop { background-color: #6b6b6b; }
+
+scrollbar slider:disabled { background-color: transparent; }
+
+scrollbar.fine-tune slider { min-width: 4px; min-height: 4px; }
+
+scrollbar.fine-tune.horizontal slider { border-width: 5px 4px; }
+
+scrollbar.fine-tune.vertical slider { border-width: 4px 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) { border-color: transparent; opacity: 0.4; background-color: transparent; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider { margin: 0; min-width: 3px; min-height: 3px; background-color: #ffffff; border: 1px solid black; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) button { min-width: 5px; min-height: 5px; background-color: #ffffff; background-clip: padding-box; border-radius: 100%; border: 1px solid black; -gtk-icon-source: none; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider { margin: 0 2px; min-width: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal button { margin: 1px 2px; min-width: 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider { margin: 2px 0; min-height: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical button { margin: 2px 1px; min-height: 5px; }
+
+scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering { opacity: 0.8; }
+
+scrollbar.horizontal slider { min-width: 40px; }
+
+scrollbar.vertical slider { min-height: 40px; }
+
+scrollbar button { padding: 0; min-width: 12px; min-height: 12px; border-style: none; border-radius: 0; transition-property: min-height, min-width, color; background-color: transparent; background-image: none; background-image: none; color: #a6a6a6; }
+
+scrollbar button:hover { background-color: transparent; background-image: none; background-image: none; color: #d2d2d2; }
+
+scrollbar button:active, scrollbar button:checked { background-color: transparent; background-image: none; background-image: none; color: #ffffff; }
+
+scrollbar button:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(166, 166, 166, 0.2); }
+
+scrollbar button:backdrop { background-color: transparent; background-image: none; background-image: none; color: #6b6b6b; }
+
+scrollbar button:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(107, 107, 107, 0.2); }
+
+scrollbar.vertical button.down { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+scrollbar.vertical button.up { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+scrollbar.horizontal button.down { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+scrollbar.horizontal button.up { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+/********** Switch * */
+switch { font-size: 0; outline-offset: -4px; min-width: 36px; min-height: 18px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border: none; padding: 2px; border-radius: 999px; background-color: #4d4d4d; background-image: none; color: transparent; }
+
+switch:checked { background-color: #ffffff; background: image(#ffffff); }
+
+switch:disabled { background-color: #313131; background-image: none; }
+
+switch:disabled:checked { background-color: #6f6f6f; background-image: none; }
+
+switch:backdrop { background-color: #434343; background-image: none; transition: 150ms ease-out; }
+
+switch:backdrop:checked { background-color: #a4a4a4; background-image: none; }
+
+switch:backdrop:disabled { background-color: #2d2d2d; background-image: none; }
+
+switch:backdrop:disabled:checked { background-color: #4a4a4a; background-image: none; }
+
+switch slider { margin: 2px; min-width: 18px; min-height: 18px; border: none; border-radius: 999px; -gtk-outline-radius: 999px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-color: #191919; box-shadow: 0 2px 4px rgba(25, 25, 25, 0.075); }
+
+switch:disabled slider { background-color: #202020; box-shadow: none; }
+
+switch:backdrop slider { transition: 150ms ease-out; background-color: #1b1b1b; box-shadow: 0 2px 4px rgba(21, 21, 21, 0.075); }
+
+switch:checked slider { background-color: #191919; box-shadow: none; }
+
+switch:backdrop:checked slider { background-color: #151515; }
+
+row:selected switch { box-shadow: none; box-shadow: inset 0 0 0 1px #191919; }
+
+/************************* Check and Radio items * */
+.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view:not(list) check { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view:not(list) check:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view:not(list) check:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view:not(list) check:backdrop { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view:not(list) check:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view:not(list) check:checked:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view:not(list) check:checked:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view:not(list) check:backdrop:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+checkbutton.text-button, radiobutton.text-button { padding: 2px 0; outline-offset: 0; }
+
+checkbutton.text-button label:not(:only-child):first-child, radiobutton.text-button label:not(:only-child):first-child { margin-left: 4px; }
+
+checkbutton.text-button label:not(:only-child):last-child, radiobutton.text-button label:not(:only-child):last-child { margin-right: 4px; }
+
+check, radio { margin: 0 4px; min-height: 14px; min-width: 14px; padding: 1px; border: none; -gtk-icon-source: none; }
+
+check:only-child, radio:only-child { margin: 0; }
+
+popover check.left:dir(rtl), popover radio.left:dir(rtl) { margin-left: 0; margin-right: 12px; }
+
+popover check.right:dir(ltr), popover radio.right:dir(ltr) { margin-left: 12px; margin-right: 0; }
+
+check, radio { background-clip: padding-box; background: image(#191919); box-shadow: inset 0 0 0 1px #4d4d4d; color: #ffffff; }
+
+check:hover, radio:hover { background: image(#252525); }
+
+check:active, radio:active { background: image(#303030); }
+
+check:disabled, radio:disabled { box-shadow: none; background-image: none; background-color: #1d1d1d; color: rgba(255, 255, 255, 0.7); }
+
+check:backdrop, radio:backdrop { background-image: none; background-color: #1a1a1a; box-shadow: inset 0 0 0 1px #4d4d4d; color: #ffffff; }
+
+check:backdrop:disabled, radio:backdrop:disabled { box-shadow: none; background-image: none; background-color: #1d1d1d; color: rgba(255, 255, 255, 0.7); }
+
+check:checked, radio:checked { background-clip: border-box; background: image(#ffffff); box-shadow: none; color: #191919; }
+
+check:checked:hover, radio:checked:hover { background: image(white); }
+
+check:checked:active, radio:checked:active { background: image(white); }
+
+check:checked:disabled, radio:checked:disabled { box-shadow: none; background-image: none; background-color: #909090; color: rgba(25, 25, 25, 0.7); }
+
+check:checked:backdrop, radio:checked:backdrop { background-image: none; background-color: #bbbbbb; box-shadow: none; color: #191919; }
+
+check:checked:backdrop:disabled, radio:checked:backdrop:disabled { box-shadow: none; background-image: none; background-color: #909090; color: rgba(25, 25, 25, 0.7); }
+
+check:indeterminate, radio:indeterminate { background-clip: border-box; background: image(#ffffff); box-shadow: none; color: #191919; }
+
+check:indeterminate:hover, radio:indeterminate:hover { background: image(white); }
+
+check:indeterminate:active, radio:indeterminate:active { background: image(white); }
+
+check:indeterminate:disabled, radio:indeterminate:disabled { box-shadow: none; background-image: none; background-color: #909090; color: rgba(25, 25, 25, 0.7); }
+
+check:indeterminate:backdrop, radio:indeterminate:backdrop { background-image: none; background-color: #bbbbbb; box-shadow: none; color: #191919; }
+
+check:indeterminate:backdrop:disabled, radio:indeterminate:backdrop:disabled { box-shadow: none; background-image: none; background-color: #909090; color: rgba(25, 25, 25, 0.7); }
+
+check:backdrop, radio:backdrop { transition: 150ms ease-out; }
+
+menu menuitem check, menu menuitem radio { margin: 0; }
+
+menu menuitem check, menu menuitem check:hover, menu menuitem check:disabled, menu menuitem check:checked, menu menuitem check:checked:hover, menu menuitem check:checked:disabled, menu menuitem check:indeterminate, menu menuitem check:indeterminate:hover, menu menuitem check:indeterminate:disabled, menu menuitem radio, menu menuitem radio:hover, menu menuitem radio:disabled, menu menuitem radio:checked, menu menuitem radio:checked:hover, menu menuitem radio:checked:disabled, menu menuitem radio:indeterminate, menu menuitem radio:indeterminate:hover, menu menuitem radio:indeterminate:disabled { min-height: 14px; min-width: 14px; background-image: none; background-color: transparent; box-shadow: none; -gtk-icon-shadow: none; color: inherit; border: 1px solid currentColor; padding: 0; }
+
+check { border-radius: 4px; }
+
+check:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/check-symbolic.svg")), -gtk-recolor(url("assets/check-symbolic.symbolic.png"))); }
+
+check:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+treeview.view radio:selected:focus, treeview.view radio:selected, radio { border-radius: 100%; }
+
+treeview.view radio:checked:selected, radio:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/bullet-symbolic.svg")), -gtk-recolor(url("assets/bullet-symbolic.symbolic.png"))); }
+
+treeview.view radio:indeterminate:selected, radio:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+radio:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: scale(0); }
+
+check:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: translate(6px, -3px) rotate(-45deg) scaleY(0.2) rotate(45deg) scaleX(0); }
+
+radio:active, check:active { -gtk-icon-transform: scale(0, 1); }
+
+radio:checked:not(:backdrop), radio:indeterminate:not(:backdrop), check:checked:not(:backdrop), check:indeterminate:not(:backdrop) { -gtk-icon-transform: unset; transition: 400ms; }
+
+menu menuitem radio:checked:not(:backdrop), menu menuitem radio:indeterminate:not(:backdrop), menu menuitem check:checked:not(:backdrop), menu menuitem check:indeterminate:not(:backdrop) { transition: none; }
+
+treeview.view check:selected:focus, treeview.view check:selected, treeview.view radio:selected:focus, treeview.view radio:selected { color: #191919; border: 1px solid #ececec; }
+
+treeview.view check:selected:focus:backdrop, treeview.view check:selected:backdrop, treeview.view radio:selected:focus:backdrop, treeview.view radio:selected:backdrop { border-color: #c2c2c2; }
+
+/************ GtkScale * */
+levelbar block.empty, progressbar trough, scale fill, scale trough { border: none; border-radius: 8px; background-color: #313131; }
+
+levelbar block.empty:disabled, progressbar trough:disabled, scale fill:disabled, scale trough:disabled { background-color: #313131; }
+
+levelbar block.empty:backdrop, progressbar trough:backdrop, scale fill:backdrop, scale trough:backdrop { background-color: #2d2d2d; transition: 150ms ease-out; }
+
+levelbar block.empty:backdrop:disabled, progressbar trough:backdrop:disabled, scale fill:backdrop:disabled, scale trough:backdrop:disabled { background-color: #2d2d2d; }
+
+row:selected levelbar block.empty, levelbar row:selected block.empty, row:selected progressbar trough, progressbar row:selected trough, row:selected scale fill, scale row:selected fill, row:selected scale trough, scale row:selected trough { border: 1px solid #191919; }
+
+progressbar progress, scale highlight { border: none; border-radius: 8px; background-color: #ffffff; background: image(#ffffff); }
+
+scale.vertical progressbar progress, progressbar scale.vertical progress, scale.vertical highlight, progressbar.vertical progress, progressbar.vertical scale highlight, scale progressbar.vertical highlight { background: image(#ffffff); }
+
+progressbar progress:disabled, scale highlight:disabled { background-image: none; background-color: #4d4d4d; }
+
+progressbar progress:backdrop, scale highlight:backdrop { background-image: none; background-color: #a4a4a4; }
+
+progressbar progress:backdrop:disabled, scale highlight:backdrop:disabled { background-image: none; background-color: #434343; }
+
+row:selected progressbar progress, progressbar row:selected progress, row:selected scale highlight, scale row:selected highlight { border: 1px solid #191919; }
+
+scale { min-height: 10px; min-width: 10px; padding: 12px; }
+
+scale slider { min-height: 16px; min-width: 16px; margin: -8px; }
+
+scale.fine-tune.horizontal { padding-top: 9px; padding-bottom: 9px; min-height: 16px; }
+
+scale.fine-tune.vertical { padding-left: 9px; padding-right: 9px; min-width: 16px; }
+
+scale.fine-tune slider { margin: -6px; }
+
+scale.fine-tune fill, scale.fine-tune highlight, scale.fine-tune trough { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+scale trough { outline-offset: 2px; -gtk-outline-radius: 8px; }
+
+scale fill:backdrop, scale fill { background-color: #313131; }
+
+scale fill:disabled:backdrop, scale fill:disabled { border-color: transparent; background-color: transparent; }
+
+scale slider { border: 2px solid #ffffff; border-radius: 100%; background-color: #202020; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-property: background, border, box-shadow; }
+
+row scale slider, popover scale slider { background-color: #191919; }
+
+scale slider:hover { background-color: #191919; }
+
+row scale slider:hover, popover scale slider:hover { background-color: #202020; }
+
+scale slider:active, row scale slider:active, popover scale slider:active { background-color: #ffffff; }
+
+scale slider:disabled { border-color: #4d4d4d; }
+
+scale slider:backdrop { background-color: #1b1b1b; border-color: #a4a4a4; transition: 150ms ease-out; }
+
+scale slider:backdrop:disabled { border-color: #434343; }
+
+row:selected scale slider:disabled, row:selected scale slider { border-color: #ececec; }
+
+scale marks, scale value { color: alpha(currentColor,0.55); font-feature-settings: "tnum"; }
+
+scale.horizontal marks.top { margin-bottom: 6px; margin-top: -12px; }
+
+scale.horizontal.fine-tune marks.top { margin-bottom: 6px; margin-top: -9px; }
+
+scale.horizontal marks.bottom { margin-top: 6px; margin-bottom: -12px; }
+
+scale.horizontal.fine-tune marks.bottom { margin-top: 6px; margin-bottom: -9px; }
+
+scale.vertical marks.top { margin-right: 6px; margin-left: -12px; }
+
+scale.vertical.fine-tune marks.top { margin-right: 6px; margin-left: -9px; }
+
+scale.vertical marks.bottom { margin-left: 6px; margin-right: -12px; }
+
+scale.vertical.fine-tune marks.bottom { margin-left: 6px; margin-right: -9px; }
+
+scale.horizontal indicator { min-height: 6px; min-width: 1px; }
+
+scale.horizontal.fine-tune indicator { min-height: 3px; }
+
+scale.vertical indicator { min-height: 1px; min-width: 6px; }
+
+scale.vertical.fine-tune indicator { min-width: 3px; }
+
+scale.horizontal.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #ffffff; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-top: -13px; background-position: top; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:hover { color: white; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:active { color: #ffffff; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:disabled { color: #4d4d4d; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop { color: #a4a4a4; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop:disabled { color: #434343; }
+
+scale.horizontal.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-top: -11px; }
+
+scale.horizontal.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #ffffff; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-bottom: -13px; background-position: bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:hover { color: white; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:active { color: #ffffff; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:disabled { color: #4d4d4d; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop { color: #a4a4a4; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop:disabled { color: #434343; }
+
+scale.horizontal.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-bottom: -11px; }
+
+scale.vertical.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #ffffff; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-left: -13px; background-position: left bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-before:not(.marks-after) slider:hover { color: white; }
+
+scale.vertical.marks-before:not(.marks-after) slider:active { color: #ffffff; }
+
+scale.vertical.marks-before:not(.marks-after) slider:disabled { color: #4d4d4d; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop { color: #a4a4a4; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop:disabled { color: #434343; }
+
+scale.vertical.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-left: -11px; }
+
+scale.vertical.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #ffffff; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-right: -13px; background-position: right bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-after:not(.marks-before) slider:hover { color: white; }
+
+scale.vertical.marks-after:not(.marks-before) slider:active { color: #ffffff; }
+
+scale.vertical.marks-after:not(.marks-before) slider:disabled { color: #4d4d4d; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop { color: #a4a4a4; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop:disabled { color: #434343; }
+
+scale.vertical.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-right: -11px; }
+
+scale.color { min-height: 0; min-width: 0; }
+
+scale.color trough { background-color: transparent; }
+
+scale.color.horizontal { padding: 0 0 15px 0; }
+
+scale.color.horizontal trough { padding-bottom: 4px; background-position: 0 -3px; border-top-left-radius: 0; border-top-right-radius: 0; }
+
+scale.color.horizontal slider:dir(ltr):hover, scale.color.horizontal slider:dir(ltr):backdrop, scale.color.horizontal slider:dir(ltr):disabled, scale.color.horizontal slider:dir(ltr):backdrop:disabled, scale.color.horizontal slider:dir(ltr), scale.color.horizontal slider:dir(rtl):hover, scale.color.horizontal slider:dir(rtl):backdrop, scale.color.horizontal slider:dir(rtl):disabled, scale.color.horizontal slider:dir(rtl):backdrop:disabled, scale.color.horizontal slider:dir(rtl) { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.vertical:dir(ltr) { padding: 0 0 0 15px; }
+
+scale.color.vertical:dir(ltr) trough { padding-left: 4px; background-position: 3px 0; border-bottom-right-radius: 0; border-top-right-radius: 0; }
+
+scale.color.vertical:dir(ltr) slider:hover, scale.color.vertical:dir(ltr) slider:backdrop, scale.color.vertical:dir(ltr) slider:disabled, scale.color.vertical:dir(ltr) slider:backdrop:disabled, scale.color.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.vertical:dir(rtl) { padding: 0 15px 0 0; }
+
+scale.color.vertical:dir(rtl) trough { padding-right: 4px; background-position: -3px 0; border-bottom-left-radius: 0; border-top-left-radius: 0; }
+
+scale.color.vertical:dir(rtl) slider:hover, scale.color.vertical:dir(rtl) slider:backdrop, scale.color.vertical:dir(rtl) slider:disabled, scale.color.vertical:dir(rtl) slider:backdrop:disabled, scale.color.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr), scale.color.fine-tune.horizontal:dir(rtl) { padding: 0 0 12px 0; }
+
+scale.color.fine-tune.horizontal:dir(ltr) trough, scale.color.fine-tune.horizontal:dir(rtl) trough { padding-bottom: 7px; background-position: 0 -6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr) slider, scale.color.fine-tune.horizontal:dir(rtl) slider { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.fine-tune.vertical:dir(ltr) { padding: 0 0 0 12px; }
+
+scale.color.fine-tune.vertical:dir(ltr) trough { padding-left: 7px; background-position: 6px 0; }
+
+scale.color.fine-tune.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.fine-tune.vertical:dir(rtl) { padding: 0 12px 0 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) trough { padding-right: 7px; background-position: -6px 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+/***************** Progress bars * */
+@keyframes progress { from { background-position: 0, calc(0% - 64px), 0%; }
+  to { background-position: 0, calc(100% + 64px), 0%; } }
+
+progressbar { font-size: smaller; color: rgba(255, 255, 255, 0.4); font-feature-settings: "tnum"; }
+
+progressbar.horizontal trough, progressbar.horizontal progress { min-height: 4px; }
+
+progressbar.vertical trough, progressbar.vertical progress { min-width: 4px; }
+
+progressbar:backdrop { box-shadow: none; transition: 150ms ease-out; }
+
+progressbar trough { border-radius: 999px; }
+
+progressbar progress { background-image: none; background-color: #ffffff; border-radius: 999px; }
+
+progressbar progress, progressbar progress:backdrop, .horizontal progressbar progress { animation: none; }
+
+progressbar.horizontal progress { margin: 0 -1px; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled) { animation: progress 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite; background-size: cover, 64px 100%; background-repeat: no-repeat; background-image: linear-gradient(to bottom, alpha(@progress_bg_color, 0.2), rgba(210, 210, 210, 0)), linear-gradient(to right, rgba(210, 210, 210, 0), #d2d2d2 60%, rgba(210, 210, 210, 0)); }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled).right { animation-direction: reverse; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled):backdrop { animation: none; background-image: none; }
+
+progressbar.vertical progress { margin: -1px 0; }
+
+progressbar.osd { min-width: 4px; min-height: 4px; background-color: transparent; }
+
+progressbar.osd trough { border-style: none; border-radius: 0; background-color: transparent; box-shadow: none; }
+
+progressbar.osd progress { border-style: none; border-radius: 0; }
+
+progressbar trough.empty progress { all: unset; }
+
+/************* Level Bar * */
+levelbar.horizontal block { min-height: 4px; }
+
+levelbar.horizontal.discrete block { margin: 0 2px; min-width: 32px; }
+
+levelbar.horizontal.discrete block:first-child { margin-left: 0; }
+
+levelbar.horizontal.discrete block:last-child { margin-right: 0; }
+
+levelbar.vertical block { min-width: 4px; }
+
+levelbar.vertical.discrete block { margin: 2px 0; min-height: 32px; }
+
+levelbar.vertical.discrete block:first-child { margin-top: 0; }
+
+levelbar.vertical.discrete block:last-child { margin-bottom: 0; }
+
+levelbar:backdrop { transition: 150ms ease-out; }
+
+levelbar trough { border: none; padding: 0; background-color: transparent; }
+
+levelbar block { border: none; border-radius: 999px; }
+
+levelbar block.warning-battery-offset { background-color: #fb7c7c; background: image(#fb7c7c); }
+
+levelbar block.warning-battery-offset:backdrop { background-image: none; background-color: #a4a4a4; }
+
+levelbar block.low, levelbar block.low-battery-offset { background-color: #faa483; background: image(#faa483); }
+
+levelbar block.low:backdrop, levelbar block.low-battery-offset:backdrop { background-image: none; background-color: #a4a4a4; }
+
+levelbar block.high, levelbar block:not(.empty) { background-color: #ffffff; background: image(#ffffff); }
+
+levelbar block.high:backdrop, levelbar block:not(.empty):backdrop { background-image: none; background-color: #a4a4a4; }
+
+levelbar block.full, levelbar block.high-battery-offset { background-color: #6ee1b6; background: image(#6ee1b6); }
+
+levelbar block.full:backdrop, levelbar block.high-battery-offset:backdrop { background-image: none; background-color: #a4a4a4; }
+
+levelbar block.empty { background-image: none; }
+
+levelbar block:disabled { background-image: none; background-color: #4d4d4d; }
+
+levelbar block:disabled:backdrop { background-image: none; background-color: #434343; }
+
+/**************** Print dialog * */
+printdialog paper { color: black; border: 1px solid #595959; background: white; padding: 0; }
+
+printdialog paper:backdrop { color: #595959; border: 1px solid #262626; }
+
+printdialog .dialog-action-box { margin: 12px; }
+
+/********** Frames * */
+frame > border, .frame { box-shadow: none; margin: 0; padding: 0; border-radius: 10px; border: 1px solid #202020; }
+
+frame > border.flat, .frame.flat { border-style: none; }
+
+frame > border:backdrop, .frame:backdrop { border-color: #1b1b1b; }
+
+.background.csd revealer > actionbar { border-radius: 0 0 10px 10px; }
+
+actionbar > revealer > box { padding: 6px; border-top: 1px solid #313131; }
+
+actionbar > revealer > box:backdrop { border-color: #2d2d2d; }
+
+scrolledwindow { background-color: transparent; border-radius: 0 0 8px 8px; }
+
+scrolledwindow viewport.frame { border-style: none; }
+
+scrolledwindow overshoot.top { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(rgba(255, 255, 255, 0.5)), to(rgba(255, 255, 255, 0))), -gtk-gradient(radial, center top, 0, center top, 0.6, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.top:backdrop { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(#2d2d2d), to(rgba(45, 45, 45, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(rgba(255, 255, 255, 0.5)), to(rgba(255, 255, 255, 0))), -gtk-gradient(radial, center bottom, 0, center bottom, 0.6, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom:backdrop { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(#2d2d2d), to(rgba(45, 45, 45, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(rgba(255, 255, 255, 0.5)), to(rgba(255, 255, 255, 0))), -gtk-gradient(radial, left center, 0, left center, 0.6, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left:backdrop { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(#2d2d2d), to(rgba(45, 45, 45, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(rgba(255, 255, 255, 0.5)), to(rgba(255, 255, 255, 0))), -gtk-gradient(radial, right center, 0, right center, 0.6, from(rgba(255, 255, 255, 0.1)), to(rgba(255, 255, 255, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right:backdrop { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(#2d2d2d), to(rgba(45, 45, 45, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+scrolledwindow junction { border-color: transparent; border-image: linear-gradient(to bottom, #313131 1px, transparent 1px) 0 0 0 1/0 1px stretch; background-color: transparent; }
+
+scrolledwindow junction:dir(rtl) { border-image-slice: 0 1 0 0; }
+
+scrolledwindow junction:backdrop { border-image-source: linear-gradient(to bottom, #2d2d2d 1px, transparent 1px); background-color: transparent; transition: 150ms ease-out; }
+
+separator { background: #313131; min-width: 1px; min-height: 1px; }
+
+/********* Lists * */
+list { color: #ffffff; background-color: #191919; border-color: transparent; border-radius: 10px; }
+
+list, list.frame { padding-top: 4px; padding-bottom: 4px; }
+
+list.content, list.content list { background-color: transparent; padding: 0; }
+
+list:backdrop { background-color: #151515; color: #8d8d8d; border-color: transparent; }
+
+list separator.horizontal { margin: 1px 16px; }
+
+list separator.vertical { margin: 16px 1px; }
+
+list row { padding: 2px; }
+
+row { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+list:not(.content) row { border-radius: 8px; margin: 1px 6px; }
+
+list.content row { background-color: #191919; }
+
+list.content row:backdrop { background-color: #151515; }
+
+list.content row:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+list.content row:last-child { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+row.expander { padding: 0px; }
+
+row:hover { transition: none; }
+
+row:backdrop { transition: 150ms ease-out; }
+
+row.activatable { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+row.activatable.has-open-popup, row.activatable:hover { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #313131; background-image: none; background-color: rgba(255, 255, 255, 0.05); }
+
+row.activatable:active { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #414141; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, rgba(255, 255, 255, 0.15) 10%, transparent 0%); background-size: 0% 0%; }
+
+row.activatable:backdrop:hover { background-color: transparent; background-image: none; background-image: none; color: #8d8d8d; }
+
+row.activatable:selected { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; background: image(#ffffff); box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); }
+
+row.activatable:selected label { color: #191919; }
+
+row.activatable:selected:active { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); }
+
+row.activatable:selected:backdrop { background-color: #a4a4a4; background-image: none; box-shadow: none; }
+
+row.activatable:selected:backdrop label, row.activatable:selected:backdrop { color: #151515; }
+
+/********************* App Notifications * */
+.app-notification, .app-notification.frame { padding: 10px; margin: 8px; border-radius: 30px; border: 1px solid rgba(49, 49, 49, 0.75); box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification:backdrop, .app-notification.frame:backdrop { background-color: #151515; transition: 150ms ease-out; border-color: rgba(45, 45, 45, 0.75); box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification border, .app-notification.frame border { border: none; }
+
+.app-notification button:not(.linked), .app-notification.frame button:not(.linked) { border-radius: 999px; -gtk-outline-radius: 999px; }
+
+/************* Expanders * */
+expander title > arrow { min-width: 16px; min-height: 16px; -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+expander title > arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+expander title > arrow:hover { color: white; }
+
+expander title > arrow:disabled { color: #909090; }
+
+expander title > arrow:disabled:backdrop { color: #414141; }
+
+expander title > arrow:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+/************ Calendar * */
+calendar { color: #ffffff; }
+
+calendar:selected { border-radius: 8px; }
+
+calendar.header { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.header:backdrop { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.button { color: rgba(255, 255, 255, 0.45); }
+
+calendar.button:hover { color: #ffffff; }
+
+calendar.button:backdrop { color: rgba(141, 141, 141, 0.45); }
+
+calendar.button:disabled { color: rgba(144, 144, 144, 0.45); }
+
+calendar.highlight { color: #909090; }
+
+calendar.highlight:backdrop { color: #414141; }
+
+calendar:backdrop { color: #8d8d8d; border-color: #2d2d2d; }
+
+calendar:indeterminate { color: alpha(currentColor,0.1); }
+
+/*********** Dialogs * */
+messagedialog .titlebar { min-height: 20px; background-image: none; background-color: #202020; border-style: none; border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+messagedialog.csd.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button { padding: 10px 14px; border-right-style: none; border-bottom-style: none; border-radius: 0; margin: 0 2px 0 0; -gtk-outline-radius: 0; }
+
+messagedialog.csd .dialog-action-area button:first-child { border-left-style: none; border-bottom-left-radius: 10px; -gtk-outline-bottom-left-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button:last-child { border-bottom-right-radius: 10px; margin-right: 0; -gtk-outline-bottom-right-radius: 10px; }
+
+filechooser .dialog-action-box { border-top: 1px solid #313131; }
+
+filechooser .dialog-action-box:backdrop { border-top-color: #2d2d2d; }
+
+filechooser #pathbarbox { border: none; }
+
+filechooser #pathbarbox:backdrop { background-color: #1b1b1b; }
+
+filechooserbutton:drop(active) { box-shadow: none; border-color: transparent; }
+
+/*********** Sidebar * */
+.sidebar { border-style: none; background-color: transparent; border-radius: 0 0 10px 10px; }
+
+stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:not(separator):dir(ltr), .sidebar:not(separator).left { border-right: 1px solid #313131; border-left-style: none; }
+
+stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:not(separator):dir(rtl), .sidebar:not(separator).right { border-left: 1px solid #313131; border-right-style: none; }
+
+.sidebar:backdrop { border-color: #2d2d2d; transition: 150ms ease-out; }
+
+.sidebar list { background-color: transparent; }
+
+paned .sidebar.left, paned .sidebar.right, paned .sidebar.left:dir(rtl), paned .sidebar:dir(rtl), paned .sidebar:dir(ltr), paned .sidebar { border-style: none; }
+
+stacksidebar row { padding: 10px 4px; }
+
+stacksidebar row > label { padding-left: 6px; padding-right: 6px; }
+
+stacksidebar row.needs-attention > label { background-size: 6px 6px, 0 0; }
+
+separator.sidebar { background-color: #313131; }
+
+separator.sidebar:backdrop { background-color: #2d2d2d; }
+
+separator.sidebar.selection-mode, .selection-mode separator.sidebar { background-color: #ececec; }
+
+/**************** File chooser * */
+row image.sidebar-icon { opacity: 0.7; }
+
+placessidebar > viewport.frame { border-style: none; background-color: transparent; }
+
+placessidebar undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+placessidebar list { padding-top: 0; }
+
+placessidebar row { min-height: 36px; padding: 0px; margin-top: 0; margin-bottom: 0; }
+
+placessidebar row:first-child { margin-top: 0; }
+
+placessidebar row > revealer { padding: 0 8px; }
+
+placessidebar row:selected { color: #191919; }
+
+placessidebar row:disabled { color: #909090; }
+
+placessidebar row:backdrop { color: #8d8d8d; }
+
+placessidebar row:backdrop:selected { color: #151515; }
+
+placessidebar row:backdrop:disabled { color: #414141; }
+
+placessidebar row image.sidebar-icon:dir(ltr) { padding-right: 8px; }
+
+placessidebar row image.sidebar-icon:dir(rtl) { padding-left: 8px; }
+
+placessidebar row label.sidebar-label:dir(ltr) { padding-right: 2px; }
+
+placessidebar row label.sidebar-label:dir(rtl) { padding-left: 2px; }
+
+button.sidebar-button { min-height: 26px; min-width: 26px; margin: 0; padding: 0; border-radius: 100%; -gtk-outline-radius: 100%; }
+
+button.sidebar-button:not(:hover):not(:active) > image, button.sidebar-button:backdrop > image { opacity: 0.7; }
+
+placessidebar row:selected:active { box-shadow: none; }
+
+placessidebar row.sidebar-placeholder-row { padding: 0 8px; min-height: 2px; background-image: image(#4cd9a4); background-clip: content-box; }
+
+placessidebar row.sidebar-new-bookmark-row { color: #ffffff; }
+
+placessidebar row:drop(active):not(:disabled) { color: #4cd9a4; box-shadow: inset 0 0 0 2px #4cd9a4; }
+
+placessidebar row:drop(active):not(:disabled):selected { color: #191919; background-color: #4cd9a4; }
+
+placesview list { background-color: #202020; border-radius: 0 0 10px 0; }
+
+placesview list:backdrop { background-color: #1b1b1b; }
+
+placesview .server-list-button > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(0turn); }
+
+placesview .server-list-button:checked > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(-0.5turn); }
+
+placesview row.activatable:hover { background-color: transparent; }
+
+placesview > actionbar > revealer > box > label { padding-left: 8px; padding-right: 8px; }
+
+/********* Paned * */
+paned > separator { min-width: 1px; min-height: 1px; -gtk-icon-source: none; border-style: none; background-color: transparent; background-image: image(#313131); background-size: 1px 1px; }
+
+paned > separator:selected { background-image: image(#ffffff); }
+
+paned > separator:backdrop { background-image: image(#2d2d2d); }
+
+paned > separator.wide { min-width: 5px; min-height: 5px; background-color: #202020; background-image: image(#313131), image(#313131); background-size: 1px 1px, 1px 1px; }
+
+paned > separator.wide:backdrop { background-color: #1b1b1b; background-image: image(#2d2d2d), image(#2d2d2d); }
+
+paned.horizontal > separator { background-repeat: repeat-y; }
+
+paned.horizontal > separator:dir(ltr) { margin: 0 -8px 0 0; padding: 0 8px 0 0; background-position: left; }
+
+paned.horizontal > separator:dir(rtl) { margin: 0 0 0 -8px; padding: 0 0 0 8px; background-position: right; }
+
+paned.horizontal > separator.wide { margin: 0; padding: 0; background-repeat: repeat-y, repeat-y; background-position: left, right; }
+
+paned.vertical > separator { margin: 0 0 -8px 0; padding: 0 0 8px 0; background-repeat: repeat-x; background-position: top; }
+
+paned.vertical > separator.wide { margin: 0; padding: 0; background-repeat: repeat-x, repeat-x; background-position: bottom, top; }
+
+/************** GtkInfoBar * */
+infobar { border-style: none; }
+
+infobar.action:hover > revealer > box { background-color: #2c1d17; border-bottom: 1px solid #202020; }
+
+infobar.info, infobar.question, infobar.warning, infobar.error { text-shadow: none; }
+
+infobar.info:backdrop > revealer > box, infobar.info > revealer > box, infobar.question:backdrop > revealer > box, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box, infobar.error > revealer > box { background-color: #32211a; border-bottom: 1px solid #202020; }
+
+infobar.info:backdrop > revealer > box label, infobar.info:backdrop > revealer > box, infobar.info > revealer > box label, infobar.info > revealer > box, infobar.question:backdrop > revealer > box label, infobar.question:backdrop > revealer > box, infobar.question > revealer > box label, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box label, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box label, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box label, infobar.error:backdrop > revealer > box, infobar.error > revealer > box label, infobar.error > revealer > box { color: #faa483; }
+
+infobar.info:backdrop, infobar.question:backdrop, infobar.warning:backdrop, infobar.error:backdrop { text-shadow: none; }
+
+infobar.info button, infobar.question button, infobar.warning button, infobar.error button { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #412b22; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #50352a; background-image: none; }
+
+infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #5a3b2f; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #6e483a 10%, transparent 0%); background-size: 0% 0%; }
+
+infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; background: image(#ffffff); box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); }
+
+infobar.info button:checked:active, infobar.question button:checked:active, infobar.warning button:checked:active, infobar.error button:checked:active { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); }
+
+infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled { color: #909090; background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop, infobar.question button:backdrop, infobar.warning button:backdrop, infobar.error button:backdrop { background-color: #242424; background-image: none; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.error button:backdrop label, infobar.error button:backdrop { color: #8d8d8d; }
+
+infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop:disabled label, infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled label, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled label, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled label, infobar.error button:backdrop:disabled { color: #414141; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.info button label, infobar.info button, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.question button label, infobar.question button, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.warning button label, infobar.warning button, infobar.error button:backdrop label, infobar.error button:backdrop, infobar.error button label, infobar.error button { color: #faa483; }
+
+infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection { background-color: #070707; }
+
+infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link { color: white; }
+
+/************ Tooltips * */
+tooltip { padding: 4px; /* not working */ border-radius: 10px; box-shadow: none; }
+
+tooltip.background, tooltip.background.csd { border-radius: 10px; background-color: rgba(0, 0, 0, 0.8); background-clip: padding-box; border: 1px solid rgba(255, 255, 255, 0.1); }
+
+tooltip decoration { background-color: transparent; }
+
+tooltip * { padding: 4px; background-color: transparent; color: white; }
+
+/***************** Color Chooser * */
+colorswatch:drop(active), colorswatch { border-style: none; }
+
+colorswatch.top { border-top-left-radius: 8.5px; border-top-right-radius: 8.5px; }
+
+colorswatch.top overlay { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+colorswatch.bottom { border-bottom-left-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.bottom overlay { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.left, colorswatch:first-child:not(.top) { border-top-left-radius: 8.5px; border-bottom-left-radius: 8.5px; }
+
+colorswatch.left overlay, colorswatch:first-child:not(.top) overlay { border-top-left-radius: 8px; border-bottom-left-radius: 8px; }
+
+colorswatch.right, colorswatch:last-child:not(.bottom) { border-top-right-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.right overlay, colorswatch:last-child:not(.bottom) overlay { border-top-right-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.dark { outline-color: rgba(255, 255, 255, 0.6); }
+
+colorswatch.dark overlay { color: white; }
+
+colorswatch.dark overlay:backdrop { color: rgba(255, 255, 255, 0.5); }
+
+colorswatch.light { outline-color: rgba(0, 0, 0, 0.6); }
+
+colorswatch.light overlay { color: black; }
+
+colorswatch.light overlay:backdrop { color: rgba(0, 0, 0, 0.5); }
+
+colorswatch:drop(active) { box-shadow: none; }
+
+colorswatch:drop(active).light overlay { border-color: #4cd9a4; }
+
+colorswatch:drop(active).dark overlay { border-color: #4cd9a4; }
+
+colorswatch overlay { border: 1px solid transparent; }
+
+colorswatch#add-color-button { border-radius: 8px 8px 0 0; }
+
+colorswatch#add-color-button:only-child { border-radius: 8px; }
+
+colorswatch#add-color-button overlay { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #313131; background-image: none; }
+
+colorswatch#add-color-button overlay:hover { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-color: #414141; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop { background-color: #242424; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop label, colorswatch#add-color-button overlay:backdrop { color: #8d8d8d; }
+
+colorswatch:disabled { opacity: 0.5; }
+
+colorswatch:disabled overlay { border-color: rgba(0, 0, 0, 0.6); box-shadow: none; }
+
+row:selected colorswatch { box-shadow: 0 0 0 2px #191919; }
+
+colorswatch#editor-color-sample { border-radius: 8px; }
+
+colorswatch#editor-color-sample overlay { border-radius: 8.5px; }
+
+colorchooser .popover.osd { border-radius: 8px; }
+
+/******** Misc * */
+.content-view { background-color: #1a1a1a; }
+
+.content-view:hover { -gtk-icon-effect: highlight; }
+
+.content-view:backdrop { background-color: #151515; }
+
+.osd .scale-popup button.flat { border-style: none; border-radius: 8px; }
+
+.scale-popup button:hover { background-color: rgba(255, 255, 255, 0.15); border-radius: 8px; }
+
+/********************** Window Decorations * */
+decoration { border-radius: 10px; border-width: 0px; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.1); margin: 10px; }
+
+decoration:backdrop { box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(141, 141, 141, 0.125); transition: 150ms ease-out; }
+
+.maximized decoration, .fullscreen decoration, .tiled decoration, .tiled-top decoration, .tiled-right decoration, .tiled-bottom decoration, .tiled-left decoration { border-radius: 0; }
+
+.popup decoration { box-shadow: none; }
+
+.ssd decoration { box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1); }
+
+.csd.popup decoration { border-radius: 8px; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.1); }
+
+.csd.popup decoration:backdrop { box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(141, 141, 141, 0.125); }
+
+tooltip.csd decoration { border-radius: 10px; box-shadow: none; }
+
+messagedialog.csd decoration { border-radius: 10px; box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.1); }
+
+messagedialog.csd decoration:backdrop { box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(141, 141, 141, 0.125); }
+
+.solid-csd decoration { margin: 0; padding: 4px; background-color: #313131; border: solid 1px #313131; border-radius: 0; box-shadow: none; }
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized), window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration, window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration-overlay { border-radius: 10px; }
+
+button.titlebutton:not(.appmenu) { border-radius: 9999px; padding: 6px; margin: 0 2px; min-width: 0; min-height: 0; }
+
+button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.selection-mode headerbar button.titlebutton:backdrop, .selection-mode .titlebar button.titlebutton:backdrop, headerbar.selection-mode button.titlebutton:backdrop, .titlebar.selection-mode button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { background-color: #ffffff; }
+
+.selection-mode button.titlebutton, .view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { color: #191919; }
+
+.selection-mode button.titlebutton:disabled, .view:disabled:selected, textview text:disabled:selected:focus, .view text:disabled:selected, textview text:disabled:selected, iconview:disabled:selected:focus, iconview:disabled:selected, flowbox flowboxchild:disabled:selected, modelbutton.flat:disabled:selected, .menuitem.button.flat:disabled:selected, treeview.view:disabled:selected, row:disabled:selected, calendar:disabled:selected { color: #8c8c8c; }
+
+.selection-mode button.titlebutton:backdrop, .view:backdrop:selected, textview text:backdrop:selected:focus, .view text:backdrop:selected, textview text:backdrop:selected, iconview:backdrop:selected:focus, iconview:backdrop:selected, flowbox flowboxchild:backdrop:selected, modelbutton.flat:backdrop:selected, .menuitem.button.flat:backdrop:selected, treeview.view:backdrop:selected, row:backdrop:selected, calendar:backdrop:selected { color: #151515; background-color: #a4a4a4; }
+
+.selection-mode button.titlebutton:backdrop:disabled, .view:backdrop:disabled:selected, .view text:backdrop:disabled:selected, textview text:backdrop:disabled:selected, iconview:backdrop:disabled:selected, flowbox flowboxchild:backdrop:disabled:selected, modelbutton.flat:backdrop:disabled:selected, .menuitem.button.flat:backdrop:disabled:selected, row:backdrop:disabled:selected, calendar:backdrop:disabled:selected { color: #b9b9b9; }
+
+.view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { background-color: #525252; }
+
+label:selected, .view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { color: white; }
+
+label:disabled selection, label:disabled:selected, .view text selection:disabled, textview text selection:disabled:focus, textview text selection:disabled, iconview text selection:disabled:focus, iconview text selection:disabled, label selection:disabled, entry selection:disabled, spinbutton:not(.vertical) selection:disabled { color: #9b9b9b; }
+
+label:backdrop selection, label:backdrop:selected, .view text selection:backdrop, textview text selection:backdrop:focus, textview text selection:backdrop, iconview text selection:backdrop:focus, iconview text selection:backdrop, label selection:backdrop, entry selection:backdrop, spinbutton:not(.vertical) selection:backdrop { background-color: #3a3a3a; color: #8f8f8f; }
+
+label:backdrop selection:disabled, label:backdrop:disabled:selected, .view text selection:backdrop:disabled, textview text selection:backdrop:disabled, iconview text selection:backdrop:disabled, label selection:backdrop:disabled, entry selection:backdrop:disabled, spinbutton:not(.vertical) selection:backdrop:disabled { color: #4b4b4b; }
+
+.monospace { font-family: monospace; }
+
+/********************** Touch Copy & Paste * */
+cursor-handle { background-color: transparent; background-image: none; box-shadow: none; border-style: none; color: #ffffff; }
+
+cursor-handle:hover { color: white; }
+
+cursor-handle:active { color: #ffffff; }
+
+cursor-handle.top:dir(ltr), cursor-handle.bottom:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-start-symbolic.svg")), -gtk-recolor(url("assets/text-select-start-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.bottom:dir(ltr), cursor-handle.top:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-end-symbolic.svg")), -gtk-recolor(url("assets/text-select-end-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); }
+
+.context-menu { font: initial; }
+
+.keycap { min-width: 20px; min-height: 25px; margin-top: 2px; padding-bottom: 3px; padding-left: 6px; padding-right: 6px; color: #ffffff; background-color: #191919; border: 1px solid; border-color: #313131; border-radius: 4px; box-shadow: inset 0 -3px #272727; font-size: smaller; }
+
+.keycap:backdrop { background-color: #151515; color: #8d8d8d; transition: 150ms ease-out; }
+
+:not(decoration):not(window):drop(active):focus, :not(decoration):not(window):drop(active) { border-color: #4cd9a4; box-shadow: inset 0 0 0 1px #4cd9a4; caret-color: #4cd9a4; }
+
+stackswitcher button.text-button { min-width: 100px; }
+
+stackswitcher button.circular, stackswitcher button.text-button.circular { min-width: 32px; min-height: 32px; padding: 0; }
+
+/************* App Icons * */
+/* Outline for low res icons */
+.lowres-icon { -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/* Dropshadow for large icons */
+.icon-dropshadow { -gtk-icon-shadow: 0 1px 12px rgba(0, 0, 0, 0.05), 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/********* Emoji * */
+popover.emoji-picker { padding-left: 0; padding-right: 0; }
+
+popover.emoji-picker entry.search { margin: 3px 5px 5px 5px; }
+
+button.emoji-section { border-color: transparent; border-width: 3px; border-style: none none solid; border-radius: 0; margin: 2px 4px 2px 4px; padding: 3px 0 0; min-width: 32px; min-height: 28px; /* reset props inherited from the button style */ background: none; box-shadow: none; text-shadow: none; outline-offset: -5px; }
+
+button.emoji-section:first-child { margin-left: 7px; }
+
+button.emoji-section:last-child { margin-right: 7px; }
+
+button.emoji-section:backdrop:not(:checked) { border-color: transparent; }
+
+button.emoji-section:hover { border-color: #313131; }
+
+button.emoji-section:checked { color: #ffffff; border-color: #ffffff; }
+
+button.emoji-section:checked:backdrop { color: #8d8d8d; background-color: transparent; }
+
+button.emoji-section label { padding: 0; opacity: 0.55; }
+
+button.emoji-section:hover label { opacity: 0.775; }
+
+button.emoji-section:checked label { opacity: 1; }
+
+popover.emoji-picker .emoji { font-size: x-large; padding: 6px; }
+
+popover.emoji-picker .emoji :hover { background: #ffffff; border-radius: 8px; }
+
+popover.emoji-completion arrow { border: none; background: none; }
+
+popover.emoji-completion contents row box { padding: 2px 10px; }
+
+popover.emoji-completion .emoji:hover { background: #313131; }
+
+/***************** View Switcher * */
+viewswitcher button { margin: 0; padding: 0; border-radius: 0; border: none; box-shadow: none; }
+
+viewswitcher button:checked { box-shadow: none; }
+
+viewswitcher button stack > box.narrow { font-size: smaller; padding-top: 6px; padding-bottom: 6px; }
+
+viewswitcher button stack > box.narrow image, viewswitcher button stack > box.narrow label { padding-left: 6px; padding-right: 6px; }
+
+viewswitcher button stack > box.wide { padding: 0 12px; }
+
+viewswitcherbar > actionbar > revealer > box { padding: 0; }
+
+viewswitcherbar > actionbar > revealer > box viewswitcher button:not(:checked):not(:hover) { background: transparent; }
+
+headerbar viewswitcher > box > button:first-child { border-bottom-left-radius: 8px; }
+
+headerbar viewswitcher > box > button:last-child { border-bottom-right-radius: 8px; }
+
+/*********** Chromium * */
+window.background.chromium { background-color: #191919; }
+
+window.background.chromium headerbar.titlebar button.toggle, window.background.chromium headerbar.titlebar button.titlebutton { border: none; }
+
+window.background.chromium headerbar.titlebar button.titlebutton { background-image: none; }
+
+window.background.chromium button { border-style: solid; border-width: 1px; border-color: #313131; }
+
+window.background.chromium > textview.view { background-color: #202020; }
+
+/*********** Firefox * */
+#MozillaGtkWidget.background { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+
+#MozillaGtkWidget.background scrollbar { background-color: transparent; border-color: transparent; }
+
+/****************** Gnome Calendar * */
+window.background.csd.org-gnome-Calendar > overlay > box.vertical > stack.view { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > button.text-button { margin: 0; border-bottom-right-radius: 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > stack > .sidebar.vertical { border-radius: 0; }
+
+window.background.csd.org-gnome-Calendar.maximized calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.tiled calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.fullscreen calendar-view.year-view > box.vertical > button.text-button { border-bottom-right-radius: 0; }
+
+/*************** LibreOffice * */
+toolbutton > button.image-button.text-button.flat button { background-color: transparent; background-image: none; background-image: none; }
+
+toolbutton > button.image-button.text-button.flat button:hover { background-color: #313131; }
+
+toolbutton > button.image-button.text-button.flat button:active, toolbutton > button.image-button.text-button.flat button:checked { background-color: #414141; box-shadow: none; }
+
+window.background:not(.solid-csd) > notebook:not(.frame) tab { margin-bottom: 4px; }
+
+/************ Nautilus * */
+.nautilus-window .floating-bar { min-height: 32px; padding: 0; border-radius: 10px 10px 0 0; background-color: #191919; background-clip: padding-box; }
+
+.nautilus-window .floating-bar.bottom.left { margin-right: 7px; border-top-left-radius: 0; border-bottom-left-radius: 10px; }
+
+.nautilus-window .floating-bar.bottom.right { margin-left: 7px; border-top-right-radius: 0; border-bottom-right-radius: 10px; }
+
+.nautilus-window .floating-bar button { padding: 0; }
+
+.nautilus-window .nautilus-list-view { background-color: #191919; border-radius: 0 0 10px 10px; }
+
+.nautilus-window .nautilus-list-view treeview.view:not(:hover):not(:active):not(:selected) { background-color: transparent; border-radius: 0; }
+
+.nautilus-window.maximized .floating-bar, .nautilus-window.maximized .nautilus-list-view, .nautilus-window.tiled .floating-bar, .nautilus-window.tiled .nautilus-list-view, .nautilus-window.fullscreen .floating-bar, .nautilus-window.fullscreen .nautilus-list-view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.nautilus-window headerbar .path-bar-box { color: transparent; background: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; background: image(#ffffff); box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child:active { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { background-color: #a4a4a4; background-image: none; box-shadow: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child label, .nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { color: #151515; }
+
+.nautilus-window notebook > header.top:dir(ltr) { border-top-left-radius: 0; }
+
+.nautilus-window notebook > header.top:dir(rtl) { border-top-right-radius: 0; }
+
+.nautilus-canvas-item { border-radius: 8px; }
+
+.nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator, headerbar .nautilus-canvas-item.subtitle, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle, popover.background label.nautilus-canvas-item.separator, .nautilus-list-dim-label { color: #9b9b9b; }
+
+.nautilus-canvas-item.dim-label:backdrop, label.nautilus-canvas-item.separator:backdrop, headerbar .nautilus-canvas-item.subtitle:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:backdrop, popover.background label.nautilus-canvas-item.separator:backdrop, .nautilus-list-dim-label:backdrop { color: #5a5a5a; }
+
+.nautilus-canvas-item.dim-label:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected, label.nautilus-canvas-item.separator:selected:focus, headerbar .nautilus-canvas-item.subtitle:selected, headerbar .nautilus-canvas-item.subtitle:selected:focus, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus, popover.background label.nautilus-canvas-item.separator:selected, popover.background label.nautilus-canvas-item.separator:selected:focus, .nautilus-list-dim-label:selected, .nautilus-list-dim-label:selected:focus { color: rgba(25, 25, 25, 0.45); }
+
+.nautilus-canvas-item.dim-label:selected:backdrop, .nautilus-canvas-item.dim-label:selected:focus:backdrop, label.nautilus-canvas-item.separator:selected:backdrop, label.nautilus-canvas-item.separator:selected:focus:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:focus:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus:backdrop, popover.background label.nautilus-canvas-item.separator:selected:backdrop, popover.background label.nautilus-canvas-item.separator:selected:focus:backdrop, .nautilus-list-dim-label:selected:backdrop, .nautilus-list-dim-label:selected:focus:backdrop { color: rgba(21, 21, 21, 0.45); }
+
+.disk-space-display.unknown { background-color: rgba(255, 255, 255, 0.4); color: rgba(255, 255, 255, 0.4); }
+
+.disk-space-display.used { background-color: #ffffff; color: #ffffff; }
+
+.disk-space-display.free { background-color: rgba(255, 255, 255, 0.1); color: rgba(255, 255, 255, 0.1); }
+
+dialog > box > grid > scrolledwindow > viewport > box > list { padding: 0; background-color: transparent; border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list:backdrop { background-color: transparent; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list > row { border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list separator.horizontal { margin: 0; }
+
+/**************************************************** documents-scrolledwin (Totem, Documents, EvView) * */
+.documents-scrolledwin:backdrop, .documents-scrolledwin { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover), .documents-scrolledwin .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin .content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:hover, .documents-scrolledwin .content-view:hover { background-color: rgba(255, 255, 255, 0.075); }
+
+.documents-scrolledwin:backdrop viewport.frame, .documents-scrolledwin viewport.frame { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover), .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover) border, .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) border { border: none; }
+
+/******************* Document Viewer * */
+window.background.csd > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { background-color: transparent; border-radius: 10px; }
+
+window.background.csd > box.vertical > paned.horizontal > box.vertical > scrolledwindow > treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+window.background.csd evview.view.content-view { background-color: transparent; border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.maximized > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { border-radius: 0; }
+
+window.background.csd.maximized evview.view.content-view, window.background.csd.tiled evview.view.content-view, window.background.csd.fullscreen evview.view.content-view { border-radius: 0; }
+
+/******************* Archive Manager * */
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow { border-radius: 0 0 10px 10px; background-color: #191919; }
+
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-radius: 0 0 0 10px; background-color: #202020; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/********* Geary * */
+frame.geary-conversation-frame scrolledwindow treeview.view:not(:selected) { background: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected { color: #191919; outline-color: rgba(25, 25, 25, 0.3); background-color: #ffffff; background: image(#ffffff); box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2); box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { background-color: #a4a4a4; background-image: none; box-shadow: none; box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop label, frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { color: #151515; }
+
+.geary_email { padding-bottom: 6px; border-radius: 8px; }
+
+.geary_email .geary-message { border-radius: 8px; }
+
+.geary-attachment-pane > separator.horizontal { margin: 0; }
+
+.geary-attachment-pane flowboxchild { border-radius: 8px; }
+
+.geary-attachment-pane > actionbar { background-color: #191919; }
+
+.geary-attachment-pane > actionbar:backdrop { background-color: #151515; }
+
+/********* Gedit * */
+window.org-gnome-gedit stack scrolledwindow viewport.frame list.gedit-document-panel { background-color: transparent; }
+
+window.org-gnome-gedit .gedit-search-entry-occurrences-tag { border: none; box-shadow: none; margin: 2px; padding: 2px; }
+
+/******************** Gnome Calculator * */
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list { padding: 0; border-radius: 0; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry { margin: 0; border-radius: 0; background-color: #202020; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry:backdrop { background-color: #1b1b1b; }
+
+grid > viewport > box > scrolledwindow.display-scrolled > .sourceview.view > text, grid > viewport > box > scrolledwindow.display-scrolled > iconview.sourceview > text { border-radius: 10px 10px 0 0; }
+
+grid > viewport > box box > textview.view.info-view > text { border-radius: 0 0 10px 10px; }
+
+/************************ Gnome Control Center * */
+window.background.csd > leaflet > stack.background, window.background.csd > hdyleaflet > stack.background, window.background.csd > box.horizontal > stack.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-left-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+window.background.csd.maximized > leaflet > stack.background, window.background.csd.maximized > hdyleaflet > stack.background, window.background.csd.maximized > box.horizontal > stack.background, window.background.csd.maximized > leaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.tiled > leaflet > stack.background, window.background.csd.tiled > hdyleaflet > stack.background, window.background.csd.tiled > box.horizontal > stack.background, window.background.csd.tiled > leaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > leaflet > stack.background, window.background.csd.fullscreen > hdyleaflet > stack.background, window.background.csd.fullscreen > box.horizontal > stack.background, window.background.csd.fullscreen > leaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+window.background.csd > leaflet > stack.background > widget > box > box > scrolledwindow > viewport.frame > box.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+/************** Gnome Maps * */
+popover.maps-popover > grid > button.radio.layer-radio-button { border-radius: 4px; color: transparent; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:active { color: #ffffff; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:checked { color: #ffffff; }
+
+/*************** Gnome Music * */
+window.background.csd > box.vertical > overlay > stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > overlay > stack.background, window.background.csd.tiled > box.vertical > overlay > stack.background, window.background.csd.fullscreen > box.vertical > overlay > stack.background { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/****************** Gnome Software * */
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal { border-radius: 8px; background-color: #191919; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal:backdrop { background-color: #151515; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal list.app-updates-section { border: none; border-radius: 10px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software { padding-top: 2px; padding-bottom: 2px; margin: 4px 2px; min-height: 24px; min-width: 54px; border-radius: 8px; -gtk-outline-radius: 8px; background-color: transparent; color: #d1d1d1; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(ltr) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(rtl) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(ltr) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(rtl) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:hover { color: #ffffff; background-color: rgba(255, 255, 255, 0.05); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:checked { color: #ffffff; outline-color: rgba(255, 255, 255, 0.3); background-image: none; background-color: #414141; box-shadow: 0 2px 4px rgba(25, 25, 25, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop { color: #8d8d8d; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:hover { background-color: transparent; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { background-image: none; background-color: #2c2c2c; box-shadow: 0 1px 2px rgba(21, 21, 21, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked label, window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { color: #8d8d8d; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal button:checked + button { border-image: none; }
+
+window.background.csd button.text-button.content-rating { color: #191919; }
+
+window.background.csd button.text-button.content-rating:backdrop { color: #151515; }
+
+/****************** Gnome Terminal * */
+terminal-window.background.csd { border-radius: 0; }
+
+terminal-window decoration { background-color: #202020; border-radius: 10px 10px 0 0; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(255, 255, 255, 0.1), 0 0 0 1px #202020; }
+
+terminal-window decoration:backdrop { background-color: #1b1b1b; box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(141, 141, 141, 0.125), 0 0 0 1px #1b1b1b; }
+
+terminal-window .terminal-screen { background-color: #202020; color: #ffffff; }
+
+terminal-window .terminal-screen:backdrop { background-color: #1b1b1b; color: #8d8d8d; }
+
+/*************** Gnome Todo * */
+window.background.csd.org-gnome-Todo > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Todo.maximized > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.maximized stack.background, window.background.csd.org-gnome-Todo.tiled > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.tiled stack.background, window.background.csd.org-gnome-Todo.fullscreen > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.fullscreen stack.background { border-radius: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row { box-shadow: none; padding: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row entry, window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row button { margin: 0; border-radius: 2.5px; }
+
+/**************** Gnome Tweaks * */
+hdyleaflet list.tweak-categories, leaflet list.tweak-categories { background-color: transparent; }
+
+hdyleaflet list.tweak-categories > separator, leaflet list.tweak-categories > separator { background-color: transparent; min-height: 0; }
+
+row#AutostartTitle.tweak { padding: 8px 8px 0 8px; }
+
+.tweak-group-startup { background-color: #191919; }
+
+.tweak-group-startup:backdrop { background-color: #151515; }
+
+/***************** Gnome Weather * */
+#weather-page, #weekly-forecast-frame { border-bottom-right-radius: 10px; }
+
+#weather-page-content-view { border-bottom-right-radius: 10px; border-bottom-left-radius: 10px; }
+
+/************ Ubiquity * */
+#live_installer #stepPartAuto #partition_container #resizewidget separator { background-image: none; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > * { background-color: transparent; border-radius: 0; border-color: #313131; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > *:backdrop { border-color: #2d2d2d; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box { background-color: #191919; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box:backdrop { background-color: #151515; }
+
+/******************** Zorin Appearance * */
+stacksidebar.sidebar > scrolledwindow > viewport.frame > list { border-radius: 0; }
+
+/********** Thunar * */
+.thunar .sidebar.frame { border: none; }
+
+.thunar .sidebar .view, .thunar .sidebar iconview { background-color: #202020; border: none; }
+
+.thunar .sidebar .view:selected, .thunar .sidebar iconview:selected { background-color: #414141; color: #ffffff; }
+
+.thunar .sidebar .view:backdrop, .thunar .sidebar iconview:backdrop { background-color: #1b1b1b; }
+
+.thunar .sidebar .view:backdrop:selected, .thunar .sidebar iconview:backdrop:selected { background-color: #2c2c2c; color: #8d8d8d; }
+
+.thunar .standard-view > .view, .thunar .standard-view > iconview { border-radius: 0; }
+
+/*********************** LightDM Gtk Greeter * */
+.lightdm-gtk-greeter #panel_window { border-radius: 0; border: none; background-color: #202020; }
+
+.lightdm-gtk-greeter #panel_window menubar { font-weight: bold; }
+
+.lightdm-gtk-greeter #panel_window menubar menu menuitem { font-weight: normal; }
+
+.lightdm-gtk-greeter #buttonbox_frame { padding-top: 20px; }
+
+.lightdm-gtk-greeter #login_window, .lightdm-gtk-greeter #shutdown_dialog, .lightdm-gtk-greeter #restart_dialog { border-style: none; border-radius: 10px; background-color: #202020; color: #ffffff; box-shadow: none; }
+
+.lightdm-gtk-greeter #login_window menu { border-radius: 0; }
+
+/******** XFCE * */
+.xfce4-panel.background { background-color: #191919; }
+
+.xfce4-panel.background button { border-radius: 0; margin: 0; font-weight: bold; }
+
+.xfce4-panel.background button menuitem { font-weight: normal; }
+
+.xfce4-panel.background button:hover { background-color: #313131; }
+
+.xfce4-panel.background button:active, .xfce4-panel.background button:checked { color: #ffffff; background-color: #414141; background-image: none; }
+
+.xfce4-panel.background button.flat image, .xfce4-panel.background button.image-button image { -gtk-icon-transform: scale(1); transition: none; }
+
+.xfce4-panel.background button.flat:active image, .xfce4-panel.background button.image-button:active image { -gtk-icon-transform: scale(1); }
+
+.tasklist button.toggle { background-color: transparent; border-top-width: 0; border-bottom-width: 0; }
+
+.tasklist button.toggle:checked { background: none; box-shadow: inset 0 -3px #ffffff; }
+
+wnck-pager { background-color: #2a2a2a; }
+
+wnck-pager:hover { background-color: #3c3c3c; }
+
+wnck-pager:selected { background-color: #474747; }
+
+XfdesktopIconView.view { background: transparent; color: white; }
+
+XfdesktopIconView.view:active { background: #ffffff; color: #191919; text-shadow: none; }
+
+XfdesktopIconView.view .label { text-shadow: 1px 1px 2px black; }
+
+#XfceNotifyWindow { background-color: #191919; border: none; box-shadow: inset 0 0 0 1px rgba(49, 49, 49, 0.75); border-radius: 10px; }
+
+#XfceNotifyWindow label#summary { font-weight: bold; }
+
+#XfceNotifyWindow progressbar progress { animation: none; background-image: none; background: image(#ffffff); }
+
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin { border-radius: 10px; }
+
+/* GTK NAMED COLORS ---------------- use responsibly! */
+/*
+widget text/foreground color */
+@define-color theme_fg_color #ffffff;
+/*
+text color for entries, views and content in general */
+@define-color theme_text_color #ffffff;
+/*
+widget base background color */
+@define-color theme_bg_color #202020;
+/*
+text widgets and the like base background color */
+@define-color theme_base_color #191919;
+/*
+base background color of selections */
+@define-color theme_selected_bg_color #e9e9e9;
+/* Tinting in dark variant to avoid a white selection on white page background when highlighting text in Evince when using Grey-Dark theme */
+/*
+text/foreground color of selections */
+@define-color theme_selected_fg_color #191919;
+/*
+base background color of insensitive widgets */
+@define-color insensitive_bg_color #202020;
+/*
+text foreground color of insensitive widgets */
+@define-color insensitive_fg_color #909090;
+/*
+insensitive text widgets and the like base background color */
+@define-color insensitive_base_color #191919;
+/*
+widget text/foreground color on backdrop windows */
+@define-color theme_unfocused_fg_color #8d8d8d;
+/*
+text color for entries, views and content in general on backdrop windows */
+@define-color theme_unfocused_text_color #ffffff;
+/*
+widget base background color on backdrop windows */
+@define-color theme_unfocused_bg_color #1b1b1b;
+/*
+text widgets and the like base background color on backdrop windows */
+@define-color theme_unfocused_base_color #151515;
+/*
+base background color of selections on backdrop windows */
+@define-color theme_unfocused_selected_bg_color #ffffff;
+/*
+text/foreground color of selections on backdrop windows */
+@define-color theme_unfocused_selected_fg_color #191919;
+/*
+insensitive color on backdrop windows*/
+@define-color unfocused_insensitive_color #414141;
+/*
+widgets main borders color */
+@define-color borders #313131;
+/*
+widgets main borders color on backdrop windows */
+@define-color unfocused_borders #2d2d2d;
+/*
+these are pretty self explicative */
+@define-color placeholder_text_color #8c8c8c;
+@define-color warning_color #faa483;
+@define-color error_color #fb7c7c;
+@define-color success_color #6ee1b6;
+/*
+these colors are exported for the window manager and shouldn't be used in applications,
+read if you used those and something break with a version upgrade you're on your own... */
+@define-color wm_title shade(#ffffff, 1.8);
+@define-color wm_unfocused_title #8d8d8d;
+@define-color wm_highlight transparent;
+@define-color wm_borders_edge rgba(255, 255, 255, 0.07);
+@define-color wm_bg_a shade(#202020, 1.2);
+@define-color wm_bg_b #202020;
+@define-color wm_shadow alpha(black, 0.35);
+@define-color wm_border alpha(black, 0.18);
+@define-color wm_button_hover_color_a shade(#202020, 1.3);
+@define-color wm_button_hover_color_b #202020;
+@define-color wm_button_active_color_a shade(#202020, 0.85);
+@define-color wm_button_active_color_b shade(#202020, 0.89);
+@define-color wm_button_active_color_c shade(#202020, 0.9);
+/* content view background such as thumbnails view in Photos or Boxes */
+@define-color content_view_bg #191919;
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #191919;

--- a/ZorinOrange-Dark/gtk-3.0/gtk-dark.css
+++ b/ZorinOrange-Dark/gtk-3.0/gtk-dark.css
@@ -1,0 +1,2308 @@
+/*************************** Check and Radio buttons * */
+@keyframes ripple_effect { to { background-size: 1000% 1000%; } }
+
+* { padding: 0; -GtkToolButton-icon-spacing: 4; -GtkTextView-error-underline-color: #fb7c7c; -GtkScrolledWindow-scrollbar-spacing: 0; -GtkToolItemGroup-expander-size: 11; -GtkWidget-text-handle-width: 20; -GtkWidget-text-handle-height: 24; -GtkDialog-button-spacing: 4; -GtkDialog-action-area-border: 0; outline-color: alpha(currentColor,0.3); outline-style: dashed; outline-offset: -3px; outline-width: 1px; -gtk-outline-radius: 8px; -gtk-secondary-caret-color: #fcc8b4; }
+
+/*************** Base States * */
+.background { color: #fcc8b4; background-color: #271e1b; }
+
+.background.csd { border-radius: 0 0 10px 10px; }
+
+.background.maximized, .background.solid-csd, .background.fullscreen, .background.tiled, .background.tiled-top, .background.tiled-right, .background.tiled-bottom, .background.tiled-left { border-radius: 0; }
+
+.background:backdrop { color: #8a736a; background-color: #201a18; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* These wildcard seems unavoidable, need to investigate. Wildcards are bad and troublesome, use them with care, or better, just don't. Everytime a wildcard is used a kitten dies, painfully. */
+*:disabled { -gtk-icon-effect: dim; }
+
+.gtkstyle-fallback { color: #fcc8b4; background-color: #271e1b; }
+
+.gtkstyle-fallback:hover { color: #fcc8b4; background-color: #453630; }
+
+.gtkstyle-fallback:active { color: #fcc8b4; background-color: #090706; }
+
+.gtkstyle-fallback:disabled { color: #927367; background-color: #271e1b; }
+
+.gtkstyle-fallback:selected { color: #1e1715; background-color: #fcc8b4; }
+
+.view, iconview, .view text, iconview text, textview text { color: #fcc8b4; background-color: #1e1715; border-radius: 10px; }
+
+.view:disabled, iconview:disabled, .view text:disabled, iconview text:disabled, textview text:disabled { color: #927367; background-color: #271e1b; }
+
+.view:backdrop, iconview:backdrop, .view text:backdrop, iconview text:backdrop, textview text:backdrop { color: #8a736a; background-color: #191413; }
+
+.view:backdrop:disabled, iconview:backdrop:disabled, .view text:backdrop:disabled, iconview text:backdrop:disabled, textview text:backdrop:disabled { color: #4c3e39; background-color: #201a18; }
+
+.view:selected:focus, iconview:selected:focus, .view:selected, iconview:selected, .view text:selected:focus, iconview text:selected:focus, textview text:selected:focus, .view text:selected, iconview text:selected, textview text:selected { border-radius: 8px; }
+
+.view.sourceview, iconview.sourceview, .view.sourceview > *, iconview.sourceview > *, textview.sourceview, textview.sourceview > * { border-radius: 0; }
+
+textview border { background-color: #231b18; }
+
+iconview { border-radius: 0 0 10px 10px; }
+
+iconview, iconview:hover, iconview:selected { border-radius: 8px; }
+
+.rubberband, rubberband, XfdesktopIconView.view .rubberband, .content-view rubberband, .content-view .rubberband, treeview.view rubberband, flowbox rubberband { border: 1px solid #faa483; background-color: rgba(250, 164, 131, 0.2); border-radius: 0; }
+
+flowbox flowboxchild { padding: 3px; }
+
+flowbox flowboxchild:selected { outline-offset: -2px; }
+
+.content-view .tile { margin: 2px; background-color: transparent; border-radius: 0; padding: 0; }
+
+label { caret-color: currentColor; }
+
+label:disabled { color: #927367; }
+
+button label:disabled { color: inherit; }
+
+label:disabled:backdrop { color: #4c3e39; }
+
+button label:disabled:backdrop { color: inherit; }
+
+label.error { color: #fb7c7c; }
+
+label.error:disabled { color: rgba(251, 124, 124, 0.5); }
+
+label.error:disabled:backdrop { color: rgba(251, 124, 124, 0.4); }
+
+.accent { color: #fcc8b4; }
+
+.dim-label, .titlebar:not(headerbar) .subtitle, headerbar .subtitle, label.separator { opacity: 0.55; text-shadow: none; }
+
+assistant .sidebar { background-color: #271e1b; border-top: 1px solid #372b26; }
+
+assistant .sidebar:backdrop { background-color: #201a18; border-color: #312824; }
+
+assistant.csd .sidebar { border-top-style: none; }
+
+assistant .sidebar label { padding: 6px 12px; }
+
+assistant .sidebar label.highlight { background-color: #52403a; }
+
+.osd .scale-popup, .app-notification, .app-notification.frame, .osd { border: none; background-color: #1e1715; background-clip: padding-box; border-radius: 8px; box-shadow: inset 0 0 0 1px rgba(55, 43, 38, 0.75); }
+
+.osd .scale-popup:backdrop, .app-notification:backdrop, .osd:backdrop { background-color: #191413; box-shadow: inset 0 0 0 1px rgba(49, 40, 36, 0.75); }
+
+.osd .scale-popup:disabled, .app-notification:disabled, .osd:disabled { box-shadow: none; }
+
+/********************* Spinner Animation * */
+@keyframes spin { to { -gtk-icon-transform: rotate(1turn); } }
+
+spinner { background: none; opacity: 0; -gtk-icon-source: -gtk-icontheme("process-working-symbolic"); }
+
+spinner:backdrop { color: #8a736a; }
+
+spinner:checked { opacity: 1; animation: spin 1s linear infinite; }
+
+spinner:checked:disabled { opacity: 0.5; }
+
+/********************** General Typography * */
+.large-title { font-weight: 300; font-size: 24pt; }
+
+.title-1, .h1 { font-weight: 800; font-size: 20pt; }
+
+.title-2, .h2 { font-weight: 800; font-size: 15pt; }
+
+.title-3, .h3 { font-weight: 700; font-size: 15pt; }
+
+.title-4, .h4 { font-weight: 700; font-size: 13pt; }
+
+.heading { font-weight: 700; font-size: 11pt; }
+
+.body { font-weight: 400; font-size: 11pt; }
+
+.caption-heading { font-weight: 700; font-size: 9pt; }
+
+.caption { font-weight: 400; font-size: 9pt; }
+
+.category-label { color: rgba(252, 200, 180, 0.8); font-weight: 700; }
+
+/**************** Text Entries * */
+spinbutton:not(.vertical), entry { min-height: 32px; padding-left: 8px; padding-right: 8px; margin: 1px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); color: #fcc8b4; background-color: #1e1715; box-shadow: inset 0 0 0 1px #372b26; }
+
+spinbutton:not(.vertical) image.left, entry image.left { margin-right: 6px; }
+
+spinbutton:not(.vertical) image.right, entry image.right { margin-left: 6px; }
+
+spinbutton.flat:not(.vertical), entry.flat:focus, entry.flat:backdrop, entry.flat:disabled, entry.flat { min-height: 0; padding: 2px; background-color: transparent; border-color: transparent; border-radius: 0; }
+
+spinbutton:focus:not(.vertical), entry:focus { color: #fcc8b4; background-color: #1e1715; box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2), inset 0 0 0 2px #fcc8b4; }
+
+spinbutton:disabled:not(.vertical), entry:disabled { color: #927367; background-color: transparent; box-shadow: none; }
+
+spinbutton:backdrop:not(.vertical), entry:backdrop { color: #8a736a; background-color: #191413; box-shadow: inset 0 0 0 1px #312824; border-color: #201a18; transition: 150ms ease-out; }
+
+spinbutton:backdrop:disabled:not(.vertical), entry:backdrop:disabled { color: #4c3e39; background-color: transparent; box-shadow: none; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; border-color: transparent; }
+
+spinbutton.error:focus:not(.vertical), entry.error:focus { color: #fb7c7c; background-color: #1e1715; box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2), inset 0 0 0 2px #fcc8b4; }
+
+spinbutton.error:not(.vertical) selection, entry.error selection { color: #1e1715; background-color: #fb7c7c; }
+
+spinbutton.warning:not(.vertical), entry.warning { color: #faa483; border-color: transparent; }
+
+spinbutton.warning:focus:not(.vertical), entry.warning:focus { color: #faa483; background-color: #1e1715; box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2), inset 0 0 0 2px #fcc8b4; }
+
+spinbutton.warning:not(.vertical) selection, entry.warning selection { color: #1e1715; background-color: #faa483; }
+
+spinbutton:not(.vertical) image, entry image { color: #d0a594; }
+
+spinbutton:not(.vertical) image:hover, entry image:hover { color: #fcc8b4; }
+
+spinbutton:not(.vertical) image:active, entry image:active { color: #fcc8b4; }
+
+spinbutton:not(.vertical) image:backdrop, entry image:backdrop { color: #746058; }
+
+spinbutton:drop(active):not(.vertical), entry:drop(active):focus, entry:drop(active) { color: #4cd9a4; border-color: transparent; background-color: #2e4436; }
+
+spinbutton:not(.vertical) progress, entry progress { margin: 1px -6px; background-color: transparent; background-image: none; border-radius: 3px; border-width: 0 0 3px; border-color: #fcc8b4; border-style: solid; box-shadow: none; }
+
+spinbutton:not(.vertical) progress:backdrop, entry progress:backdrop { background-color: transparent; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; }
+
+treeview entry:focus:dir(rtl), treeview entry:focus:dir(ltr) { background-color: #1e1715; transition-property: color, background; }
+
+treeview entry.flat, treeview entry { border: none; border-radius: 0; background-image: none; background-color: #1e1715; }
+
+.entry-tag { padding: 5px; margin-top: 4px; margin-bottom: 4px; border-style: none; color: #1e1715; background-color: #fcc8b4; }
+
+:dir(ltr) .entry-tag { margin-left: 8px; margin-right: -5px; }
+
+:dir(rtl) .entry-tag { margin-left: -5px; margin-right: 8px; }
+
+.entry-tag:hover { background-color: #feece5; }
+
+:backdrop .entry-tag { color: #191413; background-color: #fcc8b4; }
+
+.entry-tag.button { background-color: transparent; color: rgba(30, 23, 21, 0.7); }
+
+:not(:backdrop) .entry-tag.button:hover { border: 1px solid #fcc8b4; color: #1e1715; }
+
+:not(:backdrop) .entry-tag.button:active { background-color: #fcc8b4; color: #1e1715; }
+
+/*********** Buttons * */
+@keyframes needs_attention { from { background-image: -gtk-gradient(radial, center center, 0, center center, 0.01, to(#fcc8b4), to(transparent)); }
+  to { background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#fcc8b4), to(transparent)); } }
+
+button.titlebutton, notebook > header > tabs > arrow, button { min-height: 24px; min-width: 16px; margin: 1px; padding: 4px 9px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #372b26; background-image: none; }
+
+button.titlebutton, button.sidebar-button, notebook > header > tabs > arrow, notebook > header > tabs > arrow.flat, button.flat { background-color: transparent; background-image: none; background-image: none; transition: none; }
+
+button.titlebutton:hover, button.sidebar-button:hover, notebook > header > tabs > arrow:hover, button.flat:hover { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-duration: 500ms; }
+
+button.titlebutton:hover:active, button.sidebar-button:hover:active, notebook > header > tabs > arrow:hover:active, button.flat:hover:active { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header > tabs > arrow:hover, button:hover { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #473832; background-image: none; }
+
+notebook > header > tabs > arrow:active, button:active { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #52403a; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #675149 10%, transparent 0%); background-size: 0% 0%; }
+
+notebook > header > tabs > arrow:checked, button:checked { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; background: image(#fcc8b4); box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); }
+
+notebook > header > tabs > arrow:checked:active, button:checked:active { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); }
+
+notebook > header > tabs > arrow:backdrop, button:backdrop.flat, button:backdrop { background-color: #28211e; background-image: none; transition: 150ms ease-out; -gtk-icon-effect: none; }
+
+notebook > header > tabs > arrow:backdrop label, notebook > header > tabs > arrow:backdrop, button:backdrop.flat label, button:backdrop.flat, button:backdrop label, button:backdrop { color: #8a736a; }
+
+notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active, button:backdrop:active { background-color: #352c28; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:active label, notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active label, button:backdrop.flat:active, button:backdrop:active label, button:backdrop:active { color: #8a736a; }
+
+notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked, button:backdrop:checked { background-color: #a18479; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:checked label, notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked label, button:backdrop.flat:checked, button:backdrop:checked label, button:backdrop:checked { color: #191413; }
+
+notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled, button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled label, notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled label, button:backdrop.flat:disabled, button:backdrop:disabled label, button:backdrop:disabled { color: #4c3e39; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active, button:backdrop:disabled:checked { background-color: #312824; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active label, notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked label, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active label, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked label, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active label, button:backdrop:disabled:active, button:backdrop:disabled:checked label, button:backdrop:disabled:checked { color: #4c3e39; }
+
+button.titlebutton:backdrop, button.sidebar-button:backdrop, notebook > header > tabs > arrow:backdrop, button.titlebutton:disabled, button.sidebar-button:disabled, notebook > header > tabs > arrow:disabled, button.flat:backdrop, button.flat:disabled, button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+notebook > header > tabs > arrow:disabled, button:disabled { color: #927367; background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:disabled:active, notebook > header > tabs > arrow:disabled:checked, button:disabled:active, button:disabled:checked { color: #927367; background-color: #2c221f; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow.image-button, button.image-button { min-width: 24px; padding-left: 5px; padding-right: 5px; }
+
+notebook > header > tabs > arrow.flat image, notebook > header > tabs > arrow.image-button image, button.flat image, button.image-button image { -gtk-icon-transform: scale(1); transition: -gtk-icon-transform 150ms ease; }
+
+notebook > header > tabs > arrow.flat:active image, notebook > header > tabs > arrow.image-button:active image, button.flat:active image, button.image-button:active image { -gtk-icon-transform: scale(0.85); }
+
+notebook > header > tabs > arrow.text-button, button.text-button { padding-left: 16px; padding-right: 16px; }
+
+notebook > header > tabs > arrow.text-button.image-button, button.text-button.image-button { padding-left: 8px; padding-right: 8px; }
+
+notebook > header > tabs > arrow.text-button.image-button label, button.text-button.image-button label { padding-left: 8px; padding-right: 8px; }
+
+combobox:drop(active) button.combo, notebook > header > tabs > arrow:drop(active), button:drop(active) { color: #1e1715; border-color: transparent; background-color: #4cd9a4; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled), row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled) { color: #1e1715; border-color: transparent; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled):backdrop, row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled):backdrop { color: #191413; }
+
+button.osd { min-width: 26px; min-height: 32px; border-radius: 8px; border: none; }
+
+button.osd.image-button { min-width: 34px; }
+
+button.suggested-action { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; background: image(#fcc8b4); font-weight: 700; }
+
+button.suggested-action.flat { background-color: transparent; background-image: none; background-image: none; color: #fcc8b4; }
+
+button.suggested-action:hover { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background: image(#ffd5cb); background-color: #ffd5cb; }
+
+button.suggested-action:active, button.suggested-action:checked { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-image: none; background-color: #faa483; box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); }
+
+button.suggested-action:backdrop, button.suggested-action.flat:backdrop { background-color: #fbc8b5; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop label, button.suggested-action:backdrop, button.suggested-action.flat:backdrop label, button.suggested-action.flat:backdrop { color: #191413; }
+
+button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked { background-color: #f8a585; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop:active label, button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked label, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active label, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked label, button.suggested-action.flat:backdrop:checked { color: #191413; }
+
+button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.suggested-action:backdrop:disabled label, button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled label, button.suggested-action.flat:backdrop:disabled { color: #4c3e39; }
+
+button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked { background-color: #f0c0ad; box-shadow: none; background-image: none; }
+
+button.suggested-action:backdrop:disabled:active label, button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked label, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active label, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked label, button.suggested-action.flat:backdrop:disabled:checked { color: #4c3e39; }
+
+button.suggested-action.flat:backdrop, button.suggested-action.flat:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(252, 200, 180, 0.8); }
+
+button.suggested-action:disabled { color: #927367; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.suggested-action:disabled:active, button.suggested-action:disabled:checked { color: #927367; background-color: #f6c4b0; box-shadow: none; background-image: none; }
+
+button.destructive-action { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fb7c7c; background: image(#fb7c7c); font-weight: 700; }
+
+button.destructive-action.flat { background-color: transparent; background-image: none; background-image: none; color: #fb7c7c; }
+
+button.destructive-action:hover { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background: image(#ff929b); background-color: #ff929b; }
+
+button.destructive-action:active, button.destructive-action:checked { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-image: none; background-color: #fa4a4a; box-shadow: 0 2px 4px rgba(251, 124, 124, 0.2); }
+
+button.destructive-action:backdrop, button.destructive-action.flat:backdrop { background-color: #f97e7e; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop label, button.destructive-action:backdrop, button.destructive-action.flat:backdrop label, button.destructive-action.flat:backdrop { color: #191413; }
+
+button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked { background-color: #f74d4d; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop:active label, button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked label, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active label, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked label, button.destructive-action.flat:backdrop:checked { color: #191413; }
+
+button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.destructive-action:backdrop:disabled label, button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled label, button.destructive-action.flat:backdrop:disabled { color: #4c3e39; }
+
+button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked { background-color: #ee7979; box-shadow: none; background-image: none; }
+
+button.destructive-action:backdrop:disabled:active label, button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked label, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active label, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked label, button.destructive-action.flat:backdrop:disabled:checked { color: #4c3e39; }
+
+button.destructive-action.flat:backdrop, button.destructive-action.flat:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(251, 124, 124, 0.8); }
+
+button.destructive-action:disabled { color: #927367; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.destructive-action:disabled:active, button.destructive-action:disabled:checked { color: #927367; background-color: #f67979; box-shadow: none; background-image: none; }
+
+.stack-switcher > button, stackswitcher > button { padding-top: 2px; padding-bottom: 2px; margin: 2px 1px; background-color: transparent; color: #d0a594; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; outline-offset: -3px; }
+
+.stack-switcher > button:first-child:dir(ltr), stackswitcher > button:first-child:dir(ltr) { margin-left: 2px; }
+
+.stack-switcher > button:first-child:dir(rtl), stackswitcher > button:first-child:dir(rtl) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(ltr), stackswitcher > button:last-child:dir(ltr) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(rtl), stackswitcher > button:last-child:dir(rtl) { margin-left: 2px; }
+
+.stack-switcher > button:hover, stackswitcher > button:hover { color: #fcc8b4; background-color: rgba(252, 200, 180, 0.05); }
+
+.stack-switcher > button:checked, stackswitcher > button:checked { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-image: none; background-color: #473832; box-shadow: 0 2px 4px rgba(30, 23, 21, 0.075); }
+
+.stack-switcher > button:backdrop, stackswitcher > button:backdrop { color: #8a736a; }
+
+.stack-switcher > button:backdrop:hover, stackswitcher > button:backdrop:hover { background-color: transparent; }
+
+.stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked { background-image: none; background-color: #302724; box-shadow: 0 1px 2px rgba(25, 20, 19, 0.075); }
+
+.stack-switcher > button:backdrop:checked label, .stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked label, stackswitcher > button:backdrop:checked { color: #8a736a; }
+
+.stack-switcher > button > label, stackswitcher > button > label { padding-left: 6px; padding-right: 6px; }
+
+.stack-switcher > button > image, stackswitcher > button > image { padding-left: 6px; padding-right: 6px; padding-top: 3px; padding-bottom: 3px; }
+
+.stack-switcher > button.text-button, stackswitcher > button.text-button { padding-left: 10px; padding-right: 10px; }
+
+.stack-switcher > button.image-button, stackswitcher > button.image-button { padding-left: 2px; padding-right: 2px; }
+
+.stack-switcher > button.needs-attention:active > label, .stack-switcher > button.needs-attention:active > image, .stack-switcher > button.needs-attention:checked > label, .stack-switcher > button.needs-attention:checked > image, stackswitcher > button.needs-attention:active > label, stackswitcher > button.needs-attention:active > image, stackswitcher > button.needs-attention:checked > label, stackswitcher > button.needs-attention:checked > image { animation: none; background-image: none; }
+
+button.font separator, button.file separator { background-color: transparent; }
+
+button.font > box > box > label { font-weight: bold; }
+
+.primary-toolbar button { -gtk-icon-shadow: none; }
+
+button.circular { border-radius: 9999px; -gtk-outline-radius: 9999px; }
+
+button.circular label { padding: 0; }
+
+stacksidebar row.needs-attention > label, .stack-switcher > button.needs-attention > label, .stack-switcher > button.needs-attention > image, stackswitcher > button.needs-attention > label, stackswitcher > button.needs-attention > image { animation: needs_attention 150ms ease-in; background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#fcc8b4), to(transparent)), -gtk-gradient(radial, center center, 0, center center, 0.45, to(rgba(0, 0, 0, 0.896471)), to(transparent)); background-size: 6px 6px, 6px 6px; background-repeat: no-repeat; background-position: right 3px, right 2px; }
+
+stacksidebar row.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > image:backdrop, stackswitcher > button.needs-attention > label:backdrop, stackswitcher > button.needs-attention > image:backdrop { background-size: 6px 6px, 0 0; }
+
+stacksidebar row.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), stackswitcher > button.needs-attention > label:dir(rtl), stackswitcher > button.needs-attention > image:dir(rtl) { background-position: left 3px, left 2px; }
+
+.inline-toolbar toolbutton > button { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #372b26; background-image: none; }
+
+.inline-toolbar toolbutton > button:hover { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #473832; background-image: none; }
+
+.inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #52403a; }
+
+.inline-toolbar toolbutton > button:disabled { color: #927367; background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:disabled:active, .inline-toolbar toolbutton > button:disabled:checked { color: #927367; background-color: #2c221f; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop { background-color: #28211e; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop label, .inline-toolbar toolbutton > button:backdrop { color: #8a736a; }
+
+.inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked { background-color: #352c28; background-image: none; box-shadow: none; }
+
+.inline-toolbar toolbutton > button:backdrop:active label, .inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked label, .inline-toolbar toolbutton > button:backdrop:checked { color: #8a736a; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled label, .inline-toolbar toolbutton > button:backdrop:disabled { color: #4c3e39; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked { background-color: #312824; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active label, .inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked label, .inline-toolbar toolbutton > button:backdrop:disabled:checked { color: #4c3e39; }
+
+.linked:not(.vertical) > combobox > box > button.combo, filechooser .path-bar.linked > button, .linked:not(.vertical) > spinbutton:not(.vertical), .linked:not(.vertical) > entry, .inline-toolbar button, .linked > button, toolbar.inline-toolbar toolbutton > button.flat { border-right-style: none; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked:not(.vertical) > combobox:first-child > box > button.combo, combobox.linked button:nth-child(2):dir(rtl), filechooser .path-bar.linked > button:dir(rtl):last-child, filechooser .path-bar.linked > button:dir(ltr):first-child, .linked:not(.vertical) > spinbutton:first-child:not(.vertical), .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat { border-top-left-radius: 8px; border-bottom-left-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-bottom-left-radius: 8px; }
+
+.linked:not(.vertical) > combobox:last-child > box > button.combo, combobox.linked button:nth-child(2):dir(ltr), filechooser .path-bar.linked > button:dir(rtl):first-child, filechooser .path-bar.linked > button:dir(ltr):last-child, .linked:not(.vertical) > spinbutton:last-child:not(.vertical), .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat { border-right-style: solid; border-top-right-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-top-right-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked:not(.vertical) > combobox:only-child > box > button.combo, filechooser .path-bar.linked > button:only-child, .linked:not(.vertical) > spinbutton:only-child:not(.vertical), .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.linked.vertical > combobox > box > button.combo, .linked.vertical > spinbutton:not(.vertical), .linked.vertical > entry, .linked.vertical > button { border-style: solid solid none solid; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked.vertical > combobox:first-child > box > button.combo, .linked.vertical > spinbutton:first-child:not(.vertical), .linked.vertical > entry:first-child, .linked.vertical > button:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-top-right-radius: 8px; }
+
+.linked.vertical > combobox:last-child > box > button.combo, .linked.vertical > spinbutton:last-child:not(.vertical), .linked.vertical > entry:last-child, .linked.vertical > button:last-child { border-bottom-style: solid; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-bottom-left-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked.vertical > combobox:only-child > box > button.combo, .linked.vertical > spinbutton:only-child:not(.vertical), .linked.vertical > entry:only-child, .linked.vertical > button:only-child { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.scale-popup button:backdrop:hover, .scale-popup button:backdrop:disabled, .scale-popup button:backdrop, .scale-popup button:hover, calendar.button, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, button:link, button:visited, modelbutton.flat:backdrop, modelbutton.flat:backdrop:hover, modelbutton.flat, .menuitem.button.flat { background-color: transparent; background-image: none; border-color: transparent; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* menu buttons */
+modelbutton.flat, .menuitem.button.flat { min-height: 26px; padding-left: 5px; padding-right: 5px; border-radius: 8px; outline-offset: -2px; }
+
+modelbutton.flat:hover, .menuitem.button.flat:hover { background-color: #372b26; }
+
+modelbutton.flat arrow { background: none; }
+
+modelbutton.flat arrow:hover { background: none; }
+
+modelbutton.flat arrow.left { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+modelbutton.flat arrow.right { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+button.color { padding: 4px; box-shadow: none; }
+
+button.color colorswatch:only-child, button.color colorswatch:only-child overlay { border-radius: 0; }
+
+/********* Links * */
+button:link > label, button:visited > label, button:link, button:visited, *:link { color: #feece5; }
+
+button:link > label:visited, button:visited > label:visited, button:visited, *:link:visited { color: white; }
+
+*:selected button:link > label:visited, *:selected button:visited > label:visited, *:selected button:visited, *:selected *:link:visited { color: #787473; }
+
+button:link > label:hover, button:visited > label:hover, button:hover:link, button:hover:visited, *:link:hover { color: white; }
+
+*:selected button:link > label:hover, *:selected button:visited > label:hover, *:selected button:hover:link, *:selected button:hover:visited, *:selected *:link:hover { color: #352e2c; }
+
+button:link > label:active, button:visited > label:active, button:active:link, button:active:visited, *:link:active { color: #feece5; }
+
+*:selected button:link > label:active, *:selected button:visited > label:active, *:selected button:active:link, *:selected button:active:visited, *:selected *:link:active { color: #4b423f; }
+
+button:link > label:disabled, button:visited > label:disabled, button:disabled:link, button:disabled:visited, *:link:disabled, *:link:disabled:backdrop { color: rgba(242, 242, 242, 0.8); }
+
+button:link > label:backdrop, button:visited > label:backdrop, button:backdrop:link, button:backdrop:visited, *:link:backdrop:backdrop:hover, *:link:backdrop:backdrop:hover:selected, *:link:backdrop { color: rgba(254, 236, 229, 0.9); }
+
+.selection-mode .titlebar:not(headerbar) .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link, .selection-mode headerbar .subtitle:link, headerbar.selection-mode .subtitle:link, button:link > label:selected, button:visited > label:selected, button:selected:link, button:selected:visited, *:selected button:link > label, *:selected button:visited > label, *:selected button:link, *:selected button:visited, *:link:selected, *:selected *:link { color: #4b423f; }
+
+button:link, button:visited { text-shadow: none; }
+
+button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked { text-shadow: none; }
+
+button:link > label, button:visited > label { text-decoration-line: underline; }
+
+/****************** Stack Switcher * */
+stackswitcher, .stack-switcher { border-radius: 8px; background-color: #1e1715; }
+
+stackswitcher:backdrop, .stack-switcher:backdrop { background-color: #191413; }
+
+stackswitcher > button, .stack-switcher > button { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+/***************** GtkSpinButton * */
+spinbutton { font-feature-settings: "tnum"; }
+
+spinbutton:not(.vertical) { padding: 0; }
+
+spinbutton:not(.vertical) entry { min-width: 28px; margin: 0; background: none; background-color: transparent; border: none; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) entry:backdrop:disabled { background-color: transparent; }
+
+spinbutton:not(.vertical) button { min-height: 16px; margin: 0; padding-bottom: 0; padding-top: 0; color: #fcc8b4; background-image: none; border-style: none none none solid; border-color: transparent; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) button:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:disabled { color: #927367; background-color: #271e1b; }
+
+spinbutton:not(.vertical) button:backdrop:disabled { color: #4c3e39; background-color: #201a18; background-image: none; border-style: none none none solid; }
+
+spinbutton:not(.vertical) button:backdrop:disabled:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:dir(ltr):last-child { border-radius: 0 7px 7px 0; }
+
+spinbutton:not(.vertical) button:dir(rtl):first-child { border-radius: 7px 0 0 7px; }
+
+spinbutton.vertical:disabled { color: #927367; }
+
+spinbutton.vertical:backdrop:disabled { color: #4c3e39; }
+
+spinbutton.vertical:drop(active) { border-color: transparent; box-shadow: none; }
+
+spinbutton.vertical entry { min-height: 32px; min-width: 32px; padding: 0; border-radius: 0; }
+
+spinbutton.vertical button { min-height: 32px; min-width: 32px; padding: 0; }
+
+spinbutton.vertical button.up { border-radius: 8px 8px 0 0; border-style: solid solid none solid; }
+
+spinbutton.vertical button.down { border-radius: 0 0 8px 8px; border-style: none solid solid solid; }
+
+treeview spinbutton:not(.vertical) { min-height: 0; border-style: none; border-radius: 0; }
+
+treeview spinbutton:not(.vertical) entry { min-height: 0; padding: 1px 2px; }
+
+/************** ComboBoxes * */
+combobox arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); min-height: 16px; min-width: 16px; }
+
+combobox:drop(active) { box-shadow: none; }
+
+/************ Toolbars * */
+searchbar > revealer > box, .location-bar, .inline-toolbar, toolbar { -GtkWidget-window-dragging: true; padding: 4px; background-color: #271e1b; }
+
+searchbar > revealer > box:backdrop, .location-bar:backdrop, .inline-toolbar:backdrop, toolbar:backdrop { background-color: #201a18; }
+
+toolbar { padding: 4px 3px 3px 4px; }
+
+.osd toolbar { background-color: transparent; }
+
+toolbar.osd { padding: 13px; border: none; border-radius: 8px; }
+
+toolbar.osd.left, toolbar.osd.right, toolbar.osd.top, toolbar.osd.bottom { border-radius: 0; }
+
+toolbar.horizontal separator { margin: 0 7px 1px 6px; }
+
+toolbar.vertical separator { margin: 6px 1px 7px 0; }
+
+toolbar:not(.inline-toolbar):not(.osd) > *:not(.toggle):not(.popup) > * { margin-right: 1px; margin-bottom: 1px; }
+
+.inline-toolbar { padding: 3px; border-width: 0 1px 1px; border-radius: 0 0 8px 8px; }
+
+.background.csd .inline-toolbar { border-radius: 0 0 10px 10px; }
+
+searchbar > revealer > box, .location-bar { border-width: 0 0 1px; padding: 3px; }
+
+searchbar > revealer > box { margin: -6px; padding: 6px; }
+
+revealer box.view { background-color: transparent; }
+
+.inline-toolbar, searchbar > revealer > box, .location-bar { border-style: none; background-color: #271e1b; }
+
+.inline-toolbar:backdrop, searchbar > revealer > box:backdrop, .location-bar:backdrop { background-color: #201a18; }
+
+/*************** Header bars * */
+@keyframes header_ripple_effect { from { background-image: radial-gradient(circle farthest-corner at center, #271e1b 0%, transparent 0%); }
+  to { background-image: radial-gradient(circle farthest-corner at center, #fcc8b4 100%, transparent 0%); } }
+
+.titlebar:not(headerbar), headerbar { padding: 0 6px; min-height: 46px; border: none; border-radius: 0; background-color: #271e1b; /* hide the close button separator */ }
+
+.titlebar:backdrop:not(headerbar), headerbar:backdrop { background-color: #201a18; background-image: none; }
+
+.titlebar:not(headerbar) .title, headerbar .title { padding-left: 12px; padding-right: 12px; font-weight: bold; }
+
+.titlebar:not(headerbar) .subtitle, headerbar .subtitle { font-size: smaller; padding-left: 12px; padding-right: 12px; }
+
+.selection-mode .titlebar:not(headerbar), .selection-mode.titlebar:not(headerbar), .selection-mode headerbar, headerbar.selection-mode { color: #1e1715; border-color: transparent; background-color: #fcc8b4; transition: background-color 0.00001s 150ms, color 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); animation: header_ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+.selection-mode .titlebar:backdrop:not(headerbar), .selection-mode.titlebar:backdrop:not(headerbar), .selection-mode headerbar:backdrop, headerbar.selection-mode:backdrop { color: #1e1715; background-color: #fcc8b4; background-image: none; }
+
+.selection-mode .titlebar:backdrop:not(headerbar) label, .selection-mode.titlebar:backdrop:not(headerbar) label, .selection-mode headerbar:backdrop label, headerbar.selection-mode:backdrop label { text-shadow: none; color: #1e1715; }
+
+.selection-mode .titlebar:not(headerbar) button, .selection-mode.titlebar:not(headerbar) button, .selection-mode headerbar button, headerbar.selection-mode button { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #ebbba8; background-image: none; }
+
+.selection-mode button.titlebutton, .selection-mode .titlebar:not(headerbar) button.flat, .selection-mode.titlebar:not(headerbar) button.flat, .selection-mode headerbar button.flat, headerbar.selection-mode button.flat { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:hover, .selection-mode.titlebar:not(headerbar) button:hover, .selection-mode headerbar button:hover, headerbar.selection-mode button:hover { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #dbad9c; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:active, .selection-mode .titlebar:not(headerbar) button:checked, .selection-mode.titlebar:not(headerbar) button:active, .selection-mode.titlebar:not(headerbar) button:checked, .selection-mode headerbar button:active, .selection-mode headerbar button:checked, .selection-mode headerbar button.toggle:checked, .selection-mode headerbar button.toggle:active, headerbar.selection-mode button:active, headerbar.selection-mode button:checked, headerbar.selection-mode button.toggle:checked, headerbar.selection-mode button.toggle:active { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #d0a594; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop { background-color: #28211e; background-image: none; -gtk-icon-effect: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop label, .selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop label, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat label, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop label, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat label, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop label, headerbar.selection-mode button:backdrop { color: #8a736a; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked { background-color: #352c28; background-image: none; box-shadow: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active label, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked label, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active label, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked label, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active label, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked label, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active label, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked label, headerbar.selection-mode button:backdrop:checked { color: #8a736a; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled label, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled label, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled label, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled label, headerbar.selection-mode button:backdrop:disabled { color: #4c3e39; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked { background-color: #f0c0ad; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active label, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked label, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active label, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked label, headerbar.selection-mode button:backdrop:disabled:checked { color: #4c3e39; }
+
+.selection-mode button.titlebutton:backdrop, .selection-mode button.titlebutton:disabled, .selection-mode .titlebar:not(headerbar) button.flat:backdrop, .selection-mode .titlebar:not(headerbar) button.flat:disabled, .selection-mode.titlebar:not(headerbar) button.flat:backdrop, .selection-mode.titlebar:not(headerbar) button.flat:disabled, .selection-mode headerbar button.flat:backdrop, .selection-mode headerbar button.flat:disabled, .selection-mode headerbar button.flat:backdrop:disabled, headerbar.selection-mode button.flat:backdrop, headerbar.selection-mode button.flat:disabled, headerbar.selection-mode button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled, .selection-mode.titlebar:not(headerbar) button:disabled, .selection-mode headerbar button:disabled, headerbar.selection-mode button:disabled { color: #927367; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled:active, .selection-mode .titlebar:not(headerbar) button:disabled:checked, .selection-mode.titlebar:not(headerbar) button:disabled:active, .selection-mode.titlebar:not(headerbar) button:disabled:checked, .selection-mode headerbar button:disabled:active, .selection-mode headerbar button:disabled:checked, headerbar.selection-mode button:disabled:active, headerbar.selection-mode button:disabled:checked { color: #927367; background-color: #f6c4b0; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action, .selection-mode.titlebar:not(headerbar) button.suggested-action, .selection-mode headerbar button.suggested-action, headerbar.selection-mode button.suggested-action { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #372b26; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:hover, .selection-mode.titlebar:not(headerbar) button.suggested-action:hover, .selection-mode headerbar button.suggested-action:hover, headerbar.selection-mode button.suggested-action:hover { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #473832; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:active, .selection-mode.titlebar:not(headerbar) button.suggested-action:active, .selection-mode headerbar button.suggested-action:active, headerbar.selection-mode button.suggested-action:active { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #52403a; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode headerbar button.suggested-action:disabled, headerbar.selection-mode button.suggested-action:disabled { color: #927367; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop { background-color: #28211e; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop label, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop label, headerbar.selection-mode button.suggested-action:backdrop { color: #8a736a; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled label, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled label, headerbar.selection-mode button.suggested-action:backdrop:disabled { color: #4c3e39; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu, .selection-mode.titlebar:not(headerbar) .selection-menu, .selection-mode headerbar .selection-menu:backdrop, .selection-mode headerbar .selection-menu, headerbar.selection-mode .selection-menu:backdrop, headerbar.selection-mode .selection-menu { border-color: rgba(252, 200, 180, 0); background-color: rgba(252, 200, 180, 0); background-image: none; box-shadow: none; min-height: 20px; padding: 6px 10px; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu arrow, .selection-mode.titlebar:not(headerbar) .selection-menu arrow, .selection-mode headerbar .selection-menu:backdrop arrow, .selection-mode headerbar .selection-menu arrow, headerbar.selection-mode .selection-menu:backdrop arrow, headerbar.selection-mode .selection-menu arrow { -GtkArrow-arrow-scaling: 1; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu .arrow, .selection-mode.titlebar:not(headerbar) .selection-menu .arrow, .selection-mode headerbar .selection-menu:backdrop .arrow, .selection-mode headerbar .selection-menu .arrow, headerbar.selection-mode .selection-menu:backdrop .arrow, headerbar.selection-mode .selection-menu .arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); color: rgba(30, 23, 21, 0.5); -gtk-icon-shadow: none; }
+
+.tiled .titlebar:not(headerbar), .tiled-top .titlebar:not(headerbar), .tiled-right .titlebar:not(headerbar), .tiled-bottom .titlebar:not(headerbar), .tiled-left .titlebar:not(headerbar), .maximized .titlebar:not(headerbar), .fullscreen .titlebar:not(headerbar), .tiled headerbar, .tiled-top headerbar, .tiled-right headerbar, .tiled-bottom headerbar, .tiled-left headerbar, .maximized headerbar, .fullscreen headerbar { border-radius: 0; }
+
+.default-decoration.titlebar:not(headerbar), headerbar.default-decoration { min-height: 28px; padding: 4px; border-color: transparent; }
+
+.default-decoration.titlebar:not(headerbar) button.titlebutton, headerbar.default-decoration button.titlebutton { min-height: 26px; min-width: 26px; margin: 0; padding: 0; }
+
+.titlebar:not(headerbar) separator.titlebutton, headerbar separator.titlebutton { opacity: 0; }
+
+.solid-csd .titlebar:dir(rtl):not(headerbar), .solid-csd .titlebar:dir(ltr):not(headerbar), .solid-csd headerbar:backdrop:dir(rtl), .solid-csd headerbar:backdrop:dir(ltr), .solid-csd headerbar:dir(rtl), .solid-csd headerbar:dir(ltr) { margin-left: -1px; margin-right: -1px; margin-top: -1px; border-radius: 0; box-shadow: none; }
+
+headerbar entry, headerbar spinbutton, headerbar separator:not(.sidebar), headerbar button { margin-top: 6px; margin-bottom: 6px; }
+
+headerbar switch { margin-top: 10px; margin-bottom: 10px; }
+
+headerbar stackswitcher button, headerbar .stack-switcher button { min-height: 24px; min-width: 80px; margin: 4px 2px; }
+
+headerbar stackswitcher button:first-child:dir(ltr), headerbar .stack-switcher button:first-child:dir(ltr) { margin-left: 4px; }
+
+headerbar stackswitcher button:first-child:dir(rtl), headerbar .stack-switcher button:first-child:dir(rtl) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(ltr), headerbar .stack-switcher button:last-child:dir(ltr) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(rtl), headerbar .stack-switcher button:last-child:dir(rtl) { margin-left: 4px; }
+
+#MozillaGtkWidget.background headerbar button.close:hover, headerbar button.close:hover { color: #fb7c7c; background-color: #472c29; }
+
+#MozillaGtkWidget.background headerbar button.close:active, #MozillaGtkWidget.background headerbar button.close:checked, headerbar button.close:active, headerbar button.close:checked { color: #fb7c7c; background-color: #52312e; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #52312e 10%, transparent 0%); background-size: 0% 0%; }
+
+headerbar.titlebar headerbar:not(.titlebar) { background: none; box-shadow: none; }
+
+.background .titlebar:backdrop, .background .titlebar { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+.background.tiled .titlebar:backdrop, .background.tiled .titlebar, .background.tiled-top .titlebar:backdrop, .background.tiled-top .titlebar, .background.tiled-right .titlebar:backdrop, .background.tiled-right .titlebar, .background.tiled-bottom .titlebar:backdrop, .background.tiled-bottom .titlebar, .background.tiled-left .titlebar:backdrop, .background.tiled-left .titlebar, .background.maximized .titlebar:backdrop, .background.maximized .titlebar, .background.solid-csd .titlebar:backdrop, .background.solid-csd .titlebar { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window separator:first-child + headerbar:backdrop, window separator:first-child + headerbar, window headerbar:first-child:backdrop, window headerbar:first-child { border-top-left-radius: 10px; }
+
+window headerbar:last-child:backdrop, window headerbar:last-child { border-top-right-radius: 10px; }
+
+window stack headerbar:first-child:backdrop, window stack headerbar:first-child, window stack headerbar:last-child:backdrop, window stack headerbar:last-child { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+window.tiled headerbar, window.tiled headerbar:first-child, window.tiled headerbar:last-child, window.tiled headerbar:only-child, window.tiled headerbar:backdrop, window.tiled headerbar:backdrop:first-child, window.tiled headerbar:backdrop:last-child, window.tiled headerbar:backdrop:only-child, window.tiled-top headerbar, window.tiled-top headerbar:first-child, window.tiled-top headerbar:last-child, window.tiled-top headerbar:only-child, window.tiled-top headerbar:backdrop, window.tiled-top headerbar:backdrop:first-child, window.tiled-top headerbar:backdrop:last-child, window.tiled-top headerbar:backdrop:only-child, window.tiled-right headerbar, window.tiled-right headerbar:first-child, window.tiled-right headerbar:last-child, window.tiled-right headerbar:only-child, window.tiled-right headerbar:backdrop, window.tiled-right headerbar:backdrop:first-child, window.tiled-right headerbar:backdrop:last-child, window.tiled-right headerbar:backdrop:only-child, window.tiled-bottom headerbar, window.tiled-bottom headerbar:first-child, window.tiled-bottom headerbar:last-child, window.tiled-bottom headerbar:only-child, window.tiled-bottom headerbar:backdrop, window.tiled-bottom headerbar:backdrop:first-child, window.tiled-bottom headerbar:backdrop:last-child, window.tiled-bottom headerbar:backdrop:only-child, window.tiled-left headerbar, window.tiled-left headerbar:first-child, window.tiled-left headerbar:last-child, window.tiled-left headerbar:only-child, window.tiled-left headerbar:backdrop, window.tiled-left headerbar:backdrop:first-child, window.tiled-left headerbar:backdrop:last-child, window.tiled-left headerbar:backdrop:only-child, window.maximized headerbar, window.maximized headerbar:first-child, window.maximized headerbar:last-child, window.maximized headerbar:only-child, window.maximized headerbar:backdrop, window.maximized headerbar:backdrop:first-child, window.maximized headerbar:backdrop:last-child, window.maximized headerbar:backdrop:only-child, window.fullscreen headerbar, window.fullscreen headerbar:first-child, window.fullscreen headerbar:last-child, window.fullscreen headerbar:only-child, window.fullscreen headerbar:backdrop, window.fullscreen headerbar:backdrop:first-child, window.fullscreen headerbar:backdrop:last-child, window.fullscreen headerbar:backdrop:only-child, window.solid-csd headerbar, window.solid-csd headerbar:first-child, window.solid-csd headerbar:last-child, window.solid-csd headerbar:only-child, window.solid-csd headerbar:backdrop, window.solid-csd headerbar:backdrop:first-child, window.solid-csd headerbar:backdrop:last-child, window.solid-csd headerbar:backdrop:only-child { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window.csd > .titlebar:not(headerbar) { padding: 0; background-color: transparent; background-image: none; border-style: none; border-color: transparent; box-shadow: none; }
+
+.titlebar:not(headerbar) separator { background-color: #271e1b; }
+
+.titlebar:not(headerbar) separator:backdrop { background-color: #201a18; }
+
+window.devel headerbar.titlebar:not(.selection-mode) { background: #271e1b cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, linear-gradient(to right, transparent 65%, rgba(252, 200, 180, 0.15)); }
+
+window.devel headerbar.titlebar:not(.selection-mode):backdrop { background: #271e1b cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, image(#271e1b); /* background-color would flash */ }
+
+/************ Pathbars * */
+.path-bar button.text-button, .path-bar button.image-button, .path-bar button { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.text-button.image-button label { padding-left: 0; padding-right: 0; }
+
+.path-bar button.text-button.image-button label:last-child, .path-bar button label:last-child { padding-right: 8px; }
+
+.path-bar button.text-button.image-button label:first-child, .path-bar button label:first-child { padding-left: 8px; }
+
+.path-bar button image { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.slider-button { padding-left: 0; padding-right: 0; }
+
+/************** Tree Views * */
+treeview.view { border-left-color: rgba(252, 200, 180, 0.15); border-top-color: #271e1b; border-radius: 0px; }
+
+* { -GtkTreeView-horizontal-separator: 4; -GtkTreeView-grid-line-width: 1; -GtkTreeView-grid-line-pattern: ''; -GtkTreeView-tree-line-width: 1; -GtkTreeView-tree-line-pattern: ''; -GtkTreeView-expander-size: 16; }
+
+treeview.view:selected:focus, treeview.view:selected { border-radius: 0; }
+
+treeview.view:selected:backdrop, treeview.view:selected { border-left-color: #5f4d47; border-top-color: rgba(138, 115, 106, 0.1); }
+
+treeview.view:disabled { color: #927367; }
+
+treeview.view:disabled:selected { color: #a38174; }
+
+treeview.view:disabled:selected:backdrop { color: #78625b; }
+
+treeview.view:disabled:backdrop { color: #4c3e39; }
+
+treeview.view.separator { min-height: 2px; color: #271e1b; }
+
+treeview.view.separator:backdrop { color: #201a18; }
+
+treeview.view:backdrop { border-left-color: #554641; border-top: #201a18; }
+
+treeview.view:drop(active) { border-style: solid none; border-width: 1px; border-color: #e9b9a7; }
+
+treeview.view:drop(active).after { border-top-style: none; }
+
+treeview.view:drop(active).before { border-bottom-style: none; }
+
+treeview.view.expander { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); color: #b99384; }
+
+treeview.view.expander:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+treeview.view.expander:hover { color: #fcc8b4; }
+
+treeview.view.expander:selected { color: #614c45; }
+
+treeview.view.expander:selected:hover { color: #1e1715; }
+
+treeview.view.expander:selected:backdrop { color: #423532; }
+
+treeview.view.expander:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+treeview.view.expander:backdrop { color: #685650; }
+
+treeview.view.progressbar { color: #1e1715; background-color: #fcc8b4; background: image(#fcc8b4); box-shadow: none; border-radius: 8px; }
+
+treeview.view.progressbar:backdrop { color: #191413; background-color: #a18479; background-image: none; }
+
+treeview.view.progressbar:selected:focus, treeview.view.progressbar:selected { border-radius: 8px; color: #fcc8b4; background-color: #1e1715; background-image: none; }
+
+treeview.view.progressbar:selected:backdrop { color: #a18479; background-color: #191413; }
+
+treeview.view.trough { background-color: rgba(252, 200, 180, 0.1); border-radius: 8px; }
+
+treeview.view.trough:backdrop { background-color: rgba(138, 115, 106, 0.1); }
+
+treeview.view.trough:selected { border-radius: 8px; }
+
+treeview.view.trough:selected:focus, treeview.view.trough:selected { background-color: rgba(30, 23, 21, 0.3); }
+
+treeview.view.trough:selected:backdrop { background-color: rgba(30, 23, 21, 0.3); }
+
+treeview.view header button { color: #8d6f65; background-color: #1e1715; font-weight: bold; text-shadow: none; box-shadow: none; margin: 0 1px 1px 0; }
+
+treeview.view header button:last-child { margin-right: 0; }
+
+treeview.view header button:hover { color: #c49b8d; box-shadow: none; transition: none; }
+
+treeview.view header button:active { color: #fcc8b4; transition: none; }
+
+treeview.view button.dnd:active, treeview.view button.dnd:selected, treeview.view button.dnd:hover, treeview.view button.dnd, treeview.view header.button.dnd:active, treeview.view header.button.dnd:selected, treeview.view header.button.dnd:hover, treeview.view header.button.dnd { padding: 0 6px; color: #1e1715; background-image: none; background-color: #fcc8b4; border-style: none; border-radius: 0; box-shadow: inset 0 0 0 1px #1e1715; text-shadow: none; transition: none; }
+
+treeview.view acceleditor > label { background-color: #fcc8b4; }
+
+treeview.view header button, treeview.view header button:hover, treeview.view header button:active { padding: 0 6px; background-image: none; border-style: none solid solid none; border-color: #271e1b; border-radius: 0; text-shadow: none; }
+
+treeview.view header button:disabled { border-color: #271e1b; background-image: none; }
+
+treeview.view header button:backdrop { color: #554641; border-color: #201a18; border-style: none solid solid none; background-image: none; background-color: #191413; }
+
+treeview.view header button:backdrop:disabled { border-color: #201a18; background-image: none; }
+
+treeview.view header button:last-child { border-right-style: none; }
+
+/********* Menus * */
+menubar, .menubar { -GtkWidget-window-dragging: true; padding: 0px; }
+
+menubar:backdrop, .menubar:backdrop { background-color: #201a18; }
+
+menubar > menuitem, .menubar > menuitem { min-height: 16px; padding: 4px 8px; }
+
+menubar > menuitem menu:dir(rtl), menubar > menuitem menu:dir(ltr), .menubar > menuitem menu:dir(rtl), .menubar > menuitem menu:dir(ltr) { border-radius: 0; padding: 0; }
+
+menubar > menuitem:hover, .menubar > menuitem:hover { box-shadow: inset 0 -3px #fcc8b4; color: #feece5; }
+
+menubar > menuitem:disabled, .menubar > menuitem:disabled { color: #927367; box-shadow: none; }
+
+menubar .csd.popup decoration, .menubar .csd.popup decoration { border-radius: 0; }
+
+.background.popup { background-color: transparent; }
+
+menu, .menu, .context-menu { margin: 8px; padding: 8px 0px; background-color: #1e1715; border: 1px solid rgba(55, 43, 38, 0.75); }
+
+.csd menu, .csd .menu, .csd .context-menu { border: none; border-radius: 8px; }
+
+menu:backdrop, .menu:backdrop, .context-menu:backdrop { background-color: #191413; border-color: rgba(49, 40, 36, 0.75); }
+
+menu menuitem, .menu menuitem, .context-menu menuitem { min-height: 16px; min-width: 40px; padding: 4px 6px; text-shadow: none; }
+
+menu menuitem:hover, .menu menuitem:hover, .context-menu menuitem:hover { color: #1e1715; background-color: #fcc8b4; background: image(#fcc8b4); }
+
+menu menuitem:disabled, .menu menuitem:disabled, .context-menu menuitem:disabled { color: #927367; }
+
+menu menuitem:disabled:backdrop, .menu menuitem:disabled:backdrop, .context-menu menuitem:disabled:backdrop { color: #4c3e39; }
+
+menu menuitem:backdrop, menu menuitem:backdrop:hover, .menu menuitem:backdrop, .menu menuitem:backdrop:hover, .context-menu menuitem:backdrop, .context-menu menuitem:backdrop:hover { color: #8a736a; background-color: transparent; }
+
+menu menuitem arrow, .menu menuitem arrow, .context-menu menuitem arrow { min-height: 16px; min-width: 16px; }
+
+menu menuitem arrow:dir(ltr), .menu menuitem arrow:dir(ltr), .context-menu menuitem arrow:dir(ltr) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); margin-left: 10px; }
+
+menu menuitem arrow:dir(rtl), .menu menuitem arrow:dir(rtl), .context-menu menuitem arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); margin-right: 10px; }
+
+menu menuitem label:dir(rtl), menu menuitem label:dir(ltr), .menu menuitem label:dir(rtl), .menu menuitem label:dir(ltr), .context-menu menuitem label:dir(rtl), .context-menu menuitem label:dir(ltr) { color: inherit; }
+
+menu separator, .menu separator, .context-menu separator { margin: 3px 16px; }
+
+menu > arrow, .menu > arrow, .context-menu > arrow { background-color: transparent; background-image: none; background-image: none; min-height: 16px; min-width: 16px; padding: 4px; background-color: #1e1715; border-radius: 0; }
+
+menu > arrow.top, .menu > arrow.top, .context-menu > arrow.top { margin-top: -8px; border-bottom: 1px solid #342925; border-top-right-radius: 8px; border-top-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+menu > arrow.bottom, .menu > arrow.bottom, .context-menu > arrow.bottom { margin-top: 16px; margin-bottom: -24px; border-top: 1px solid #342925; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+menu > arrow:hover, .menu > arrow:hover, .context-menu > arrow:hover { background-color: #3f322d; }
+
+menu > arrow:backdrop, .menu > arrow:backdrop, .context-menu > arrow:backdrop { background-color: #191413; }
+
+menu > arrow:disabled, .menu > arrow:disabled, .context-menu > arrow:disabled { color: transparent; background-color: transparent; border-color: transparent; }
+
+menuitem accelerator { color: alpha(currentColor,0.55); }
+
+menuitem check, menuitem radio { min-height: 16px; min-width: 16px; }
+
+menuitem check:dir(ltr), menuitem radio:dir(ltr) { margin-right: 7px; }
+
+menuitem check:dir(rtl), menuitem radio:dir(rtl) { margin-left: 7px; }
+
+/*************** Popovers   * */
+popover.background { padding: 2px; background-color: #1e1715; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.csd popover.background, popover.background { border: 1px solid rgba(55, 43, 38, 0.75); border-radius: 10px; }
+
+.csd popover.background { background-clip: padding-box; }
+
+popover.background:backdrop { background-color: #191413; box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); border-color: rgba(49, 40, 36, 0.75); }
+
+popover.background > list, popover.background > .view, popover.background > iconview, popover.background > toolbar { border-style: none; background-color: transparent; }
+
+popover.background separator { margin: 3px; }
+
+popover.background list separator { margin: 0px; }
+
+/************* Notebooks * */
+notebook > header { padding: 2px; border-style: none; background-color: #1e1715; }
+
+notebook > header:backdrop { background-color: #191413; }
+
+notebook > header.top { border-radius: 8px 8px 0 0; }
+
+notebook > header.bottom { border-radius: 0 0 8px 8px; }
+
+notebook > header.left { border-radius: 8px 0 0 8px; }
+
+notebook > header.right { border-radius: 0 8px 8px 0; }
+
+notebook > header > button { padding: 2px 9px; margin: 2px; }
+
+notebook > header.left > tabs > arrow, notebook > header.right > tabs > arrow { margin-top: -5px; margin-bottom: -5px; padding-top: 4px; padding-bottom: 4px; }
+
+notebook > header.left > tabs > arrow.down, notebook > header.right > tabs > arrow.down { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+notebook > header.left > tabs > arrow.up, notebook > header.right > tabs > arrow.up { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+notebook > header > tabs > arrow { transition: none; min-height: 16px; min-width: 16px; }
+
+notebook > header > tabs > arrow:hover:not(:active):not(:backdrop) { background-clip: padding-box; background-image: none; border-color: transparent; box-shadow: none; transition: none; }
+
+notebook > header > tabs > arrow:disabled { color: #927367; background-color: transparent; background-image: none; }
+
+notebook > header tab { min-height: 24px; min-width: 30px; padding: 2px 9px; margin: 2px; outline-offset: -3px; border-radius: 8px; color: #d0a594; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header tab:hover { color: #fcc8b4; background-color: rgba(252, 200, 180, 0.05); }
+
+notebook > header tab:backdrop { color: #8a736a; }
+
+notebook > header tab:backdrop.reorderable-page { background-color: transparent; }
+
+notebook > header tab:checked { color: #fcc8b4; background-color: #473832; box-shadow: 0 2px 4px rgba(30, 23, 21, 0.075); }
+
+notebook > header tab:backdrop:checked { color: #8a736a; background-color: #302724; box-shadow: 0 1px 2px rgba(25, 20, 19, 0.075); }
+
+notebook > header tab:backdrop:checked.reorderable-page { background-color: #302724; }
+
+notebook > header tab button.flat { border-radius: 999px; padding: 0; margin-top: 2px; margin-bottom: 2px; min-width: 20px; min-height: 20px; }
+
+notebook > header tab button.flat:hover { color: currentColor; }
+
+notebook > header tab button.flat, notebook > header tab button.flat:backdrop { color: alpha(currentColor,0.3); }
+
+notebook > header tab button.flat:last-child { margin-left: 4px; margin-right: -4px; }
+
+notebook > header tab button.flat:first-child { margin-left: -4px; margin-right: 4px; }
+
+notebook > stack:not(:only-child) { background-color: transparent; }
+
+notebook > stack:not(:only-child):backdrop { background-color: transparent; }
+
+/************** Scrollbars * */
+scrollbar { background-color: transparent; transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border-radius: 8px; }
+
+* { -GtkScrollbar-has-backward-stepper: false; -GtkScrollbar-has-forward-stepper: false; }
+
+scrollbar:backdrop { border-color: #312824; transition: 150ms ease-out; }
+
+scrollbar slider { min-width: 6px; min-height: 6px; margin: -1px; border: 4px solid transparent; border-radius: 8px; background-clip: padding-box; background-color: #a78477; }
+
+scrollbar slider:hover { background-color: #d1a695; }
+
+scrollbar slider:hover:active { background-color: #fcc8b4; }
+
+scrollbar slider:backdrop { background-color: #6a5851; }
+
+scrollbar slider:disabled { background-color: transparent; }
+
+scrollbar.fine-tune slider { min-width: 4px; min-height: 4px; }
+
+scrollbar.fine-tune.horizontal slider { border-width: 5px 4px; }
+
+scrollbar.fine-tune.vertical slider { border-width: 4px 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) { border-color: transparent; opacity: 0.4; background-color: transparent; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider { margin: 0; min-width: 3px; min-height: 3px; background-color: #fcc8b4; border: 1px solid black; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) button { min-width: 5px; min-height: 5px; background-color: #fcc8b4; background-clip: padding-box; border-radius: 100%; border: 1px solid black; -gtk-icon-source: none; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider { margin: 0 2px; min-width: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal button { margin: 1px 2px; min-width: 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider { margin: 2px 0; min-height: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical button { margin: 2px 1px; min-height: 5px; }
+
+scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering { opacity: 0.8; }
+
+scrollbar.horizontal slider { min-width: 40px; }
+
+scrollbar.vertical slider { min-height: 40px; }
+
+scrollbar button { padding: 0; min-width: 12px; min-height: 12px; border-style: none; border-radius: 0; transition-property: min-height, min-width, color; background-color: transparent; background-image: none; background-image: none; color: #a78477; }
+
+scrollbar button:hover { background-color: transparent; background-image: none; background-image: none; color: #d1a695; }
+
+scrollbar button:active, scrollbar button:checked { background-color: transparent; background-image: none; background-image: none; color: #fcc8b4; }
+
+scrollbar button:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(167, 132, 119, 0.2); }
+
+scrollbar button:backdrop { background-color: transparent; background-image: none; background-image: none; color: #6a5851; }
+
+scrollbar button:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(106, 88, 81, 0.2); }
+
+scrollbar.vertical button.down { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+scrollbar.vertical button.up { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+scrollbar.horizontal button.down { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+scrollbar.horizontal button.up { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+/********** Switch * */
+switch { font-size: 0; outline-offset: -4px; min-width: 36px; min-height: 18px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border: none; padding: 2px; border-radius: 999px; background-color: #52403a; background-image: none; color: transparent; }
+
+switch:checked { background-color: #fcc8b4; background: image(#fcc8b4); }
+
+switch:disabled { background-color: #372b26; background-image: none; }
+
+switch:disabled:checked { background-color: #725a51; background-image: none; }
+
+switch:backdrop { background-color: #463935; background-image: none; transition: 150ms ease-out; }
+
+switch:backdrop:checked { background-color: #a18479; background-image: none; }
+
+switch:backdrop:disabled { background-color: #312824; background-image: none; }
+
+switch:backdrop:disabled:checked { background-color: #4c3e39; background-image: none; }
+
+switch slider { margin: 2px; min-width: 18px; min-height: 18px; border: none; border-radius: 999px; -gtk-outline-radius: 999px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-color: #1e1715; box-shadow: 0 2px 4px rgba(30, 23, 21, 0.075); }
+
+switch:disabled slider { background-color: #271e1b; box-shadow: none; }
+
+switch:backdrop slider { transition: 150ms ease-out; background-color: #201a18; box-shadow: 0 2px 4px rgba(25, 20, 19, 0.075); }
+
+switch:checked slider { background-color: #1e1715; box-shadow: none; }
+
+switch:backdrop:checked slider { background-color: #191413; }
+
+row:selected switch { box-shadow: none; box-shadow: inset 0 0 0 1px #1e1715; }
+
+/************************* Check and Radio items * */
+.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view:not(list) check { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view:not(list) check:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view:not(list) check:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view:not(list) check:backdrop { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view:not(list) check:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view:not(list) check:checked:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view:not(list) check:checked:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view:not(list) check:backdrop:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+checkbutton.text-button, radiobutton.text-button { padding: 2px 0; outline-offset: 0; }
+
+checkbutton.text-button label:not(:only-child):first-child, radiobutton.text-button label:not(:only-child):first-child { margin-left: 4px; }
+
+checkbutton.text-button label:not(:only-child):last-child, radiobutton.text-button label:not(:only-child):last-child { margin-right: 4px; }
+
+check, radio { margin: 0 4px; min-height: 14px; min-width: 14px; padding: 1px; border: none; -gtk-icon-source: none; }
+
+check:only-child, radio:only-child { margin: 0; }
+
+popover check.left:dir(rtl), popover radio.left:dir(rtl) { margin-left: 0; margin-right: 12px; }
+
+popover check.right:dir(ltr), popover radio.right:dir(ltr) { margin-left: 12px; margin-right: 0; }
+
+check, radio { background-clip: padding-box; background: image(#1e1715); box-shadow: inset 0 0 0 1px #52403a; color: #fcc8b4; }
+
+check:hover, radio:hover { background: image(#29201d); }
+
+check:active, radio:active { background: image(#342925); }
+
+check:disabled, radio:disabled { box-shadow: none; background-image: none; background-color: #231b18; color: rgba(252, 200, 180, 0.7); }
+
+check:backdrop, radio:backdrop { background-image: none; background-color: #1e1817; box-shadow: inset 0 0 0 1px #50413c; color: #fcc8b4; }
+
+check:backdrop:disabled, radio:backdrop:disabled { box-shadow: none; background-image: none; background-color: #221b19; color: rgba(252, 200, 180, 0.7); }
+
+check:checked, radio:checked { background-clip: border-box; background: image(#fcc8b4); box-shadow: none; color: #1e1715; }
+
+check:checked:hover, radio:checked:hover { background: image(#fcc8b4); }
+
+check:checked:active, radio:checked:active { background: image(#fcc8b4); }
+
+check:checked:disabled, radio:checked:disabled { box-shadow: none; background-image: none; background-color: #927367; color: rgba(30, 23, 21, 0.7); }
+
+check:checked:backdrop, radio:checked:backdrop { background-image: none; background-color: #b79588; box-shadow: none; color: #1e1715; }
+
+check:checked:backdrop:disabled, radio:checked:backdrop:disabled { box-shadow: none; background-image: none; background-color: #8e756b; color: rgba(30, 23, 21, 0.7); }
+
+check:indeterminate, radio:indeterminate { background-clip: border-box; background: image(#fcc8b4); box-shadow: none; color: #1e1715; }
+
+check:indeterminate:hover, radio:indeterminate:hover { background: image(#fcc8b4); }
+
+check:indeterminate:active, radio:indeterminate:active { background: image(#fcc8b4); }
+
+check:indeterminate:disabled, radio:indeterminate:disabled { box-shadow: none; background-image: none; background-color: #927367; color: rgba(30, 23, 21, 0.7); }
+
+check:indeterminate:backdrop, radio:indeterminate:backdrop { background-image: none; background-color: #b79588; box-shadow: none; color: #1e1715; }
+
+check:indeterminate:backdrop:disabled, radio:indeterminate:backdrop:disabled { box-shadow: none; background-image: none; background-color: #8e756b; color: rgba(30, 23, 21, 0.7); }
+
+check:backdrop, radio:backdrop { transition: 150ms ease-out; }
+
+menu menuitem check, menu menuitem radio { margin: 0; }
+
+menu menuitem check, menu menuitem check:hover, menu menuitem check:disabled, menu menuitem check:checked, menu menuitem check:checked:hover, menu menuitem check:checked:disabled, menu menuitem check:indeterminate, menu menuitem check:indeterminate:hover, menu menuitem check:indeterminate:disabled, menu menuitem radio, menu menuitem radio:hover, menu menuitem radio:disabled, menu menuitem radio:checked, menu menuitem radio:checked:hover, menu menuitem radio:checked:disabled, menu menuitem radio:indeterminate, menu menuitem radio:indeterminate:hover, menu menuitem radio:indeterminate:disabled { min-height: 14px; min-width: 14px; background-image: none; background-color: transparent; box-shadow: none; -gtk-icon-shadow: none; color: inherit; border: 1px solid currentColor; padding: 0; }
+
+check { border-radius: 4px; }
+
+check:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/check-symbolic.svg")), -gtk-recolor(url("assets/check-symbolic.symbolic.png"))); }
+
+check:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+treeview.view radio:selected:focus, treeview.view radio:selected, radio { border-radius: 100%; }
+
+treeview.view radio:checked:selected, radio:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/bullet-symbolic.svg")), -gtk-recolor(url("assets/bullet-symbolic.symbolic.png"))); }
+
+treeview.view radio:indeterminate:selected, radio:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+radio:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: scale(0); }
+
+check:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: translate(6px, -3px) rotate(-45deg) scaleY(0.2) rotate(45deg) scaleX(0); }
+
+radio:active, check:active { -gtk-icon-transform: scale(0, 1); }
+
+radio:checked:not(:backdrop), radio:indeterminate:not(:backdrop), check:checked:not(:backdrop), check:indeterminate:not(:backdrop) { -gtk-icon-transform: unset; transition: 400ms; }
+
+menu menuitem radio:checked:not(:backdrop), menu menuitem radio:indeterminate:not(:backdrop), menu menuitem check:checked:not(:backdrop), menu menuitem check:indeterminate:not(:backdrop) { transition: none; }
+
+treeview.view check:selected:focus, treeview.view check:selected, treeview.view radio:selected:focus, treeview.view radio:selected { color: #1e1715; border: 1px solid #e9b9a7; }
+
+treeview.view check:selected:focus:backdrop, treeview.view check:selected:backdrop, treeview.view radio:selected:focus:backdrop, treeview.view radio:selected:backdrop { border-color: #bf9a8c; }
+
+/************ GtkScale * */
+levelbar block.empty, progressbar trough, scale fill, scale trough { border: none; border-radius: 8px; background-color: #372b26; }
+
+levelbar block.empty:disabled, progressbar trough:disabled, scale fill:disabled, scale trough:disabled { background-color: #372b26; }
+
+levelbar block.empty:backdrop, progressbar trough:backdrop, scale fill:backdrop, scale trough:backdrop { background-color: #312824; transition: 150ms ease-out; }
+
+levelbar block.empty:backdrop:disabled, progressbar trough:backdrop:disabled, scale fill:backdrop:disabled, scale trough:backdrop:disabled { background-color: #312824; }
+
+row:selected levelbar block.empty, levelbar row:selected block.empty, row:selected progressbar trough, progressbar row:selected trough, row:selected scale fill, scale row:selected fill, row:selected scale trough, scale row:selected trough { border: 1px solid #1e1715; }
+
+progressbar progress, scale highlight { border: none; border-radius: 8px; background-color: #fcc8b4; background: image(#fcc8b4); }
+
+scale.vertical progressbar progress, progressbar scale.vertical progress, scale.vertical highlight, progressbar.vertical progress, progressbar.vertical scale highlight, scale progressbar.vertical highlight { background: image(#fcc8b4); }
+
+progressbar progress:disabled, scale highlight:disabled { background-image: none; background-color: #52403a; }
+
+progressbar progress:backdrop, scale highlight:backdrop { background-image: none; background-color: #a18479; }
+
+progressbar progress:backdrop:disabled, scale highlight:backdrop:disabled { background-image: none; background-color: #463935; }
+
+row:selected progressbar progress, progressbar row:selected progress, row:selected scale highlight, scale row:selected highlight { border: 1px solid #1e1715; }
+
+scale { min-height: 10px; min-width: 10px; padding: 12px; }
+
+scale slider { min-height: 16px; min-width: 16px; margin: -8px; }
+
+scale.fine-tune.horizontal { padding-top: 9px; padding-bottom: 9px; min-height: 16px; }
+
+scale.fine-tune.vertical { padding-left: 9px; padding-right: 9px; min-width: 16px; }
+
+scale.fine-tune slider { margin: -6px; }
+
+scale.fine-tune fill, scale.fine-tune highlight, scale.fine-tune trough { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+scale trough { outline-offset: 2px; -gtk-outline-radius: 8px; }
+
+scale fill:backdrop, scale fill { background-color: #372b26; }
+
+scale fill:disabled:backdrop, scale fill:disabled { border-color: transparent; background-color: transparent; }
+
+scale slider { border: 2px solid #fcc8b4; border-radius: 100%; background-color: #271e1b; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-property: background, border, box-shadow; }
+
+row scale slider, popover scale slider { background-color: #1e1715; }
+
+scale slider:hover { background-color: #1e1715; }
+
+row scale slider:hover, popover scale slider:hover { background-color: #271e1b; }
+
+scale slider:active, row scale slider:active, popover scale slider:active { background-color: #fcc8b4; }
+
+scale slider:disabled { border-color: #52403a; }
+
+scale slider:backdrop { background-color: #201a18; border-color: #a18479; transition: 150ms ease-out; }
+
+scale slider:backdrop:disabled { border-color: #463935; }
+
+row:selected scale slider:disabled, row:selected scale slider { border-color: #e9b9a7; }
+
+scale marks, scale value { color: alpha(currentColor,0.55); font-feature-settings: "tnum"; }
+
+scale.horizontal marks.top { margin-bottom: 6px; margin-top: -12px; }
+
+scale.horizontal.fine-tune marks.top { margin-bottom: 6px; margin-top: -9px; }
+
+scale.horizontal marks.bottom { margin-top: 6px; margin-bottom: -12px; }
+
+scale.horizontal.fine-tune marks.bottom { margin-top: 6px; margin-bottom: -9px; }
+
+scale.vertical marks.top { margin-right: 6px; margin-left: -12px; }
+
+scale.vertical.fine-tune marks.top { margin-right: 6px; margin-left: -9px; }
+
+scale.vertical marks.bottom { margin-left: 6px; margin-right: -12px; }
+
+scale.vertical.fine-tune marks.bottom { margin-left: 6px; margin-right: -9px; }
+
+scale.horizontal indicator { min-height: 6px; min-width: 1px; }
+
+scale.horizontal.fine-tune indicator { min-height: 3px; }
+
+scale.vertical indicator { min-height: 1px; min-width: 6px; }
+
+scale.vertical.fine-tune indicator { min-width: 3px; }
+
+scale.horizontal.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #fcc8b4; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-top: -13px; background-position: top; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:hover { color: #fddacd; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:active { color: #fcc8b4; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:disabled { color: #52403a; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop { color: #a18479; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop:disabled { color: #463935; }
+
+scale.horizontal.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-top: -11px; }
+
+scale.horizontal.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #fcc8b4; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-bottom: -13px; background-position: bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:hover { color: #fddacd; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:active { color: #fcc8b4; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:disabled { color: #52403a; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop { color: #a18479; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop:disabled { color: #463935; }
+
+scale.horizontal.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-bottom: -11px; }
+
+scale.vertical.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #fcc8b4; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-left: -13px; background-position: left bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-before:not(.marks-after) slider:hover { color: #fddacd; }
+
+scale.vertical.marks-before:not(.marks-after) slider:active { color: #fcc8b4; }
+
+scale.vertical.marks-before:not(.marks-after) slider:disabled { color: #52403a; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop { color: #a18479; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop:disabled { color: #463935; }
+
+scale.vertical.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-left: -11px; }
+
+scale.vertical.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #fcc8b4; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-right: -13px; background-position: right bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-after:not(.marks-before) slider:hover { color: #fddacd; }
+
+scale.vertical.marks-after:not(.marks-before) slider:active { color: #fcc8b4; }
+
+scale.vertical.marks-after:not(.marks-before) slider:disabled { color: #52403a; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop { color: #a18479; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop:disabled { color: #463935; }
+
+scale.vertical.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-right: -11px; }
+
+scale.color { min-height: 0; min-width: 0; }
+
+scale.color trough { background-color: transparent; }
+
+scale.color.horizontal { padding: 0 0 15px 0; }
+
+scale.color.horizontal trough { padding-bottom: 4px; background-position: 0 -3px; border-top-left-radius: 0; border-top-right-radius: 0; }
+
+scale.color.horizontal slider:dir(ltr):hover, scale.color.horizontal slider:dir(ltr):backdrop, scale.color.horizontal slider:dir(ltr):disabled, scale.color.horizontal slider:dir(ltr):backdrop:disabled, scale.color.horizontal slider:dir(ltr), scale.color.horizontal slider:dir(rtl):hover, scale.color.horizontal slider:dir(rtl):backdrop, scale.color.horizontal slider:dir(rtl):disabled, scale.color.horizontal slider:dir(rtl):backdrop:disabled, scale.color.horizontal slider:dir(rtl) { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.vertical:dir(ltr) { padding: 0 0 0 15px; }
+
+scale.color.vertical:dir(ltr) trough { padding-left: 4px; background-position: 3px 0; border-bottom-right-radius: 0; border-top-right-radius: 0; }
+
+scale.color.vertical:dir(ltr) slider:hover, scale.color.vertical:dir(ltr) slider:backdrop, scale.color.vertical:dir(ltr) slider:disabled, scale.color.vertical:dir(ltr) slider:backdrop:disabled, scale.color.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.vertical:dir(rtl) { padding: 0 15px 0 0; }
+
+scale.color.vertical:dir(rtl) trough { padding-right: 4px; background-position: -3px 0; border-bottom-left-radius: 0; border-top-left-radius: 0; }
+
+scale.color.vertical:dir(rtl) slider:hover, scale.color.vertical:dir(rtl) slider:backdrop, scale.color.vertical:dir(rtl) slider:disabled, scale.color.vertical:dir(rtl) slider:backdrop:disabled, scale.color.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr), scale.color.fine-tune.horizontal:dir(rtl) { padding: 0 0 12px 0; }
+
+scale.color.fine-tune.horizontal:dir(ltr) trough, scale.color.fine-tune.horizontal:dir(rtl) trough { padding-bottom: 7px; background-position: 0 -6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr) slider, scale.color.fine-tune.horizontal:dir(rtl) slider { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.fine-tune.vertical:dir(ltr) { padding: 0 0 0 12px; }
+
+scale.color.fine-tune.vertical:dir(ltr) trough { padding-left: 7px; background-position: 6px 0; }
+
+scale.color.fine-tune.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.fine-tune.vertical:dir(rtl) { padding: 0 12px 0 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) trough { padding-right: 7px; background-position: -6px 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+/***************** Progress bars * */
+@keyframes progress { from { background-position: 0, calc(0% - 64px), 0%; }
+  to { background-position: 0, calc(100% + 64px), 0%; } }
+
+progressbar { font-size: smaller; color: rgba(252, 200, 180, 0.4); font-feature-settings: "tnum"; }
+
+progressbar.horizontal trough, progressbar.horizontal progress { min-height: 4px; }
+
+progressbar.vertical trough, progressbar.vertical progress { min-width: 4px; }
+
+progressbar:backdrop { box-shadow: none; transition: 150ms ease-out; }
+
+progressbar trough { border-radius: 999px; }
+
+progressbar progress { background-image: none; background-color: #fcc8b4; border-radius: 999px; }
+
+progressbar progress, progressbar progress:backdrop, .horizontal progressbar progress { animation: none; }
+
+progressbar.horizontal progress { margin: 0 -1px; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled) { animation: progress 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite; background-size: cover, 64px 100%; background-repeat: no-repeat; background-image: linear-gradient(to bottom, alpha(@progress_bg_color, 0.2), rgba(209, 166, 149, 0)), linear-gradient(to right, rgba(209, 166, 149, 0), #d1a695 60%, rgba(209, 166, 149, 0)); }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled).right { animation-direction: reverse; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled):backdrop { animation: none; background-image: none; }
+
+progressbar.vertical progress { margin: -1px 0; }
+
+progressbar.osd { min-width: 4px; min-height: 4px; background-color: transparent; }
+
+progressbar.osd trough { border-style: none; border-radius: 0; background-color: transparent; box-shadow: none; }
+
+progressbar.osd progress { border-style: none; border-radius: 0; }
+
+progressbar trough.empty progress { all: unset; }
+
+/************* Level Bar * */
+levelbar.horizontal block { min-height: 4px; }
+
+levelbar.horizontal.discrete block { margin: 0 2px; min-width: 32px; }
+
+levelbar.horizontal.discrete block:first-child { margin-left: 0; }
+
+levelbar.horizontal.discrete block:last-child { margin-right: 0; }
+
+levelbar.vertical block { min-width: 4px; }
+
+levelbar.vertical.discrete block { margin: 2px 0; min-height: 32px; }
+
+levelbar.vertical.discrete block:first-child { margin-top: 0; }
+
+levelbar.vertical.discrete block:last-child { margin-bottom: 0; }
+
+levelbar:backdrop { transition: 150ms ease-out; }
+
+levelbar trough { border: none; padding: 0; background-color: transparent; }
+
+levelbar block { border: none; border-radius: 999px; }
+
+levelbar block.warning-battery-offset { background-color: #fb7c7c; background: image(#fb7c7c); }
+
+levelbar block.warning-battery-offset:backdrop { background-image: none; background-color: #a18479; }
+
+levelbar block.low, levelbar block.low-battery-offset { background-color: #faa483; background: image(#faa483); }
+
+levelbar block.low:backdrop, levelbar block.low-battery-offset:backdrop { background-image: none; background-color: #a18479; }
+
+levelbar block.high, levelbar block:not(.empty) { background-color: #fcc8b4; background: image(#fcc8b4); }
+
+levelbar block.high:backdrop, levelbar block:not(.empty):backdrop { background-image: none; background-color: #a18479; }
+
+levelbar block.full, levelbar block.high-battery-offset { background-color: #6ee1b6; background: image(#6ee1b6); }
+
+levelbar block.full:backdrop, levelbar block.high-battery-offset:backdrop { background-image: none; background-color: #a18479; }
+
+levelbar block.empty { background-image: none; }
+
+levelbar block:disabled { background-image: none; background-color: #52403a; }
+
+levelbar block:disabled:backdrop { background-image: none; background-color: #463935; }
+
+/**************** Print dialog * */
+printdialog paper { color: black; border: 1px solid #595959; background: white; padding: 0; }
+
+printdialog paper:backdrop { color: #595959; border: 1px solid #262626; }
+
+printdialog .dialog-action-box { margin: 12px; }
+
+/********** Frames * */
+frame > border, .frame { box-shadow: none; margin: 0; padding: 0; border-radius: 10px; border: 1px solid #271e1b; }
+
+frame > border.flat, .frame.flat { border-style: none; }
+
+frame > border:backdrop, .frame:backdrop { border-color: #201a18; }
+
+.background.csd revealer > actionbar { border-radius: 0 0 10px 10px; }
+
+actionbar > revealer > box { padding: 6px; border-top: 1px solid #372b26; }
+
+actionbar > revealer > box:backdrop { border-color: #312824; }
+
+scrolledwindow { background-color: transparent; border-radius: 0 0 8px 8px; }
+
+scrolledwindow viewport.frame { border-style: none; }
+
+scrolledwindow overshoot.top { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(rgba(252, 200, 180, 0.5)), to(rgba(252, 200, 180, 0))), -gtk-gradient(radial, center top, 0, center top, 0.6, from(rgba(252, 200, 180, 0.1)), to(rgba(252, 200, 180, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.top:backdrop { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(#312824), to(rgba(49, 40, 36, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(rgba(252, 200, 180, 0.5)), to(rgba(252, 200, 180, 0))), -gtk-gradient(radial, center bottom, 0, center bottom, 0.6, from(rgba(252, 200, 180, 0.1)), to(rgba(252, 200, 180, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom:backdrop { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(#312824), to(rgba(49, 40, 36, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(rgba(252, 200, 180, 0.5)), to(rgba(252, 200, 180, 0))), -gtk-gradient(radial, left center, 0, left center, 0.6, from(rgba(252, 200, 180, 0.1)), to(rgba(252, 200, 180, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left:backdrop { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(#312824), to(rgba(49, 40, 36, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(rgba(252, 200, 180, 0.5)), to(rgba(252, 200, 180, 0))), -gtk-gradient(radial, right center, 0, right center, 0.6, from(rgba(252, 200, 180, 0.1)), to(rgba(252, 200, 180, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right:backdrop { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(#312824), to(rgba(49, 40, 36, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+scrolledwindow junction { border-color: transparent; border-image: linear-gradient(to bottom, #372b26 1px, transparent 1px) 0 0 0 1/0 1px stretch; background-color: transparent; }
+
+scrolledwindow junction:dir(rtl) { border-image-slice: 0 1 0 0; }
+
+scrolledwindow junction:backdrop { border-image-source: linear-gradient(to bottom, #312824 1px, transparent 1px); background-color: transparent; transition: 150ms ease-out; }
+
+separator { background: #372b26; min-width: 1px; min-height: 1px; }
+
+/********* Lists * */
+list { color: #fcc8b4; background-color: #1e1715; border-color: transparent; border-radius: 10px; }
+
+list, list.frame { padding-top: 4px; padding-bottom: 4px; }
+
+list.content, list.content list { background-color: transparent; padding: 0; }
+
+list:backdrop { background-color: #191413; color: #8a736a; border-color: transparent; }
+
+list separator.horizontal { margin: 1px 16px; }
+
+list separator.vertical { margin: 16px 1px; }
+
+list row { padding: 2px; }
+
+row { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+list:not(.content) row { border-radius: 8px; margin: 1px 6px; }
+
+list.content row { background-color: #1e1715; }
+
+list.content row:backdrop { background-color: #191413; }
+
+list.content row:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+list.content row:last-child { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+row.expander { padding: 0px; }
+
+row:hover { transition: none; }
+
+row:backdrop { transition: 150ms ease-out; }
+
+row.activatable { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+row.activatable.has-open-popup, row.activatable:hover { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #372b26; background-image: none; background-color: rgba(252, 200, 180, 0.05); }
+
+row.activatable:active { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #473832; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, rgba(252, 200, 180, 0.15) 10%, transparent 0%); background-size: 0% 0%; }
+
+row.activatable:backdrop:hover { background-color: transparent; background-image: none; background-image: none; color: #8a736a; }
+
+row.activatable:selected { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; background: image(#fcc8b4); box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); }
+
+row.activatable:selected label { color: #1e1715; }
+
+row.activatable:selected:active { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); }
+
+row.activatable:selected:backdrop { background-color: #a18479; background-image: none; box-shadow: none; }
+
+row.activatable:selected:backdrop label, row.activatable:selected:backdrop { color: #191413; }
+
+/********************* App Notifications * */
+.app-notification, .app-notification.frame { padding: 10px; margin: 8px; border-radius: 30px; border: 1px solid rgba(55, 43, 38, 0.75); box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification:backdrop, .app-notification.frame:backdrop { background-color: #191413; transition: 150ms ease-out; border-color: rgba(49, 40, 36, 0.75); box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification border, .app-notification.frame border { border: none; }
+
+.app-notification button:not(.linked), .app-notification.frame button:not(.linked) { border-radius: 999px; -gtk-outline-radius: 999px; }
+
+/************* Expanders * */
+expander title > arrow { min-width: 16px; min-height: 16px; -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+expander title > arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+expander title > arrow:hover { color: white; }
+
+expander title > arrow:disabled { color: #927367; }
+
+expander title > arrow:disabled:backdrop { color: #4c3e39; }
+
+expander title > arrow:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+/************ Calendar * */
+calendar { color: #fcc8b4; }
+
+calendar:selected { border-radius: 8px; }
+
+calendar.header { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.header:backdrop { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.button { color: rgba(252, 200, 180, 0.45); }
+
+calendar.button:hover { color: #fcc8b4; }
+
+calendar.button:backdrop { color: rgba(138, 115, 106, 0.45); }
+
+calendar.button:disabled { color: rgba(146, 115, 103, 0.45); }
+
+calendar.highlight { color: #927367; }
+
+calendar.highlight:backdrop { color: #4c3e39; }
+
+calendar:backdrop { color: #8a736a; border-color: #312824; }
+
+calendar:indeterminate { color: alpha(currentColor,0.1); }
+
+/*********** Dialogs * */
+messagedialog .titlebar { min-height: 20px; background-image: none; background-color: #271e1b; border-style: none; border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+messagedialog.csd.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button { padding: 10px 14px; border-right-style: none; border-bottom-style: none; border-radius: 0; margin: 0 2px 0 0; -gtk-outline-radius: 0; }
+
+messagedialog.csd .dialog-action-area button:first-child { border-left-style: none; border-bottom-left-radius: 10px; -gtk-outline-bottom-left-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button:last-child { border-bottom-right-radius: 10px; margin-right: 0; -gtk-outline-bottom-right-radius: 10px; }
+
+filechooser .dialog-action-box { border-top: 1px solid #372b26; }
+
+filechooser .dialog-action-box:backdrop { border-top-color: #312824; }
+
+filechooser #pathbarbox { border: none; }
+
+filechooser #pathbarbox:backdrop { background-color: #201a18; }
+
+filechooserbutton:drop(active) { box-shadow: none; border-color: transparent; }
+
+/*********** Sidebar * */
+.sidebar { border-style: none; background-color: transparent; border-radius: 0 0 10px 10px; }
+
+stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:not(separator):dir(ltr), .sidebar:not(separator).left { border-right: 1px solid #372b26; border-left-style: none; }
+
+stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:not(separator):dir(rtl), .sidebar:not(separator).right { border-left: 1px solid #372b26; border-right-style: none; }
+
+.sidebar:backdrop { border-color: #312824; transition: 150ms ease-out; }
+
+.sidebar list { background-color: transparent; }
+
+paned .sidebar.left, paned .sidebar.right, paned .sidebar.left:dir(rtl), paned .sidebar:dir(rtl), paned .sidebar:dir(ltr), paned .sidebar { border-style: none; }
+
+stacksidebar row { padding: 10px 4px; }
+
+stacksidebar row > label { padding-left: 6px; padding-right: 6px; }
+
+stacksidebar row.needs-attention > label { background-size: 6px 6px, 0 0; }
+
+separator.sidebar { background-color: #372b26; }
+
+separator.sidebar:backdrop { background-color: #312824; }
+
+separator.sidebar.selection-mode, .selection-mode separator.sidebar { background-color: #e9b9a7; }
+
+/**************** File chooser * */
+row image.sidebar-icon { opacity: 0.7; }
+
+placessidebar > viewport.frame { border-style: none; background-color: transparent; }
+
+placessidebar undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+placessidebar list { padding-top: 0; }
+
+placessidebar row { min-height: 36px; padding: 0px; margin-top: 0; margin-bottom: 0; }
+
+placessidebar row:first-child { margin-top: 0; }
+
+placessidebar row > revealer { padding: 0 8px; }
+
+placessidebar row:selected { color: #1e1715; }
+
+placessidebar row:disabled { color: #927367; }
+
+placessidebar row:backdrop { color: #8a736a; }
+
+placessidebar row:backdrop:selected { color: #191413; }
+
+placessidebar row:backdrop:disabled { color: #4c3e39; }
+
+placessidebar row image.sidebar-icon:dir(ltr) { padding-right: 8px; }
+
+placessidebar row image.sidebar-icon:dir(rtl) { padding-left: 8px; }
+
+placessidebar row label.sidebar-label:dir(ltr) { padding-right: 2px; }
+
+placessidebar row label.sidebar-label:dir(rtl) { padding-left: 2px; }
+
+button.sidebar-button { min-height: 26px; min-width: 26px; margin: 0; padding: 0; border-radius: 100%; -gtk-outline-radius: 100%; }
+
+button.sidebar-button:not(:hover):not(:active) > image, button.sidebar-button:backdrop > image { opacity: 0.7; }
+
+placessidebar row:selected:active { box-shadow: none; }
+
+placessidebar row.sidebar-placeholder-row { padding: 0 8px; min-height: 2px; background-image: image(#4cd9a4); background-clip: content-box; }
+
+placessidebar row.sidebar-new-bookmark-row { color: #fcc8b4; }
+
+placessidebar row:drop(active):not(:disabled) { color: #4cd9a4; box-shadow: inset 0 0 0 2px #4cd9a4; }
+
+placessidebar row:drop(active):not(:disabled):selected { color: #1e1715; background-color: #4cd9a4; }
+
+placesview list { background-color: #271e1b; border-radius: 0 0 10px 0; }
+
+placesview list:backdrop { background-color: #201a18; }
+
+placesview .server-list-button > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(0turn); }
+
+placesview .server-list-button:checked > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(-0.5turn); }
+
+placesview row.activatable:hover { background-color: transparent; }
+
+placesview > actionbar > revealer > box > label { padding-left: 8px; padding-right: 8px; }
+
+/********* Paned * */
+paned > separator { min-width: 1px; min-height: 1px; -gtk-icon-source: none; border-style: none; background-color: transparent; background-image: image(#372b26); background-size: 1px 1px; }
+
+paned > separator:selected { background-image: image(#fcc8b4); }
+
+paned > separator:backdrop { background-image: image(#312824); }
+
+paned > separator.wide { min-width: 5px; min-height: 5px; background-color: #271e1b; background-image: image(#372b26), image(#372b26); background-size: 1px 1px, 1px 1px; }
+
+paned > separator.wide:backdrop { background-color: #201a18; background-image: image(#312824), image(#312824); }
+
+paned.horizontal > separator { background-repeat: repeat-y; }
+
+paned.horizontal > separator:dir(ltr) { margin: 0 -8px 0 0; padding: 0 8px 0 0; background-position: left; }
+
+paned.horizontal > separator:dir(rtl) { margin: 0 0 0 -8px; padding: 0 0 0 8px; background-position: right; }
+
+paned.horizontal > separator.wide { margin: 0; padding: 0; background-repeat: repeat-y, repeat-y; background-position: left, right; }
+
+paned.vertical > separator { margin: 0 0 -8px 0; padding: 0 0 8px 0; background-repeat: repeat-x; background-position: top; }
+
+paned.vertical > separator.wide { margin: 0; padding: 0; background-repeat: repeat-x, repeat-x; background-position: bottom, top; }
+
+/************** GtkInfoBar * */
+infobar { border-style: none; }
+
+infobar.action:hover > revealer > box { background-color: #2c1d17; border-bottom: 1px solid #271e1b; }
+
+infobar.info, infobar.question, infobar.warning, infobar.error { text-shadow: none; }
+
+infobar.info:backdrop > revealer > box, infobar.info > revealer > box, infobar.question:backdrop > revealer > box, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box, infobar.error > revealer > box { background-color: #32211a; border-bottom: 1px solid #271e1b; }
+
+infobar.info:backdrop > revealer > box label, infobar.info:backdrop > revealer > box, infobar.info > revealer > box label, infobar.info > revealer > box, infobar.question:backdrop > revealer > box label, infobar.question:backdrop > revealer > box, infobar.question > revealer > box label, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box label, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box label, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box label, infobar.error:backdrop > revealer > box, infobar.error > revealer > box label, infobar.error > revealer > box { color: #faa483; }
+
+infobar.info:backdrop, infobar.question:backdrop, infobar.warning:backdrop, infobar.error:backdrop { text-shadow: none; }
+
+infobar.info button, infobar.question button, infobar.warning button, infobar.error button { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #412b22; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #50352a; background-image: none; }
+
+infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #5a3b2f; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #6e483a 10%, transparent 0%); background-size: 0% 0%; }
+
+infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; background: image(#fcc8b4); box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); }
+
+infobar.info button:checked:active, infobar.question button:checked:active, infobar.warning button:checked:active, infobar.error button:checked:active { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); }
+
+infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled { color: #927367; background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop, infobar.question button:backdrop, infobar.warning button:backdrop, infobar.error button:backdrop { background-color: #28211e; background-image: none; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.error button:backdrop label, infobar.error button:backdrop { color: #8a736a; }
+
+infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop:disabled label, infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled label, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled label, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled label, infobar.error button:backdrop:disabled { color: #4c3e39; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.info button label, infobar.info button, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.question button label, infobar.question button, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.warning button label, infobar.warning button, infobar.error button:backdrop label, infobar.error button:backdrop, infobar.error button label, infobar.error button { color: #faa483; }
+
+infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection { background-color: #090706; }
+
+infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link { color: #feece5; }
+
+/************ Tooltips * */
+tooltip { padding: 4px; /* not working */ border-radius: 10px; box-shadow: none; }
+
+tooltip.background, tooltip.background.csd { border-radius: 10px; background-color: rgba(0, 0, 0, 0.8); background-clip: padding-box; border: 1px solid rgba(255, 255, 255, 0.1); }
+
+tooltip decoration { background-color: transparent; }
+
+tooltip * { padding: 4px; background-color: transparent; color: white; }
+
+/***************** Color Chooser * */
+colorswatch:drop(active), colorswatch { border-style: none; }
+
+colorswatch.top { border-top-left-radius: 8.5px; border-top-right-radius: 8.5px; }
+
+colorswatch.top overlay { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+colorswatch.bottom { border-bottom-left-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.bottom overlay { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.left, colorswatch:first-child:not(.top) { border-top-left-radius: 8.5px; border-bottom-left-radius: 8.5px; }
+
+colorswatch.left overlay, colorswatch:first-child:not(.top) overlay { border-top-left-radius: 8px; border-bottom-left-radius: 8px; }
+
+colorswatch.right, colorswatch:last-child:not(.bottom) { border-top-right-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.right overlay, colorswatch:last-child:not(.bottom) overlay { border-top-right-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.dark { outline-color: rgba(255, 255, 255, 0.6); }
+
+colorswatch.dark overlay { color: white; }
+
+colorswatch.dark overlay:backdrop { color: rgba(255, 255, 255, 0.5); }
+
+colorswatch.light { outline-color: rgba(0, 0, 0, 0.6); }
+
+colorswatch.light overlay { color: black; }
+
+colorswatch.light overlay:backdrop { color: rgba(0, 0, 0, 0.5); }
+
+colorswatch:drop(active) { box-shadow: none; }
+
+colorswatch:drop(active).light overlay { border-color: #4cd9a4; }
+
+colorswatch:drop(active).dark overlay { border-color: #4cd9a4; }
+
+colorswatch overlay { border: 1px solid transparent; }
+
+colorswatch#add-color-button { border-radius: 8px 8px 0 0; }
+
+colorswatch#add-color-button:only-child { border-radius: 8px; }
+
+colorswatch#add-color-button overlay { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #372b26; background-image: none; }
+
+colorswatch#add-color-button overlay:hover { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-color: #473832; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop { background-color: #28211e; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop label, colorswatch#add-color-button overlay:backdrop { color: #8a736a; }
+
+colorswatch:disabled { opacity: 0.5; }
+
+colorswatch:disabled overlay { border-color: rgba(0, 0, 0, 0.6); box-shadow: none; }
+
+row:selected colorswatch { box-shadow: 0 0 0 2px #1e1715; }
+
+colorswatch#editor-color-sample { border-radius: 8px; }
+
+colorswatch#editor-color-sample overlay { border-radius: 8.5px; }
+
+colorchooser .popover.osd { border-radius: 8px; }
+
+/******** Misc * */
+.content-view { background-color: #201816; }
+
+.content-view:hover { -gtk-icon-effect: highlight; }
+
+.content-view:backdrop { background-color: #191413; }
+
+.osd .scale-popup button.flat { border-style: none; border-radius: 8px; }
+
+.scale-popup button:hover { background-color: rgba(252, 200, 180, 0.15); border-radius: 8px; }
+
+/********************** Window Decorations * */
+decoration { border-radius: 10px; border-width: 0px; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(252, 200, 180, 0.1); margin: 10px; }
+
+decoration:backdrop { box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(138, 115, 106, 0.125); transition: 150ms ease-out; }
+
+.maximized decoration, .fullscreen decoration, .tiled decoration, .tiled-top decoration, .tiled-right decoration, .tiled-bottom decoration, .tiled-left decoration { border-radius: 0; }
+
+.popup decoration { box-shadow: none; }
+
+.ssd decoration { box-shadow: 0 0 0 1px rgba(252, 200, 180, 0.1); }
+
+.csd.popup decoration { border-radius: 8px; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(252, 200, 180, 0.1); }
+
+.csd.popup decoration:backdrop { box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(138, 115, 106, 0.125); }
+
+tooltip.csd decoration { border-radius: 10px; box-shadow: none; }
+
+messagedialog.csd decoration { border-radius: 10px; box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(252, 200, 180, 0.1); }
+
+messagedialog.csd decoration:backdrop { box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(138, 115, 106, 0.125); }
+
+.solid-csd decoration { margin: 0; padding: 4px; background-color: #372b26; border: solid 1px #372b26; border-radius: 0; box-shadow: none; }
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized), window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration, window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration-overlay { border-radius: 10px; }
+
+button.titlebutton:not(.appmenu) { border-radius: 9999px; padding: 6px; margin: 0 2px; min-width: 0; min-height: 0; }
+
+button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.selection-mode headerbar button.titlebutton:backdrop, .selection-mode .titlebar button.titlebutton:backdrop, headerbar.selection-mode button.titlebutton:backdrop, .titlebar.selection-mode button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { background-color: #fcc8b4; }
+
+.selection-mode button.titlebutton, .view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { color: #1e1715; }
+
+.selection-mode button.titlebutton:disabled, .view:disabled:selected, textview text:disabled:selected:focus, .view text:disabled:selected, textview text:disabled:selected, iconview:disabled:selected:focus, iconview:disabled:selected, flowbox flowboxchild:disabled:selected, modelbutton.flat:disabled:selected, .menuitem.button.flat:disabled:selected, treeview.view:disabled:selected, row:disabled:selected, calendar:disabled:selected { color: #8d6f65; }
+
+.selection-mode button.titlebutton:backdrop, .view:backdrop:selected, textview text:backdrop:selected:focus, .view text:backdrop:selected, textview text:backdrop:selected, iconview:backdrop:selected:focus, iconview:backdrop:selected, flowbox flowboxchild:backdrop:selected, modelbutton.flat:backdrop:selected, .menuitem.button.flat:backdrop:selected, treeview.view:backdrop:selected, row:backdrop:selected, calendar:backdrop:selected { color: #191413; background-color: #a18479; }
+
+.selection-mode button.titlebutton:backdrop:disabled, .view:backdrop:disabled:selected, .view text:backdrop:disabled:selected, textview text:backdrop:disabled:selected, iconview:backdrop:disabled:selected, flowbox flowboxchild:backdrop:disabled:selected, modelbutton.flat:backdrop:disabled:selected, .menuitem.button.flat:backdrop:disabled:selected, row:backdrop:disabled:selected, calendar:backdrop:disabled:selected { color: #b89284; }
+
+.view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { background-color: #57443d; }
+
+label:selected, .view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { color: #fcc8b4; }
+
+label:disabled selection, label:disabled:selected, .view text selection:disabled, textview text selection:disabled:focus, textview text selection:disabled, iconview text selection:disabled:focus, iconview text selection:disabled, label selection:disabled, entry selection:disabled, spinbutton:not(.vertical) selection:disabled { color: #9d7b6f; }
+
+label:backdrop selection, label:backdrop:selected, .view text selection:backdrop, textview text selection:backdrop:focus, textview text selection:backdrop, iconview text selection:backdrop:focus, iconview text selection:backdrop, label selection:backdrop, entry selection:backdrop, spinbutton:not(.vertical) selection:backdrop { background-color: #3d322e; color: #8d746b; }
+
+label:backdrop selection:disabled, label:backdrop:disabled:selected, .view text selection:backdrop:disabled, textview text selection:backdrop:disabled, iconview text selection:backdrop:disabled, label selection:backdrop:disabled, entry selection:backdrop:disabled, spinbutton:not(.vertical) selection:backdrop:disabled { color: #54453f; }
+
+.monospace { font-family: monospace; }
+
+/********************** Touch Copy & Paste * */
+cursor-handle { background-color: transparent; background-image: none; box-shadow: none; border-style: none; color: #fcc8b4; }
+
+cursor-handle:hover { color: #fffefe; }
+
+cursor-handle:active { color: #fcc8b4; }
+
+cursor-handle.top:dir(ltr), cursor-handle.bottom:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-start-symbolic.svg")), -gtk-recolor(url("assets/text-select-start-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.bottom:dir(ltr), cursor-handle.top:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-end-symbolic.svg")), -gtk-recolor(url("assets/text-select-end-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); }
+
+.context-menu { font: initial; }
+
+.keycap { min-width: 20px; min-height: 25px; margin-top: 2px; padding-bottom: 3px; padding-left: 6px; padding-right: 6px; color: #fcc8b4; background-color: #1e1715; border: 1px solid; border-color: #372b26; border-radius: 4px; box-shadow: inset 0 -3px #2d231f; font-size: smaller; }
+
+.keycap:backdrop { background-color: #191413; color: #8a736a; transition: 150ms ease-out; }
+
+:not(decoration):not(window):drop(active):focus, :not(decoration):not(window):drop(active) { border-color: #4cd9a4; box-shadow: inset 0 0 0 1px #4cd9a4; caret-color: #4cd9a4; }
+
+stackswitcher button.text-button { min-width: 100px; }
+
+stackswitcher button.circular, stackswitcher button.text-button.circular { min-width: 32px; min-height: 32px; padding: 0; }
+
+/************* App Icons * */
+/* Outline for low res icons */
+.lowres-icon { -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/* Dropshadow for large icons */
+.icon-dropshadow { -gtk-icon-shadow: 0 1px 12px rgba(0, 0, 0, 0.05), 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/********* Emoji * */
+popover.emoji-picker { padding-left: 0; padding-right: 0; }
+
+popover.emoji-picker entry.search { margin: 3px 5px 5px 5px; }
+
+button.emoji-section { border-color: transparent; border-width: 3px; border-style: none none solid; border-radius: 0; margin: 2px 4px 2px 4px; padding: 3px 0 0; min-width: 32px; min-height: 28px; /* reset props inherited from the button style */ background: none; box-shadow: none; text-shadow: none; outline-offset: -5px; }
+
+button.emoji-section:first-child { margin-left: 7px; }
+
+button.emoji-section:last-child { margin-right: 7px; }
+
+button.emoji-section:backdrop:not(:checked) { border-color: transparent; }
+
+button.emoji-section:hover { border-color: #372b26; }
+
+button.emoji-section:checked { color: #fcc8b4; border-color: #fcc8b4; }
+
+button.emoji-section:checked:backdrop { color: #8a736a; background-color: transparent; }
+
+button.emoji-section label { padding: 0; opacity: 0.55; }
+
+button.emoji-section:hover label { opacity: 0.775; }
+
+button.emoji-section:checked label { opacity: 1; }
+
+popover.emoji-picker .emoji { font-size: x-large; padding: 6px; }
+
+popover.emoji-picker .emoji :hover { background: #fcc8b4; border-radius: 8px; }
+
+popover.emoji-completion arrow { border: none; background: none; }
+
+popover.emoji-completion contents row box { padding: 2px 10px; }
+
+popover.emoji-completion .emoji:hover { background: #372b26; }
+
+/***************** View Switcher * */
+viewswitcher button { margin: 0; padding: 0; border-radius: 0; border: none; box-shadow: none; }
+
+viewswitcher button:checked { box-shadow: none; }
+
+viewswitcher button stack > box.narrow { font-size: smaller; padding-top: 6px; padding-bottom: 6px; }
+
+viewswitcher button stack > box.narrow image, viewswitcher button stack > box.narrow label { padding-left: 6px; padding-right: 6px; }
+
+viewswitcher button stack > box.wide { padding: 0 12px; }
+
+viewswitcherbar > actionbar > revealer > box { padding: 0; }
+
+viewswitcherbar > actionbar > revealer > box viewswitcher button:not(:checked):not(:hover) { background: transparent; }
+
+headerbar viewswitcher > box > button:first-child { border-bottom-left-radius: 8px; }
+
+headerbar viewswitcher > box > button:last-child { border-bottom-right-radius: 8px; }
+
+/*********** Chromium * */
+window.background.chromium { background-color: #1e1715; }
+
+window.background.chromium headerbar.titlebar button.toggle, window.background.chromium headerbar.titlebar button.titlebutton { border: none; }
+
+window.background.chromium headerbar.titlebar button.titlebutton { background-image: none; }
+
+window.background.chromium button { border-style: solid; border-width: 1px; border-color: #372b26; }
+
+window.background.chromium > textview.view { background-color: #271e1b; }
+
+/*********** Firefox * */
+#MozillaGtkWidget.background { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+
+#MozillaGtkWidget.background scrollbar { background-color: transparent; border-color: transparent; }
+
+/****************** Gnome Calendar * */
+window.background.csd.org-gnome-Calendar > overlay > box.vertical > stack.view { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > button.text-button { margin: 0; border-bottom-right-radius: 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > stack > .sidebar.vertical { border-radius: 0; }
+
+window.background.csd.org-gnome-Calendar.maximized calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.tiled calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.fullscreen calendar-view.year-view > box.vertical > button.text-button { border-bottom-right-radius: 0; }
+
+/*************** LibreOffice * */
+toolbutton > button.image-button.text-button.flat button { background-color: transparent; background-image: none; background-image: none; }
+
+toolbutton > button.image-button.text-button.flat button:hover { background-color: #372b26; }
+
+toolbutton > button.image-button.text-button.flat button:active, toolbutton > button.image-button.text-button.flat button:checked { background-color: #473832; box-shadow: none; }
+
+window.background:not(.solid-csd) > notebook:not(.frame) tab { margin-bottom: 4px; }
+
+/************ Nautilus * */
+.nautilus-window .floating-bar { min-height: 32px; padding: 0; border-radius: 10px 10px 0 0; background-color: #1e1715; background-clip: padding-box; }
+
+.nautilus-window .floating-bar.bottom.left { margin-right: 7px; border-top-left-radius: 0; border-bottom-left-radius: 10px; }
+
+.nautilus-window .floating-bar.bottom.right { margin-left: 7px; border-top-right-radius: 0; border-bottom-right-radius: 10px; }
+
+.nautilus-window .floating-bar button { padding: 0; }
+
+.nautilus-window .nautilus-list-view { background-color: #1e1715; border-radius: 0 0 10px 10px; }
+
+.nautilus-window .nautilus-list-view treeview.view:not(:hover):not(:active):not(:selected) { background-color: transparent; border-radius: 0; }
+
+.nautilus-window.maximized .floating-bar, .nautilus-window.maximized .nautilus-list-view, .nautilus-window.tiled .floating-bar, .nautilus-window.tiled .nautilus-list-view, .nautilus-window.fullscreen .floating-bar, .nautilus-window.fullscreen .nautilus-list-view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.nautilus-window headerbar .path-bar-box { color: transparent; background: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; background: image(#fcc8b4); box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child:active { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { background-color: #a18479; background-image: none; box-shadow: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child label, .nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { color: #191413; }
+
+.nautilus-window notebook > header.top:dir(ltr) { border-top-left-radius: 0; }
+
+.nautilus-window notebook > header.top:dir(rtl) { border-top-right-radius: 0; }
+
+.nautilus-canvas-item { border-radius: 8px; }
+
+.nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator, headerbar .nautilus-canvas-item.subtitle, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle, popover.background label.nautilus-canvas-item.separator, .nautilus-list-dim-label { color: #9c7c6f; }
+
+.nautilus-canvas-item.dim-label:backdrop, label.nautilus-canvas-item.separator:backdrop, headerbar .nautilus-canvas-item.subtitle:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:backdrop, popover.background label.nautilus-canvas-item.separator:backdrop, .nautilus-list-dim-label:backdrop { color: #5a4b45; }
+
+.nautilus-canvas-item.dim-label:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected, label.nautilus-canvas-item.separator:selected:focus, headerbar .nautilus-canvas-item.subtitle:selected, headerbar .nautilus-canvas-item.subtitle:selected:focus, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus, popover.background label.nautilus-canvas-item.separator:selected, popover.background label.nautilus-canvas-item.separator:selected:focus, .nautilus-list-dim-label:selected, .nautilus-list-dim-label:selected:focus { color: rgba(30, 23, 21, 0.45); }
+
+.nautilus-canvas-item.dim-label:selected:backdrop, .nautilus-canvas-item.dim-label:selected:focus:backdrop, label.nautilus-canvas-item.separator:selected:backdrop, label.nautilus-canvas-item.separator:selected:focus:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:focus:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus:backdrop, popover.background label.nautilus-canvas-item.separator:selected:backdrop, popover.background label.nautilus-canvas-item.separator:selected:focus:backdrop, .nautilus-list-dim-label:selected:backdrop, .nautilus-list-dim-label:selected:focus:backdrop { color: rgba(25, 20, 19, 0.45); }
+
+.disk-space-display.unknown { background-color: rgba(252, 200, 180, 0.4); color: rgba(252, 200, 180, 0.4); }
+
+.disk-space-display.used { background-color: #fcc8b4; color: #fcc8b4; }
+
+.disk-space-display.free { background-color: rgba(252, 200, 180, 0.1); color: rgba(252, 200, 180, 0.1); }
+
+dialog > box > grid > scrolledwindow > viewport > box > list { padding: 0; background-color: transparent; border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list:backdrop { background-color: transparent; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list > row { border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list separator.horizontal { margin: 0; }
+
+/**************************************************** documents-scrolledwin (Totem, Documents, EvView) * */
+.documents-scrolledwin:backdrop, .documents-scrolledwin { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover), .documents-scrolledwin .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin .content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:hover, .documents-scrolledwin .content-view:hover { background-color: rgba(252, 200, 180, 0.075); }
+
+.documents-scrolledwin:backdrop viewport.frame, .documents-scrolledwin viewport.frame { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover), .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover) border, .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) border { border: none; }
+
+/******************* Document Viewer * */
+window.background.csd > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { background-color: transparent; border-radius: 10px; }
+
+window.background.csd > box.vertical > paned.horizontal > box.vertical > scrolledwindow > treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+window.background.csd evview.view.content-view { background-color: transparent; border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.maximized > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { border-radius: 0; }
+
+window.background.csd.maximized evview.view.content-view, window.background.csd.tiled evview.view.content-view, window.background.csd.fullscreen evview.view.content-view { border-radius: 0; }
+
+/******************* Archive Manager * */
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow { border-radius: 0 0 10px 10px; background-color: #1e1715; }
+
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-radius: 0 0 0 10px; background-color: #271e1b; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/********* Geary * */
+frame.geary-conversation-frame scrolledwindow treeview.view:not(:selected) { background: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected { color: #1e1715; outline-color: rgba(30, 23, 21, 0.3); background-color: #fcc8b4; background: image(#fcc8b4); box-shadow: 0 2px 4px rgba(252, 200, 180, 0.2); box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { background-color: #a18479; background-image: none; box-shadow: none; box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop label, frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { color: #191413; }
+
+.geary_email { padding-bottom: 6px; border-radius: 8px; }
+
+.geary_email .geary-message { border-radius: 8px; }
+
+.geary-attachment-pane > separator.horizontal { margin: 0; }
+
+.geary-attachment-pane flowboxchild { border-radius: 8px; }
+
+.geary-attachment-pane > actionbar { background-color: #1e1715; }
+
+.geary-attachment-pane > actionbar:backdrop { background-color: #191413; }
+
+/********* Gedit * */
+window.org-gnome-gedit stack scrolledwindow viewport.frame list.gedit-document-panel { background-color: transparent; }
+
+window.org-gnome-gedit .gedit-search-entry-occurrences-tag { border: none; box-shadow: none; margin: 2px; padding: 2px; }
+
+/******************** Gnome Calculator * */
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list { padding: 0; border-radius: 0; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry { margin: 0; border-radius: 0; background-color: #271e1b; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry:backdrop { background-color: #201a18; }
+
+grid > viewport > box > scrolledwindow.display-scrolled > .sourceview.view > text, grid > viewport > box > scrolledwindow.display-scrolled > iconview.sourceview > text { border-radius: 10px 10px 0 0; }
+
+grid > viewport > box box > textview.view.info-view > text { border-radius: 0 0 10px 10px; }
+
+/************************ Gnome Control Center * */
+window.background.csd > leaflet > stack.background, window.background.csd > hdyleaflet > stack.background, window.background.csd > box.horizontal > stack.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-left-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+window.background.csd.maximized > leaflet > stack.background, window.background.csd.maximized > hdyleaflet > stack.background, window.background.csd.maximized > box.horizontal > stack.background, window.background.csd.maximized > leaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.tiled > leaflet > stack.background, window.background.csd.tiled > hdyleaflet > stack.background, window.background.csd.tiled > box.horizontal > stack.background, window.background.csd.tiled > leaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > leaflet > stack.background, window.background.csd.fullscreen > hdyleaflet > stack.background, window.background.csd.fullscreen > box.horizontal > stack.background, window.background.csd.fullscreen > leaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+window.background.csd > leaflet > stack.background > widget > box > box > scrolledwindow > viewport.frame > box.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+/************** Gnome Maps * */
+popover.maps-popover > grid > button.radio.layer-radio-button { border-radius: 4px; color: transparent; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:active { color: #fcc8b4; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:checked { color: #fcc8b4; }
+
+/*************** Gnome Music * */
+window.background.csd > box.vertical > overlay > stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > overlay > stack.background, window.background.csd.tiled > box.vertical > overlay > stack.background, window.background.csd.fullscreen > box.vertical > overlay > stack.background { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/****************** Gnome Software * */
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal { border-radius: 8px; background-color: #1e1715; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal:backdrop { background-color: #191413; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal list.app-updates-section { border: none; border-radius: 10px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software { padding-top: 2px; padding-bottom: 2px; margin: 4px 2px; min-height: 24px; min-width: 54px; border-radius: 8px; -gtk-outline-radius: 8px; background-color: transparent; color: #d0a594; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(ltr) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(rtl) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(ltr) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(rtl) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:hover { color: #fcc8b4; background-color: rgba(252, 200, 180, 0.05); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:checked { color: #fcc8b4; outline-color: rgba(252, 200, 180, 0.3); background-image: none; background-color: #473832; box-shadow: 0 2px 4px rgba(30, 23, 21, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop { color: #8a736a; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:hover { background-color: transparent; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { background-image: none; background-color: #302724; box-shadow: 0 1px 2px rgba(25, 20, 19, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked label, window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { color: #8a736a; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal button:checked + button { border-image: none; }
+
+window.background.csd button.text-button.content-rating { color: #1e1715; }
+
+window.background.csd button.text-button.content-rating:backdrop { color: #191413; }
+
+/****************** Gnome Terminal * */
+terminal-window.background.csd { border-radius: 0; }
+
+terminal-window decoration { background-color: #271e1b; border-radius: 10px 10px 0 0; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(252, 200, 180, 0.1), 0 0 0 1px #271e1b; }
+
+terminal-window decoration:backdrop { background-color: #201a18; box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(138, 115, 106, 0.125), 0 0 0 1px #201a18; }
+
+terminal-window .terminal-screen { background-color: #271e1b; color: #fcc8b4; }
+
+terminal-window .terminal-screen:backdrop { background-color: #201a18; color: #8a736a; }
+
+/*************** Gnome Todo * */
+window.background.csd.org-gnome-Todo > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Todo.maximized > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.maximized stack.background, window.background.csd.org-gnome-Todo.tiled > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.tiled stack.background, window.background.csd.org-gnome-Todo.fullscreen > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.fullscreen stack.background { border-radius: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row { box-shadow: none; padding: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row entry, window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row button { margin: 0; border-radius: 2.5px; }
+
+/**************** Gnome Tweaks * */
+hdyleaflet list.tweak-categories, leaflet list.tweak-categories { background-color: transparent; }
+
+hdyleaflet list.tweak-categories > separator, leaflet list.tweak-categories > separator { background-color: transparent; min-height: 0; }
+
+row#AutostartTitle.tweak { padding: 8px 8px 0 8px; }
+
+.tweak-group-startup { background-color: #1e1715; }
+
+.tweak-group-startup:backdrop { background-color: #191413; }
+
+/***************** Gnome Weather * */
+#weather-page, #weekly-forecast-frame { border-bottom-right-radius: 10px; }
+
+#weather-page-content-view { border-bottom-right-radius: 10px; border-bottom-left-radius: 10px; }
+
+/************ Ubiquity * */
+#live_installer #stepPartAuto #partition_container #resizewidget separator { background-image: none; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > * { background-color: transparent; border-radius: 0; border-color: #372b26; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > *:backdrop { border-color: #312824; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box { background-color: #1e1715; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box:backdrop { background-color: #191413; }
+
+/******************** Zorin Appearance * */
+stacksidebar.sidebar > scrolledwindow > viewport.frame > list { border-radius: 0; }
+
+/********** Thunar * */
+.thunar .sidebar.frame { border: none; }
+
+.thunar .sidebar .view, .thunar .sidebar iconview { background-color: #271e1b; border: none; }
+
+.thunar .sidebar .view:selected, .thunar .sidebar iconview:selected { background-color: #473832; color: #fcc8b4; }
+
+.thunar .sidebar .view:backdrop, .thunar .sidebar iconview:backdrop { background-color: #201a18; }
+
+.thunar .sidebar .view:backdrop:selected, .thunar .sidebar iconview:backdrop:selected { background-color: #302724; color: #8a736a; }
+
+.thunar .standard-view > .view, .thunar .standard-view > iconview { border-radius: 0; }
+
+/*********************** LightDM Gtk Greeter * */
+.lightdm-gtk-greeter #panel_window { border-radius: 0; border: none; background-color: #271e1b; }
+
+.lightdm-gtk-greeter #panel_window menubar { font-weight: bold; }
+
+.lightdm-gtk-greeter #panel_window menubar menu menuitem { font-weight: normal; }
+
+.lightdm-gtk-greeter #buttonbox_frame { padding-top: 20px; }
+
+.lightdm-gtk-greeter #login_window, .lightdm-gtk-greeter #shutdown_dialog, .lightdm-gtk-greeter #restart_dialog { border-style: none; border-radius: 10px; background-color: #271e1b; color: #fcc8b4; box-shadow: none; }
+
+.lightdm-gtk-greeter #login_window menu { border-radius: 0; }
+
+/******** XFCE * */
+.xfce4-panel.background { background-color: #1e1715; }
+
+.xfce4-panel.background button { border-radius: 0; margin: 0; font-weight: bold; }
+
+.xfce4-panel.background button menuitem { font-weight: normal; }
+
+.xfce4-panel.background button:hover { background-color: #372b26; }
+
+.xfce4-panel.background button:active, .xfce4-panel.background button:checked { color: #fcc8b4; background-color: #473832; background-image: none; }
+
+.xfce4-panel.background button.flat image, .xfce4-panel.background button.image-button image { -gtk-icon-transform: scale(1); transition: none; }
+
+.xfce4-panel.background button.flat:active image, .xfce4-panel.background button.image-button:active image { -gtk-icon-transform: scale(1); }
+
+.tasklist button.toggle { background-color: transparent; border-top-width: 0; border-bottom-width: 0; }
+
+.tasklist button.toggle:checked { background: none; box-shadow: inset 0 -3px #fcc8b4; }
+
+wnck-pager { background-color: #2f2421; }
+
+wnck-pager:hover { background-color: #3f322d; }
+
+wnck-pager:selected { background-color: #4a3a35; }
+
+XfdesktopIconView.view { background: transparent; color: white; }
+
+XfdesktopIconView.view:active { background: #fcc8b4; color: #1e1715; text-shadow: none; }
+
+XfdesktopIconView.view .label { text-shadow: 1px 1px 2px black; }
+
+#XfceNotifyWindow { background-color: #1e1715; border: none; box-shadow: inset 0 0 0 1px rgba(55, 43, 38, 0.75); border-radius: 10px; }
+
+#XfceNotifyWindow label#summary { font-weight: bold; }
+
+#XfceNotifyWindow progressbar progress { animation: none; background-image: none; background: image(#fcc8b4); }
+
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin { border-radius: 10px; }
+
+/* GTK NAMED COLORS ---------------- use responsibly! */
+/*
+widget text/foreground color */
+@define-color theme_fg_color #fcc8b4;
+/*
+text color for entries, views and content in general */
+@define-color theme_text_color #fcc8b4;
+/*
+widget base background color */
+@define-color theme_bg_color #271e1b;
+/*
+text widgets and the like base background color */
+@define-color theme_base_color #1e1715;
+/*
+base background color of selections */
+@define-color theme_selected_bg_color #e7b7a5;
+/* Tinting in dark variant to avoid a white selection on white page background when highlighting text in Evince when using Grey-Dark theme */
+/*
+text/foreground color of selections */
+@define-color theme_selected_fg_color #1e1715;
+/*
+base background color of insensitive widgets */
+@define-color insensitive_bg_color #271e1b;
+/*
+text foreground color of insensitive widgets */
+@define-color insensitive_fg_color #927367;
+/*
+insensitive text widgets and the like base background color */
+@define-color insensitive_base_color #1e1715;
+/*
+widget text/foreground color on backdrop windows */
+@define-color theme_unfocused_fg_color #8a736a;
+/*
+text color for entries, views and content in general on backdrop windows */
+@define-color theme_unfocused_text_color #fcc8b4;
+/*
+widget base background color on backdrop windows */
+@define-color theme_unfocused_bg_color #201a18;
+/*
+text widgets and the like base background color on backdrop windows */
+@define-color theme_unfocused_base_color #191413;
+/*
+base background color of selections on backdrop windows */
+@define-color theme_unfocused_selected_bg_color #fcc8b4;
+/*
+text/foreground color of selections on backdrop windows */
+@define-color theme_unfocused_selected_fg_color #1e1715;
+/*
+insensitive color on backdrop windows*/
+@define-color unfocused_insensitive_color #4c3e39;
+/*
+widgets main borders color */
+@define-color borders #372b26;
+/*
+widgets main borders color on backdrop windows */
+@define-color unfocused_borders #312824;
+/*
+these are pretty self explicative */
+@define-color placeholder_text_color #8d6f65;
+@define-color warning_color #faa483;
+@define-color error_color #fb7c7c;
+@define-color success_color #6ee1b6;
+/*
+these colors are exported for the window manager and shouldn't be used in applications,
+read if you used those and something break with a version upgrade you're on your own... */
+@define-color wm_title shade(#fcc8b4, 1.8);
+@define-color wm_unfocused_title #8a736a;
+@define-color wm_highlight transparent;
+@define-color wm_borders_edge rgba(252, 200, 180, 0.07);
+@define-color wm_bg_a shade(#271e1b, 1.2);
+@define-color wm_bg_b #271e1b;
+@define-color wm_shadow alpha(black, 0.35);
+@define-color wm_border alpha(black, 0.18);
+@define-color wm_button_hover_color_a shade(#271e1b, 1.3);
+@define-color wm_button_hover_color_b #271e1b;
+@define-color wm_button_active_color_a shade(#271e1b, 0.85);
+@define-color wm_button_active_color_b shade(#271e1b, 0.89);
+@define-color wm_button_active_color_c shade(#271e1b, 0.9);
+/* content view background such as thumbnails view in Photos or Boxes */
+@define-color content_view_bg #1e1715;
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #1e1715;

--- a/ZorinPurple-Dark/gtk-3.0/gtk-dark.css
+++ b/ZorinPurple-Dark/gtk-3.0/gtk-dark.css
@@ -1,0 +1,2308 @@
+/*************************** Check and Radio buttons * */
+@keyframes ripple_effect { to { background-size: 1000% 1000%; } }
+
+* { padding: 0; -GtkToolButton-icon-spacing: 4; -GtkTextView-error-underline-color: #fb7c7c; -GtkScrolledWindow-scrollbar-spacing: 0; -GtkToolItemGroup-expander-size: 11; -GtkWidget-text-handle-width: 20; -GtkWidget-text-handle-height: 24; -GtkDialog-button-spacing: 4; -GtkDialog-action-area-border: 0; outline-color: alpha(currentColor,0.3); outline-style: dashed; outline-offset: -3px; outline-width: 1px; -gtk-outline-radius: 8px; -gtk-secondary-caret-color: #d8c4f1; }
+
+/*************** Base States * */
+.background { color: #d8c4f1; background-color: #221f26; }
+
+.background.csd { border-radius: 0 0 10px 10px; }
+
+.background.maximized, .background.solid-csd, .background.fullscreen, .background.tiled, .background.tiled-top, .background.tiled-right, .background.tiled-bottom, .background.tiled-left { border-radius: 0; }
+
+.background:backdrop { color: #7b7484; background-color: #1d1b20; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* These wildcard seems unavoidable, need to investigate. Wildcards are bad and troublesome, use them with care, or better, just don't. Everytime a wildcard is used a kitten dies, painfully. */
+*:disabled { -gtk-icon-effect: dim; }
+
+.gtkstyle-fallback { color: #d8c4f1; background-color: #221f26; }
+
+.gtkstyle-fallback:hover { color: #d8c4f1; background-color: #3b3543; }
+
+.gtkstyle-fallback:active { color: #d8c4f1; background-color: #09080a; }
+
+.gtkstyle-fallback:disabled { color: #7d718c; background-color: #221f26; }
+
+.gtkstyle-fallback:selected { color: #1a181e; background-color: #d8c4f1; }
+
+.view, iconview, .view text, iconview text, textview text { color: #d8c4f1; background-color: #1a181e; border-radius: 10px; }
+
+.view:disabled, iconview:disabled, .view text:disabled, iconview text:disabled, textview text:disabled { color: #7d718c; background-color: #221f26; }
+
+.view:backdrop, iconview:backdrop, .view text:backdrop, iconview text:backdrop, textview text:backdrop { color: #7b7484; background-color: #161519; }
+
+.view:backdrop:disabled, iconview:backdrop:disabled, .view text:backdrop:disabled, iconview text:backdrop:disabled, textview text:backdrop:disabled { color: #433e49; background-color: #1d1b20; }
+
+.view:selected:focus, iconview:selected:focus, .view:selected, iconview:selected, .view text:selected:focus, iconview text:selected:focus, textview text:selected:focus, .view text:selected, iconview text:selected, textview text:selected { border-radius: 8px; }
+
+.view.sourceview, iconview.sourceview, .view.sourceview > *, iconview.sourceview > *, textview.sourceview, textview.sourceview > * { border-radius: 0; }
+
+textview border { background-color: #1e1b22; }
+
+iconview { border-radius: 0 0 10px 10px; }
+
+iconview, iconview:hover, iconview:selected { border-radius: 8px; }
+
+.rubberband, rubberband, XfdesktopIconView.view .rubberband, .content-view rubberband, .content-view .rubberband, treeview.view rubberband, flowbox rubberband { border: 1px solid #be9be7; background-color: rgba(190, 155, 231, 0.2); border-radius: 0; }
+
+flowbox flowboxchild { padding: 3px; }
+
+flowbox flowboxchild:selected { outline-offset: -2px; }
+
+.content-view .tile { margin: 2px; background-color: transparent; border-radius: 0; padding: 0; }
+
+label { caret-color: currentColor; }
+
+label:disabled { color: #7d718c; }
+
+button label:disabled { color: inherit; }
+
+label:disabled:backdrop { color: #433e49; }
+
+button label:disabled:backdrop { color: inherit; }
+
+label.error { color: #fb7c7c; }
+
+label.error:disabled { color: rgba(251, 124, 124, 0.5); }
+
+label.error:disabled:backdrop { color: rgba(251, 124, 124, 0.4); }
+
+.accent { color: #d8c4f1; }
+
+.dim-label, .titlebar:not(headerbar) .subtitle, headerbar .subtitle, label.separator { opacity: 0.55; text-shadow: none; }
+
+assistant .sidebar { background-color: #221f26; border-top: 1px solid #302b36; }
+
+assistant .sidebar:backdrop { background-color: #1d1b20; border-color: #2c2930; }
+
+assistant.csd .sidebar { border-top-style: none; }
+
+assistant .sidebar label { padding: 6px 12px; }
+
+assistant .sidebar label.highlight { background-color: #47404f; }
+
+.osd .scale-popup, .app-notification, .app-notification.frame, .osd { border: none; background-color: #1a181e; background-clip: padding-box; border-radius: 8px; box-shadow: inset 0 0 0 1px rgba(48, 43, 54, 0.75); }
+
+.osd .scale-popup:backdrop, .app-notification:backdrop, .osd:backdrop { background-color: #161519; box-shadow: inset 0 0 0 1px rgba(44, 41, 48, 0.75); }
+
+.osd .scale-popup:disabled, .app-notification:disabled, .osd:disabled { box-shadow: none; }
+
+/********************* Spinner Animation * */
+@keyframes spin { to { -gtk-icon-transform: rotate(1turn); } }
+
+spinner { background: none; opacity: 0; -gtk-icon-source: -gtk-icontheme("process-working-symbolic"); }
+
+spinner:backdrop { color: #7b7484; }
+
+spinner:checked { opacity: 1; animation: spin 1s linear infinite; }
+
+spinner:checked:disabled { opacity: 0.5; }
+
+/********************** General Typography * */
+.large-title { font-weight: 300; font-size: 24pt; }
+
+.title-1, .h1 { font-weight: 800; font-size: 20pt; }
+
+.title-2, .h2 { font-weight: 800; font-size: 15pt; }
+
+.title-3, .h3 { font-weight: 700; font-size: 15pt; }
+
+.title-4, .h4 { font-weight: 700; font-size: 13pt; }
+
+.heading { font-weight: 700; font-size: 11pt; }
+
+.body { font-weight: 400; font-size: 11pt; }
+
+.caption-heading { font-weight: 700; font-size: 9pt; }
+
+.caption { font-weight: 400; font-size: 9pt; }
+
+.category-label { color: rgba(216, 196, 241, 0.8); font-weight: 700; }
+
+/**************** Text Entries * */
+spinbutton:not(.vertical), entry { min-height: 32px; padding-left: 8px; padding-right: 8px; margin: 1px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); color: #d8c4f1; background-color: #1a181e; box-shadow: inset 0 0 0 1px #302b36; }
+
+spinbutton:not(.vertical) image.left, entry image.left { margin-right: 6px; }
+
+spinbutton:not(.vertical) image.right, entry image.right { margin-left: 6px; }
+
+spinbutton.flat:not(.vertical), entry.flat:focus, entry.flat:backdrop, entry.flat:disabled, entry.flat { min-height: 0; padding: 2px; background-color: transparent; border-color: transparent; border-radius: 0; }
+
+spinbutton:focus:not(.vertical), entry:focus { color: #d8c4f1; background-color: #1a181e; box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2), inset 0 0 0 2px #d8c4f1; }
+
+spinbutton:disabled:not(.vertical), entry:disabled { color: #7d718c; background-color: transparent; box-shadow: none; }
+
+spinbutton:backdrop:not(.vertical), entry:backdrop { color: #7b7484; background-color: #161519; box-shadow: inset 0 0 0 1px #2c2930; border-color: #1d1b20; transition: 150ms ease-out; }
+
+spinbutton:backdrop:disabled:not(.vertical), entry:backdrop:disabled { color: #433e49; background-color: transparent; box-shadow: none; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; border-color: transparent; }
+
+spinbutton.error:focus:not(.vertical), entry.error:focus { color: #fb7c7c; background-color: #1a181e; box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2), inset 0 0 0 2px #d8c4f1; }
+
+spinbutton.error:not(.vertical) selection, entry.error selection { color: #1a181e; background-color: #fb7c7c; }
+
+spinbutton.warning:not(.vertical), entry.warning { color: #faa483; border-color: transparent; }
+
+spinbutton.warning:focus:not(.vertical), entry.warning:focus { color: #faa483; background-color: #1a181e; box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2), inset 0 0 0 2px #d8c4f1; }
+
+spinbutton.warning:not(.vertical) selection, entry.warning selection { color: #1a181e; background-color: #faa483; }
+
+spinbutton:not(.vertical) image, entry image { color: #b2a2c6; }
+
+spinbutton:not(.vertical) image:hover, entry image:hover { color: #d8c4f1; }
+
+spinbutton:not(.vertical) image:active, entry image:active { color: #d8c4f1; }
+
+spinbutton:not(.vertical) image:backdrop, entry image:backdrop { color: #67616f; }
+
+spinbutton:drop(active):not(.vertical), entry:drop(active):focus, entry:drop(active) { color: #4cd9a4; border-color: transparent; background-color: #2a4440; }
+
+spinbutton:not(.vertical) progress, entry progress { margin: 1px -6px; background-color: transparent; background-image: none; border-radius: 3px; border-width: 0 0 3px; border-color: #d8c4f1; border-style: solid; box-shadow: none; }
+
+spinbutton:not(.vertical) progress:backdrop, entry progress:backdrop { background-color: transparent; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; }
+
+treeview entry:focus:dir(rtl), treeview entry:focus:dir(ltr) { background-color: #1a181e; transition-property: color, background; }
+
+treeview entry.flat, treeview entry { border: none; border-radius: 0; background-image: none; background-color: #1a181e; }
+
+.entry-tag { padding: 5px; margin-top: 4px; margin-bottom: 4px; border-style: none; color: #1a181e; background-color: #d8c4f1; }
+
+:dir(ltr) .entry-tag { margin-left: 8px; margin-right: -5px; }
+
+:dir(rtl) .entry-tag { margin-left: -5px; margin-right: 8px; }
+
+.entry-tag:hover { background-color: #f3edfb; }
+
+:backdrop .entry-tag { color: #161519; background-color: #d8c4f1; }
+
+.entry-tag.button { background-color: transparent; color: rgba(26, 24, 30, 0.7); }
+
+:not(:backdrop) .entry-tag.button:hover { border: 1px solid #d8c4f1; color: #1a181e; }
+
+:not(:backdrop) .entry-tag.button:active { background-color: #d8c4f1; color: #1a181e; }
+
+/*********** Buttons * */
+@keyframes needs_attention { from { background-image: -gtk-gradient(radial, center center, 0, center center, 0.01, to(#d8c4f1), to(transparent)); }
+  to { background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#d8c4f1), to(transparent)); } }
+
+button.titlebutton, notebook > header > tabs > arrow, button { min-height: 24px; min-width: 16px; margin: 1px; padding: 4px 9px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #302b36; background-image: none; }
+
+button.titlebutton, button.sidebar-button, notebook > header > tabs > arrow, notebook > header > tabs > arrow.flat, button.flat { background-color: transparent; background-image: none; background-image: none; transition: none; }
+
+button.titlebutton:hover, button.sidebar-button:hover, notebook > header > tabs > arrow:hover, button.flat:hover { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-duration: 500ms; }
+
+button.titlebutton:hover:active, button.sidebar-button:hover:active, notebook > header > tabs > arrow:hover:active, button.flat:hover:active { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header > tabs > arrow:hover, button:hover { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #3d3745; background-image: none; }
+
+notebook > header > tabs > arrow:active, button:active { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #47404f; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #595063 10%, transparent 0%); background-size: 0% 0%; }
+
+notebook > header > tabs > arrow:checked, button:checked { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; background: image(#d8c4f1); box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); }
+
+notebook > header > tabs > arrow:checked:active, button:checked:active { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); }
+
+notebook > header > tabs > arrow:backdrop, button:backdrop.flat, button:backdrop { background-color: #242228; background-image: none; transition: 150ms ease-out; -gtk-icon-effect: none; }
+
+notebook > header > tabs > arrow:backdrop label, notebook > header > tabs > arrow:backdrop, button:backdrop.flat label, button:backdrop.flat, button:backdrop label, button:backdrop { color: #7b7484; }
+
+notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active, button:backdrop:active { background-color: #302d34; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:active label, notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active label, button:backdrop.flat:active, button:backdrop:active label, button:backdrop:active { color: #7b7484; }
+
+notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked, button:backdrop:checked { background-color: #8d839a; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:checked label, notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked label, button:backdrop.flat:checked, button:backdrop:checked label, button:backdrop:checked { color: #161519; }
+
+notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled, button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled label, notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled label, button:backdrop.flat:disabled, button:backdrop:disabled label, button:backdrop:disabled { color: #433e49; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active, button:backdrop:disabled:checked { background-color: #2b2830; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active label, notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked label, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active label, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked label, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active label, button:backdrop:disabled:active, button:backdrop:disabled:checked label, button:backdrop:disabled:checked { color: #433e49; }
+
+button.titlebutton:backdrop, button.sidebar-button:backdrop, notebook > header > tabs > arrow:backdrop, button.titlebutton:disabled, button.sidebar-button:disabled, notebook > header > tabs > arrow:disabled, button.flat:backdrop, button.flat:disabled, button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+notebook > header > tabs > arrow:disabled, button:disabled { color: #7d718c; background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:disabled:active, notebook > header > tabs > arrow:disabled:checked, button:disabled:active, button:disabled:checked { color: #7d718c; background-color: #27232b; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow.image-button, button.image-button { min-width: 24px; padding-left: 5px; padding-right: 5px; }
+
+notebook > header > tabs > arrow.flat image, notebook > header > tabs > arrow.image-button image, button.flat image, button.image-button image { -gtk-icon-transform: scale(1); transition: -gtk-icon-transform 150ms ease; }
+
+notebook > header > tabs > arrow.flat:active image, notebook > header > tabs > arrow.image-button:active image, button.flat:active image, button.image-button:active image { -gtk-icon-transform: scale(0.85); }
+
+notebook > header > tabs > arrow.text-button, button.text-button { padding-left: 16px; padding-right: 16px; }
+
+notebook > header > tabs > arrow.text-button.image-button, button.text-button.image-button { padding-left: 8px; padding-right: 8px; }
+
+notebook > header > tabs > arrow.text-button.image-button label, button.text-button.image-button label { padding-left: 8px; padding-right: 8px; }
+
+combobox:drop(active) button.combo, notebook > header > tabs > arrow:drop(active), button:drop(active) { color: #1a181e; border-color: transparent; background-color: #4cd9a4; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled), row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled) { color: #1a181e; border-color: transparent; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled):backdrop, row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled):backdrop { color: #161519; }
+
+button.osd { min-width: 26px; min-height: 32px; border-radius: 8px; border: none; }
+
+button.osd.image-button { min-width: 34px; }
+
+button.suggested-action { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; background: image(#d8c4f1); font-weight: 700; }
+
+button.suggested-action.flat { background-color: transparent; background-image: none; background-image: none; color: #d8c4f1; }
+
+button.suggested-action:hover { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background: image(#e3d6f8); background-color: #e3d6f8; }
+
+button.suggested-action:active, button.suggested-action:checked { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-image: none; background-color: #be9be7; box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); }
+
+button.suggested-action:backdrop, button.suggested-action.flat:backdrop { background-color: #d9c5ef; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop label, button.suggested-action:backdrop, button.suggested-action.flat:backdrop label, button.suggested-action.flat:backdrop { color: #161519; }
+
+button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked { background-color: #be9de5; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop:active label, button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked label, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active label, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked label, button.suggested-action.flat:backdrop:checked { color: #161519; }
+
+button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.suggested-action:backdrop:disabled label, button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled label, button.suggested-action.flat:backdrop:disabled { color: #433e49; }
+
+button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked { background-color: #cfbce5; box-shadow: none; background-image: none; }
+
+button.suggested-action:backdrop:disabled:active label, button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked label, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active label, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked label, button.suggested-action.flat:backdrop:disabled:checked { color: #433e49; }
+
+button.suggested-action.flat:backdrop, button.suggested-action.flat:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(216, 196, 241, 0.8); }
+
+button.suggested-action:disabled { color: #7d718c; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.suggested-action:disabled:active, button.suggested-action:disabled:checked { color: #7d718c; background-color: #d4c0eb; box-shadow: none; background-image: none; }
+
+button.destructive-action { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #fb7c7c; background: image(#fb7c7c); font-weight: 700; }
+
+button.destructive-action.flat { background-color: transparent; background-image: none; background-image: none; color: #fb7c7c; }
+
+button.destructive-action:hover { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background: image(#ff929b); background-color: #ff929b; }
+
+button.destructive-action:active, button.destructive-action:checked { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-image: none; background-color: #fa4a4a; box-shadow: 0 2px 4px rgba(251, 124, 124, 0.2); }
+
+button.destructive-action:backdrop, button.destructive-action.flat:backdrop { background-color: #f97e7e; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop label, button.destructive-action:backdrop, button.destructive-action.flat:backdrop label, button.destructive-action.flat:backdrop { color: #161519; }
+
+button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked { background-color: #f74d4d; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop:active label, button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked label, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active label, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked label, button.destructive-action.flat:backdrop:checked { color: #161519; }
+
+button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.destructive-action:backdrop:disabled label, button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled label, button.destructive-action.flat:backdrop:disabled { color: #433e49; }
+
+button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked { background-color: #ee7979; box-shadow: none; background-image: none; }
+
+button.destructive-action:backdrop:disabled:active label, button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked label, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active label, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked label, button.destructive-action.flat:backdrop:disabled:checked { color: #433e49; }
+
+button.destructive-action.flat:backdrop, button.destructive-action.flat:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(251, 124, 124, 0.8); }
+
+button.destructive-action:disabled { color: #7d718c; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.destructive-action:disabled:active, button.destructive-action:disabled:checked { color: #7d718c; background-color: #f6797a; box-shadow: none; background-image: none; }
+
+.stack-switcher > button, stackswitcher > button { padding-top: 2px; padding-bottom: 2px; margin: 2px 1px; background-color: transparent; color: #b2a2c6; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; outline-offset: -3px; }
+
+.stack-switcher > button:first-child:dir(ltr), stackswitcher > button:first-child:dir(ltr) { margin-left: 2px; }
+
+.stack-switcher > button:first-child:dir(rtl), stackswitcher > button:first-child:dir(rtl) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(ltr), stackswitcher > button:last-child:dir(ltr) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(rtl), stackswitcher > button:last-child:dir(rtl) { margin-left: 2px; }
+
+.stack-switcher > button:hover, stackswitcher > button:hover { color: #d8c4f1; background-color: rgba(216, 196, 241, 0.05); }
+
+.stack-switcher > button:checked, stackswitcher > button:checked { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-image: none; background-color: #3d3745; box-shadow: 0 2px 4px rgba(26, 24, 30, 0.075); }
+
+.stack-switcher > button:backdrop, stackswitcher > button:backdrop { color: #7b7484; }
+
+.stack-switcher > button:backdrop:hover, stackswitcher > button:backdrop:hover { background-color: transparent; }
+
+.stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked { background-image: none; background-color: #2b282f; box-shadow: 0 1px 2px rgba(22, 21, 25, 0.075); }
+
+.stack-switcher > button:backdrop:checked label, .stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked label, stackswitcher > button:backdrop:checked { color: #7b7484; }
+
+.stack-switcher > button > label, stackswitcher > button > label { padding-left: 6px; padding-right: 6px; }
+
+.stack-switcher > button > image, stackswitcher > button > image { padding-left: 6px; padding-right: 6px; padding-top: 3px; padding-bottom: 3px; }
+
+.stack-switcher > button.text-button, stackswitcher > button.text-button { padding-left: 10px; padding-right: 10px; }
+
+.stack-switcher > button.image-button, stackswitcher > button.image-button { padding-left: 2px; padding-right: 2px; }
+
+.stack-switcher > button.needs-attention:active > label, .stack-switcher > button.needs-attention:active > image, .stack-switcher > button.needs-attention:checked > label, .stack-switcher > button.needs-attention:checked > image, stackswitcher > button.needs-attention:active > label, stackswitcher > button.needs-attention:active > image, stackswitcher > button.needs-attention:checked > label, stackswitcher > button.needs-attention:checked > image { animation: none; background-image: none; }
+
+button.font separator, button.file separator { background-color: transparent; }
+
+button.font > box > box > label { font-weight: bold; }
+
+.primary-toolbar button { -gtk-icon-shadow: none; }
+
+button.circular { border-radius: 9999px; -gtk-outline-radius: 9999px; }
+
+button.circular label { padding: 0; }
+
+stacksidebar row.needs-attention > label, .stack-switcher > button.needs-attention > label, .stack-switcher > button.needs-attention > image, stackswitcher > button.needs-attention > label, stackswitcher > button.needs-attention > image { animation: needs_attention 150ms ease-in; background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#d8c4f1), to(transparent)), -gtk-gradient(radial, center center, 0, center center, 0.45, to(rgba(0, 0, 0, 0.891765)), to(transparent)); background-size: 6px 6px, 6px 6px; background-repeat: no-repeat; background-position: right 3px, right 2px; }
+
+stacksidebar row.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > image:backdrop, stackswitcher > button.needs-attention > label:backdrop, stackswitcher > button.needs-attention > image:backdrop { background-size: 6px 6px, 0 0; }
+
+stacksidebar row.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), stackswitcher > button.needs-attention > label:dir(rtl), stackswitcher > button.needs-attention > image:dir(rtl) { background-position: left 3px, left 2px; }
+
+.inline-toolbar toolbutton > button { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #302b36; background-image: none; }
+
+.inline-toolbar toolbutton > button:hover { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #3d3745; background-image: none; }
+
+.inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #47404f; }
+
+.inline-toolbar toolbutton > button:disabled { color: #7d718c; background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:disabled:active, .inline-toolbar toolbutton > button:disabled:checked { color: #7d718c; background-color: #27232b; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop { background-color: #242228; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop label, .inline-toolbar toolbutton > button:backdrop { color: #7b7484; }
+
+.inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked { background-color: #302d34; background-image: none; box-shadow: none; }
+
+.inline-toolbar toolbutton > button:backdrop:active label, .inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked label, .inline-toolbar toolbutton > button:backdrop:checked { color: #7b7484; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled label, .inline-toolbar toolbutton > button:backdrop:disabled { color: #433e49; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked { background-color: #2b2830; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active label, .inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked label, .inline-toolbar toolbutton > button:backdrop:disabled:checked { color: #433e49; }
+
+.linked:not(.vertical) > combobox > box > button.combo, filechooser .path-bar.linked > button, .linked:not(.vertical) > spinbutton:not(.vertical), .linked:not(.vertical) > entry, .inline-toolbar button, .linked > button, toolbar.inline-toolbar toolbutton > button.flat { border-right-style: none; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked:not(.vertical) > combobox:first-child > box > button.combo, combobox.linked button:nth-child(2):dir(rtl), filechooser .path-bar.linked > button:dir(rtl):last-child, filechooser .path-bar.linked > button:dir(ltr):first-child, .linked:not(.vertical) > spinbutton:first-child:not(.vertical), .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat { border-top-left-radius: 8px; border-bottom-left-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-bottom-left-radius: 8px; }
+
+.linked:not(.vertical) > combobox:last-child > box > button.combo, combobox.linked button:nth-child(2):dir(ltr), filechooser .path-bar.linked > button:dir(rtl):first-child, filechooser .path-bar.linked > button:dir(ltr):last-child, .linked:not(.vertical) > spinbutton:last-child:not(.vertical), .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat { border-right-style: solid; border-top-right-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-top-right-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked:not(.vertical) > combobox:only-child > box > button.combo, filechooser .path-bar.linked > button:only-child, .linked:not(.vertical) > spinbutton:only-child:not(.vertical), .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.linked.vertical > combobox > box > button.combo, .linked.vertical > spinbutton:not(.vertical), .linked.vertical > entry, .linked.vertical > button { border-style: solid solid none solid; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked.vertical > combobox:first-child > box > button.combo, .linked.vertical > spinbutton:first-child:not(.vertical), .linked.vertical > entry:first-child, .linked.vertical > button:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-top-right-radius: 8px; }
+
+.linked.vertical > combobox:last-child > box > button.combo, .linked.vertical > spinbutton:last-child:not(.vertical), .linked.vertical > entry:last-child, .linked.vertical > button:last-child { border-bottom-style: solid; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-bottom-left-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked.vertical > combobox:only-child > box > button.combo, .linked.vertical > spinbutton:only-child:not(.vertical), .linked.vertical > entry:only-child, .linked.vertical > button:only-child { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.scale-popup button:backdrop:hover, .scale-popup button:backdrop:disabled, .scale-popup button:backdrop, .scale-popup button:hover, calendar.button, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, button:link, button:visited, modelbutton.flat:backdrop, modelbutton.flat:backdrop:hover, modelbutton.flat, .menuitem.button.flat { background-color: transparent; background-image: none; border-color: transparent; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* menu buttons */
+modelbutton.flat, .menuitem.button.flat { min-height: 26px; padding-left: 5px; padding-right: 5px; border-radius: 8px; outline-offset: -2px; }
+
+modelbutton.flat:hover, .menuitem.button.flat:hover { background-color: #302b36; }
+
+modelbutton.flat arrow { background: none; }
+
+modelbutton.flat arrow:hover { background: none; }
+
+modelbutton.flat arrow.left { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+modelbutton.flat arrow.right { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+button.color { padding: 4px; box-shadow: none; }
+
+button.color colorswatch:only-child, button.color colorswatch:only-child overlay { border-radius: 0; }
+
+/********* Links * */
+button:link > label, button:visited > label, button:link, button:visited, *:link { color: #f3edfb; }
+
+button:link > label:visited, button:visited > label:visited, button:visited, *:link:visited { color: white; }
+
+*:selected button:link > label:visited, *:selected button:visited > label:visited, *:selected button:visited, *:selected *:link:visited { color: #767478; }
+
+button:link > label:hover, button:visited > label:hover, button:hover:link, button:hover:visited, *:link:hover { color: white; }
+
+*:selected button:link > label:hover, *:selected button:visited > label:hover, *:selected button:hover:link, *:selected button:hover:visited, *:selected *:link:hover { color: #312f35; }
+
+button:link > label:active, button:visited > label:active, button:active:link, button:active:visited, *:link:active { color: #f3edfb; }
+
+*:selected button:link > label:active, *:selected button:visited > label:active, *:selected button:active:link, *:selected button:active:visited, *:selected *:link:active { color: #45434a; }
+
+button:link > label:disabled, button:visited > label:disabled, button:disabled:link, button:disabled:visited, *:link:disabled, *:link:disabled:backdrop { color: rgba(244, 244, 244, 0.8); }
+
+button:link > label:backdrop, button:visited > label:backdrop, button:backdrop:link, button:backdrop:visited, *:link:backdrop:backdrop:hover, *:link:backdrop:backdrop:hover:selected, *:link:backdrop { color: rgba(243, 237, 251, 0.9); }
+
+.selection-mode .titlebar:not(headerbar) .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link, .selection-mode headerbar .subtitle:link, headerbar.selection-mode .subtitle:link, button:link > label:selected, button:visited > label:selected, button:selected:link, button:selected:visited, *:selected button:link > label, *:selected button:visited > label, *:selected button:link, *:selected button:visited, *:link:selected, *:selected *:link { color: #45434a; }
+
+button:link, button:visited { text-shadow: none; }
+
+button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked { text-shadow: none; }
+
+button:link > label, button:visited > label { text-decoration-line: underline; }
+
+/****************** Stack Switcher * */
+stackswitcher, .stack-switcher { border-radius: 8px; background-color: #1a181e; }
+
+stackswitcher:backdrop, .stack-switcher:backdrop { background-color: #161519; }
+
+stackswitcher > button, .stack-switcher > button { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+/***************** GtkSpinButton * */
+spinbutton { font-feature-settings: "tnum"; }
+
+spinbutton:not(.vertical) { padding: 0; }
+
+spinbutton:not(.vertical) entry { min-width: 28px; margin: 0; background: none; background-color: transparent; border: none; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) entry:backdrop:disabled { background-color: transparent; }
+
+spinbutton:not(.vertical) button { min-height: 16px; margin: 0; padding-bottom: 0; padding-top: 0; color: #d8c4f1; background-image: none; border-style: none none none solid; border-color: transparent; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) button:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:disabled { color: #7d718c; background-color: #221f26; }
+
+spinbutton:not(.vertical) button:backdrop:disabled { color: #433e49; background-color: #1d1b20; background-image: none; border-style: none none none solid; }
+
+spinbutton:not(.vertical) button:backdrop:disabled:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:dir(ltr):last-child { border-radius: 0 7px 7px 0; }
+
+spinbutton:not(.vertical) button:dir(rtl):first-child { border-radius: 7px 0 0 7px; }
+
+spinbutton.vertical:disabled { color: #7d718c; }
+
+spinbutton.vertical:backdrop:disabled { color: #433e49; }
+
+spinbutton.vertical:drop(active) { border-color: transparent; box-shadow: none; }
+
+spinbutton.vertical entry { min-height: 32px; min-width: 32px; padding: 0; border-radius: 0; }
+
+spinbutton.vertical button { min-height: 32px; min-width: 32px; padding: 0; }
+
+spinbutton.vertical button.up { border-radius: 8px 8px 0 0; border-style: solid solid none solid; }
+
+spinbutton.vertical button.down { border-radius: 0 0 8px 8px; border-style: none solid solid solid; }
+
+treeview spinbutton:not(.vertical) { min-height: 0; border-style: none; border-radius: 0; }
+
+treeview spinbutton:not(.vertical) entry { min-height: 0; padding: 1px 2px; }
+
+/************** ComboBoxes * */
+combobox arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); min-height: 16px; min-width: 16px; }
+
+combobox:drop(active) { box-shadow: none; }
+
+/************ Toolbars * */
+searchbar > revealer > box, .location-bar, .inline-toolbar, toolbar { -GtkWidget-window-dragging: true; padding: 4px; background-color: #221f26; }
+
+searchbar > revealer > box:backdrop, .location-bar:backdrop, .inline-toolbar:backdrop, toolbar:backdrop { background-color: #1d1b20; }
+
+toolbar { padding: 4px 3px 3px 4px; }
+
+.osd toolbar { background-color: transparent; }
+
+toolbar.osd { padding: 13px; border: none; border-radius: 8px; }
+
+toolbar.osd.left, toolbar.osd.right, toolbar.osd.top, toolbar.osd.bottom { border-radius: 0; }
+
+toolbar.horizontal separator { margin: 0 7px 1px 6px; }
+
+toolbar.vertical separator { margin: 6px 1px 7px 0; }
+
+toolbar:not(.inline-toolbar):not(.osd) > *:not(.toggle):not(.popup) > * { margin-right: 1px; margin-bottom: 1px; }
+
+.inline-toolbar { padding: 3px; border-width: 0 1px 1px; border-radius: 0 0 8px 8px; }
+
+.background.csd .inline-toolbar { border-radius: 0 0 10px 10px; }
+
+searchbar > revealer > box, .location-bar { border-width: 0 0 1px; padding: 3px; }
+
+searchbar > revealer > box { margin: -6px; padding: 6px; }
+
+revealer box.view { background-color: transparent; }
+
+.inline-toolbar, searchbar > revealer > box, .location-bar { border-style: none; background-color: #221f26; }
+
+.inline-toolbar:backdrop, searchbar > revealer > box:backdrop, .location-bar:backdrop { background-color: #1d1b20; }
+
+/*************** Header bars * */
+@keyframes header_ripple_effect { from { background-image: radial-gradient(circle farthest-corner at center, #221f26 0%, transparent 0%); }
+  to { background-image: radial-gradient(circle farthest-corner at center, #d8c4f1 100%, transparent 0%); } }
+
+.titlebar:not(headerbar), headerbar { padding: 0 6px; min-height: 46px; border: none; border-radius: 0; background-color: #221f26; /* hide the close button separator */ }
+
+.titlebar:backdrop:not(headerbar), headerbar:backdrop { background-color: #1d1b20; background-image: none; }
+
+.titlebar:not(headerbar) .title, headerbar .title { padding-left: 12px; padding-right: 12px; font-weight: bold; }
+
+.titlebar:not(headerbar) .subtitle, headerbar .subtitle { font-size: smaller; padding-left: 12px; padding-right: 12px; }
+
+.selection-mode .titlebar:not(headerbar), .selection-mode.titlebar:not(headerbar), .selection-mode headerbar, headerbar.selection-mode { color: #1a181e; border-color: transparent; background-color: #d8c4f1; transition: background-color 0.00001s 150ms, color 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); animation: header_ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+.selection-mode .titlebar:backdrop:not(headerbar), .selection-mode.titlebar:backdrop:not(headerbar), .selection-mode headerbar:backdrop, headerbar.selection-mode:backdrop { color: #1a181e; background-color: #d8c4f1; background-image: none; }
+
+.selection-mode .titlebar:backdrop:not(headerbar) label, .selection-mode.titlebar:backdrop:not(headerbar) label, .selection-mode headerbar:backdrop label, headerbar.selection-mode:backdrop label { text-shadow: none; color: #1a181e; }
+
+.selection-mode .titlebar:not(headerbar) button, .selection-mode.titlebar:not(headerbar) button, .selection-mode headerbar button, headerbar.selection-mode button { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #cab7e1; background-image: none; }
+
+.selection-mode button.titlebutton, .selection-mode .titlebar:not(headerbar) button.flat, .selection-mode.titlebar:not(headerbar) button.flat, .selection-mode headerbar button.flat, headerbar.selection-mode button.flat { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:hover, .selection-mode.titlebar:not(headerbar) button:hover, .selection-mode headerbar button:hover, headerbar.selection-mode button:hover { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #bcaad1; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:active, .selection-mode .titlebar:not(headerbar) button:checked, .selection-mode.titlebar:not(headerbar) button:active, .selection-mode.titlebar:not(headerbar) button:checked, .selection-mode headerbar button:active, .selection-mode headerbar button:checked, .selection-mode headerbar button.toggle:checked, .selection-mode headerbar button.toggle:active, headerbar.selection-mode button:active, headerbar.selection-mode button:checked, headerbar.selection-mode button.toggle:checked, headerbar.selection-mode button.toggle:active { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #b2a2c6; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop { background-color: #242228; background-image: none; -gtk-icon-effect: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop label, .selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop label, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat label, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop label, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat label, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop label, headerbar.selection-mode button:backdrop { color: #7b7484; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked { background-color: #302d34; background-image: none; box-shadow: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active label, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked label, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active label, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked label, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active label, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked label, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active label, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked label, headerbar.selection-mode button:backdrop:checked { color: #7b7484; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled label, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled label, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled label, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled label, headerbar.selection-mode button:backdrop:disabled { color: #433e49; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked { background-color: #cfbde5; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active label, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked label, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active label, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked label, headerbar.selection-mode button:backdrop:disabled:checked { color: #433e49; }
+
+.selection-mode button.titlebutton:backdrop, .selection-mode button.titlebutton:disabled, .selection-mode .titlebar:not(headerbar) button.flat:backdrop, .selection-mode .titlebar:not(headerbar) button.flat:disabled, .selection-mode.titlebar:not(headerbar) button.flat:backdrop, .selection-mode.titlebar:not(headerbar) button.flat:disabled, .selection-mode headerbar button.flat:backdrop, .selection-mode headerbar button.flat:disabled, .selection-mode headerbar button.flat:backdrop:disabled, headerbar.selection-mode button.flat:backdrop, headerbar.selection-mode button.flat:disabled, headerbar.selection-mode button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled, .selection-mode.titlebar:not(headerbar) button:disabled, .selection-mode headerbar button:disabled, headerbar.selection-mode button:disabled { color: #7d718c; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled:active, .selection-mode .titlebar:not(headerbar) button:disabled:checked, .selection-mode.titlebar:not(headerbar) button:disabled:active, .selection-mode.titlebar:not(headerbar) button:disabled:checked, .selection-mode headerbar button:disabled:active, .selection-mode headerbar button:disabled:checked, headerbar.selection-mode button:disabled:active, headerbar.selection-mode button:disabled:checked { color: #7d718c; background-color: #d4c0eb; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action, .selection-mode.titlebar:not(headerbar) button.suggested-action, .selection-mode headerbar button.suggested-action, headerbar.selection-mode button.suggested-action { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #302b36; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:hover, .selection-mode.titlebar:not(headerbar) button.suggested-action:hover, .selection-mode headerbar button.suggested-action:hover, headerbar.selection-mode button.suggested-action:hover { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #3d3745; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:active, .selection-mode.titlebar:not(headerbar) button.suggested-action:active, .selection-mode headerbar button.suggested-action:active, headerbar.selection-mode button.suggested-action:active { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #47404f; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode headerbar button.suggested-action:disabled, headerbar.selection-mode button.suggested-action:disabled { color: #7d718c; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop { background-color: #242228; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop label, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop label, headerbar.selection-mode button.suggested-action:backdrop { color: #7b7484; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled label, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled label, headerbar.selection-mode button.suggested-action:backdrop:disabled { color: #433e49; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu, .selection-mode.titlebar:not(headerbar) .selection-menu, .selection-mode headerbar .selection-menu:backdrop, .selection-mode headerbar .selection-menu, headerbar.selection-mode .selection-menu:backdrop, headerbar.selection-mode .selection-menu { border-color: rgba(216, 196, 241, 0); background-color: rgba(216, 196, 241, 0); background-image: none; box-shadow: none; min-height: 20px; padding: 6px 10px; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu arrow, .selection-mode.titlebar:not(headerbar) .selection-menu arrow, .selection-mode headerbar .selection-menu:backdrop arrow, .selection-mode headerbar .selection-menu arrow, headerbar.selection-mode .selection-menu:backdrop arrow, headerbar.selection-mode .selection-menu arrow { -GtkArrow-arrow-scaling: 1; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu .arrow, .selection-mode.titlebar:not(headerbar) .selection-menu .arrow, .selection-mode headerbar .selection-menu:backdrop .arrow, .selection-mode headerbar .selection-menu .arrow, headerbar.selection-mode .selection-menu:backdrop .arrow, headerbar.selection-mode .selection-menu .arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); color: rgba(26, 24, 30, 0.5); -gtk-icon-shadow: none; }
+
+.tiled .titlebar:not(headerbar), .tiled-top .titlebar:not(headerbar), .tiled-right .titlebar:not(headerbar), .tiled-bottom .titlebar:not(headerbar), .tiled-left .titlebar:not(headerbar), .maximized .titlebar:not(headerbar), .fullscreen .titlebar:not(headerbar), .tiled headerbar, .tiled-top headerbar, .tiled-right headerbar, .tiled-bottom headerbar, .tiled-left headerbar, .maximized headerbar, .fullscreen headerbar { border-radius: 0; }
+
+.default-decoration.titlebar:not(headerbar), headerbar.default-decoration { min-height: 28px; padding: 4px; border-color: transparent; }
+
+.default-decoration.titlebar:not(headerbar) button.titlebutton, headerbar.default-decoration button.titlebutton { min-height: 26px; min-width: 26px; margin: 0; padding: 0; }
+
+.titlebar:not(headerbar) separator.titlebutton, headerbar separator.titlebutton { opacity: 0; }
+
+.solid-csd .titlebar:dir(rtl):not(headerbar), .solid-csd .titlebar:dir(ltr):not(headerbar), .solid-csd headerbar:backdrop:dir(rtl), .solid-csd headerbar:backdrop:dir(ltr), .solid-csd headerbar:dir(rtl), .solid-csd headerbar:dir(ltr) { margin-left: -1px; margin-right: -1px; margin-top: -1px; border-radius: 0; box-shadow: none; }
+
+headerbar entry, headerbar spinbutton, headerbar separator:not(.sidebar), headerbar button { margin-top: 6px; margin-bottom: 6px; }
+
+headerbar switch { margin-top: 10px; margin-bottom: 10px; }
+
+headerbar stackswitcher button, headerbar .stack-switcher button { min-height: 24px; min-width: 80px; margin: 4px 2px; }
+
+headerbar stackswitcher button:first-child:dir(ltr), headerbar .stack-switcher button:first-child:dir(ltr) { margin-left: 4px; }
+
+headerbar stackswitcher button:first-child:dir(rtl), headerbar .stack-switcher button:first-child:dir(rtl) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(ltr), headerbar .stack-switcher button:last-child:dir(ltr) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(rtl), headerbar .stack-switcher button:last-child:dir(rtl) { margin-left: 4px; }
+
+#MozillaGtkWidget.background headerbar button.close:hover, headerbar button.close:hover { color: #fb7c7c; background-color: #432d33; }
+
+#MozillaGtkWidget.background headerbar button.close:active, #MozillaGtkWidget.background headerbar button.close:checked, headerbar button.close:active, headerbar button.close:checked { color: #fb7c7c; background-color: #4e3138; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #4e3138 10%, transparent 0%); background-size: 0% 0%; }
+
+headerbar.titlebar headerbar:not(.titlebar) { background: none; box-shadow: none; }
+
+.background .titlebar:backdrop, .background .titlebar { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+.background.tiled .titlebar:backdrop, .background.tiled .titlebar, .background.tiled-top .titlebar:backdrop, .background.tiled-top .titlebar, .background.tiled-right .titlebar:backdrop, .background.tiled-right .titlebar, .background.tiled-bottom .titlebar:backdrop, .background.tiled-bottom .titlebar, .background.tiled-left .titlebar:backdrop, .background.tiled-left .titlebar, .background.maximized .titlebar:backdrop, .background.maximized .titlebar, .background.solid-csd .titlebar:backdrop, .background.solid-csd .titlebar { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window separator:first-child + headerbar:backdrop, window separator:first-child + headerbar, window headerbar:first-child:backdrop, window headerbar:first-child { border-top-left-radius: 10px; }
+
+window headerbar:last-child:backdrop, window headerbar:last-child { border-top-right-radius: 10px; }
+
+window stack headerbar:first-child:backdrop, window stack headerbar:first-child, window stack headerbar:last-child:backdrop, window stack headerbar:last-child { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+window.tiled headerbar, window.tiled headerbar:first-child, window.tiled headerbar:last-child, window.tiled headerbar:only-child, window.tiled headerbar:backdrop, window.tiled headerbar:backdrop:first-child, window.tiled headerbar:backdrop:last-child, window.tiled headerbar:backdrop:only-child, window.tiled-top headerbar, window.tiled-top headerbar:first-child, window.tiled-top headerbar:last-child, window.tiled-top headerbar:only-child, window.tiled-top headerbar:backdrop, window.tiled-top headerbar:backdrop:first-child, window.tiled-top headerbar:backdrop:last-child, window.tiled-top headerbar:backdrop:only-child, window.tiled-right headerbar, window.tiled-right headerbar:first-child, window.tiled-right headerbar:last-child, window.tiled-right headerbar:only-child, window.tiled-right headerbar:backdrop, window.tiled-right headerbar:backdrop:first-child, window.tiled-right headerbar:backdrop:last-child, window.tiled-right headerbar:backdrop:only-child, window.tiled-bottom headerbar, window.tiled-bottom headerbar:first-child, window.tiled-bottom headerbar:last-child, window.tiled-bottom headerbar:only-child, window.tiled-bottom headerbar:backdrop, window.tiled-bottom headerbar:backdrop:first-child, window.tiled-bottom headerbar:backdrop:last-child, window.tiled-bottom headerbar:backdrop:only-child, window.tiled-left headerbar, window.tiled-left headerbar:first-child, window.tiled-left headerbar:last-child, window.tiled-left headerbar:only-child, window.tiled-left headerbar:backdrop, window.tiled-left headerbar:backdrop:first-child, window.tiled-left headerbar:backdrop:last-child, window.tiled-left headerbar:backdrop:only-child, window.maximized headerbar, window.maximized headerbar:first-child, window.maximized headerbar:last-child, window.maximized headerbar:only-child, window.maximized headerbar:backdrop, window.maximized headerbar:backdrop:first-child, window.maximized headerbar:backdrop:last-child, window.maximized headerbar:backdrop:only-child, window.fullscreen headerbar, window.fullscreen headerbar:first-child, window.fullscreen headerbar:last-child, window.fullscreen headerbar:only-child, window.fullscreen headerbar:backdrop, window.fullscreen headerbar:backdrop:first-child, window.fullscreen headerbar:backdrop:last-child, window.fullscreen headerbar:backdrop:only-child, window.solid-csd headerbar, window.solid-csd headerbar:first-child, window.solid-csd headerbar:last-child, window.solid-csd headerbar:only-child, window.solid-csd headerbar:backdrop, window.solid-csd headerbar:backdrop:first-child, window.solid-csd headerbar:backdrop:last-child, window.solid-csd headerbar:backdrop:only-child { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window.csd > .titlebar:not(headerbar) { padding: 0; background-color: transparent; background-image: none; border-style: none; border-color: transparent; box-shadow: none; }
+
+.titlebar:not(headerbar) separator { background-color: #221f26; }
+
+.titlebar:not(headerbar) separator:backdrop { background-color: #1d1b20; }
+
+window.devel headerbar.titlebar:not(.selection-mode) { background: #221f26 cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, linear-gradient(to right, transparent 65%, rgba(216, 196, 241, 0.15)); }
+
+window.devel headerbar.titlebar:not(.selection-mode):backdrop { background: #221f26 cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, image(#221f26); /* background-color would flash */ }
+
+/************ Pathbars * */
+.path-bar button.text-button, .path-bar button.image-button, .path-bar button { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.text-button.image-button label { padding-left: 0; padding-right: 0; }
+
+.path-bar button.text-button.image-button label:last-child, .path-bar button label:last-child { padding-right: 8px; }
+
+.path-bar button.text-button.image-button label:first-child, .path-bar button label:first-child { padding-left: 8px; }
+
+.path-bar button image { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.slider-button { padding-left: 0; padding-right: 0; }
+
+/************** Tree Views * */
+treeview.view { border-left-color: rgba(216, 196, 241, 0.15); border-top-color: #221f26; border-radius: 0px; }
+
+* { -GtkTreeView-horizontal-separator: 4; -GtkTreeView-grid-line-width: 1; -GtkTreeView-grid-line-pattern: ''; -GtkTreeView-tree-line-width: 1; -GtkTreeView-tree-line-pattern: ''; -GtkTreeView-expander-size: 16; }
+
+treeview.view:selected:focus, treeview.view:selected { border-radius: 0; }
+
+treeview.view:selected:backdrop, treeview.view:selected { border-left-color: #544e5c; border-top-color: rgba(123, 116, 132, 0.1); }
+
+treeview.view:disabled { color: #7d718c; }
+
+treeview.view:disabled:selected { color: #8c7f9c; }
+
+treeview.view:disabled:selected:backdrop { color: #6a6273; }
+
+treeview.view:disabled:backdrop { color: #433e49; }
+
+treeview.view.separator { min-height: 2px; color: #221f26; }
+
+treeview.view.separator:backdrop { color: #1d1b20; }
+
+treeview.view:backdrop { border-left-color: #4c4752; border-top: #1d1b20; }
+
+treeview.view:drop(active) { border-style: solid none; border-width: 1px; border-color: #c8b5df; }
+
+treeview.view:drop(active).after { border-top-style: none; }
+
+treeview.view:drop(active).before { border-bottom-style: none; }
+
+treeview.view.expander { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); color: #9f91b1; }
+
+treeview.view.expander:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+treeview.view.expander:hover { color: #d8c4f1; }
+
+treeview.view.expander:selected { color: #534c5d; }
+
+treeview.view.expander:selected:hover { color: #1a181e; }
+
+treeview.view.expander:selected:backdrop { color: #3a3640; }
+
+treeview.view.expander:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+treeview.view.expander:backdrop { color: #5d5764; }
+
+treeview.view.progressbar { color: #1a181e; background-color: #d8c4f1; background: image(#d8c4f1); box-shadow: none; border-radius: 8px; }
+
+treeview.view.progressbar:backdrop { color: #161519; background-color: #8d839a; background-image: none; }
+
+treeview.view.progressbar:selected:focus, treeview.view.progressbar:selected { border-radius: 8px; color: #d8c4f1; background-color: #1a181e; background-image: none; }
+
+treeview.view.progressbar:selected:backdrop { color: #8d839a; background-color: #161519; }
+
+treeview.view.trough { background-color: rgba(216, 196, 241, 0.1); border-radius: 8px; }
+
+treeview.view.trough:backdrop { background-color: rgba(123, 116, 132, 0.1); }
+
+treeview.view.trough:selected { border-radius: 8px; }
+
+treeview.view.trough:selected:focus, treeview.view.trough:selected { background-color: rgba(26, 24, 30, 0.3); }
+
+treeview.view.trough:selected:backdrop { background-color: rgba(26, 24, 30, 0.3); }
+
+treeview.view header button { color: #796e87; background-color: #1a181e; font-weight: bold; text-shadow: none; box-shadow: none; margin: 0 1px 1px 0; }
+
+treeview.view header button:last-child { margin-right: 0; }
+
+treeview.view header button:hover { color: #a999bc; box-shadow: none; transition: none; }
+
+treeview.view header button:active { color: #d8c4f1; transition: none; }
+
+treeview.view button.dnd:active, treeview.view button.dnd:selected, treeview.view button.dnd:hover, treeview.view button.dnd, treeview.view header.button.dnd:active, treeview.view header.button.dnd:selected, treeview.view header.button.dnd:hover, treeview.view header.button.dnd { padding: 0 6px; color: #1a181e; background-image: none; background-color: #d8c4f1; border-style: none; border-radius: 0; box-shadow: inset 0 0 0 1px #1a181e; text-shadow: none; transition: none; }
+
+treeview.view acceleditor > label { background-color: #d8c4f1; }
+
+treeview.view header button, treeview.view header button:hover, treeview.view header button:active { padding: 0 6px; background-image: none; border-style: none solid solid none; border-color: #221f26; border-radius: 0; text-shadow: none; }
+
+treeview.view header button:disabled { border-color: #221f26; background-image: none; }
+
+treeview.view header button:backdrop { color: #4c4752; border-color: #1d1b20; border-style: none solid solid none; background-image: none; background-color: #161519; }
+
+treeview.view header button:backdrop:disabled { border-color: #1d1b20; background-image: none; }
+
+treeview.view header button:last-child { border-right-style: none; }
+
+/********* Menus * */
+menubar, .menubar { -GtkWidget-window-dragging: true; padding: 0px; }
+
+menubar:backdrop, .menubar:backdrop { background-color: #1d1b20; }
+
+menubar > menuitem, .menubar > menuitem { min-height: 16px; padding: 4px 8px; }
+
+menubar > menuitem menu:dir(rtl), menubar > menuitem menu:dir(ltr), .menubar > menuitem menu:dir(rtl), .menubar > menuitem menu:dir(ltr) { border-radius: 0; padding: 0; }
+
+menubar > menuitem:hover, .menubar > menuitem:hover { box-shadow: inset 0 -3px #d8c4f1; color: #f3edfb; }
+
+menubar > menuitem:disabled, .menubar > menuitem:disabled { color: #7d718c; box-shadow: none; }
+
+menubar .csd.popup decoration, .menubar .csd.popup decoration { border-radius: 0; }
+
+.background.popup { background-color: transparent; }
+
+menu, .menu, .context-menu { margin: 8px; padding: 8px 0px; background-color: #1a181e; border: 1px solid rgba(48, 43, 54, 0.75); }
+
+.csd menu, .csd .menu, .csd .context-menu { border: none; border-radius: 8px; }
+
+menu:backdrop, .menu:backdrop, .context-menu:backdrop { background-color: #161519; border-color: rgba(44, 41, 48, 0.75); }
+
+menu menuitem, .menu menuitem, .context-menu menuitem { min-height: 16px; min-width: 40px; padding: 4px 6px; text-shadow: none; }
+
+menu menuitem:hover, .menu menuitem:hover, .context-menu menuitem:hover { color: #1a181e; background-color: #d8c4f1; background: image(#d8c4f1); }
+
+menu menuitem:disabled, .menu menuitem:disabled, .context-menu menuitem:disabled { color: #7d718c; }
+
+menu menuitem:disabled:backdrop, .menu menuitem:disabled:backdrop, .context-menu menuitem:disabled:backdrop { color: #433e49; }
+
+menu menuitem:backdrop, menu menuitem:backdrop:hover, .menu menuitem:backdrop, .menu menuitem:backdrop:hover, .context-menu menuitem:backdrop, .context-menu menuitem:backdrop:hover { color: #7b7484; background-color: transparent; }
+
+menu menuitem arrow, .menu menuitem arrow, .context-menu menuitem arrow { min-height: 16px; min-width: 16px; }
+
+menu menuitem arrow:dir(ltr), .menu menuitem arrow:dir(ltr), .context-menu menuitem arrow:dir(ltr) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); margin-left: 10px; }
+
+menu menuitem arrow:dir(rtl), .menu menuitem arrow:dir(rtl), .context-menu menuitem arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); margin-right: 10px; }
+
+menu menuitem label:dir(rtl), menu menuitem label:dir(ltr), .menu menuitem label:dir(rtl), .menu menuitem label:dir(ltr), .context-menu menuitem label:dir(rtl), .context-menu menuitem label:dir(ltr) { color: inherit; }
+
+menu separator, .menu separator, .context-menu separator { margin: 3px 16px; }
+
+menu > arrow, .menu > arrow, .context-menu > arrow { background-color: transparent; background-image: none; background-image: none; min-height: 16px; min-width: 16px; padding: 4px; background-color: #1a181e; border-radius: 0; }
+
+menu > arrow.top, .menu > arrow.top, .context-menu > arrow.top { margin-top: -8px; border-bottom: 1px solid #2d2933; border-top-right-radius: 8px; border-top-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+menu > arrow.bottom, .menu > arrow.bottom, .context-menu > arrow.bottom { margin-top: 16px; margin-bottom: -24px; border-top: 1px solid #2d2933; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+menu > arrow:hover, .menu > arrow:hover, .context-menu > arrow:hover { background-color: #37323e; }
+
+menu > arrow:backdrop, .menu > arrow:backdrop, .context-menu > arrow:backdrop { background-color: #161519; }
+
+menu > arrow:disabled, .menu > arrow:disabled, .context-menu > arrow:disabled { color: transparent; background-color: transparent; border-color: transparent; }
+
+menuitem accelerator { color: alpha(currentColor,0.55); }
+
+menuitem check, menuitem radio { min-height: 16px; min-width: 16px; }
+
+menuitem check:dir(ltr), menuitem radio:dir(ltr) { margin-right: 7px; }
+
+menuitem check:dir(rtl), menuitem radio:dir(rtl) { margin-left: 7px; }
+
+/*************** Popovers   * */
+popover.background { padding: 2px; background-color: #1a181e; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.csd popover.background, popover.background { border: 1px solid rgba(48, 43, 54, 0.75); border-radius: 10px; }
+
+.csd popover.background { background-clip: padding-box; }
+
+popover.background:backdrop { background-color: #161519; box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); border-color: rgba(44, 41, 48, 0.75); }
+
+popover.background > list, popover.background > .view, popover.background > iconview, popover.background > toolbar { border-style: none; background-color: transparent; }
+
+popover.background separator { margin: 3px; }
+
+popover.background list separator { margin: 0px; }
+
+/************* Notebooks * */
+notebook > header { padding: 2px; border-style: none; background-color: #1a181e; }
+
+notebook > header:backdrop { background-color: #161519; }
+
+notebook > header.top { border-radius: 8px 8px 0 0; }
+
+notebook > header.bottom { border-radius: 0 0 8px 8px; }
+
+notebook > header.left { border-radius: 8px 0 0 8px; }
+
+notebook > header.right { border-radius: 0 8px 8px 0; }
+
+notebook > header > button { padding: 2px 9px; margin: 2px; }
+
+notebook > header.left > tabs > arrow, notebook > header.right > tabs > arrow { margin-top: -5px; margin-bottom: -5px; padding-top: 4px; padding-bottom: 4px; }
+
+notebook > header.left > tabs > arrow.down, notebook > header.right > tabs > arrow.down { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+notebook > header.left > tabs > arrow.up, notebook > header.right > tabs > arrow.up { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+notebook > header > tabs > arrow { transition: none; min-height: 16px; min-width: 16px; }
+
+notebook > header > tabs > arrow:hover:not(:active):not(:backdrop) { background-clip: padding-box; background-image: none; border-color: transparent; box-shadow: none; transition: none; }
+
+notebook > header > tabs > arrow:disabled { color: #7d718c; background-color: transparent; background-image: none; }
+
+notebook > header tab { min-height: 24px; min-width: 30px; padding: 2px 9px; margin: 2px; outline-offset: -3px; border-radius: 8px; color: #b2a2c6; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header tab:hover { color: #d8c4f1; background-color: rgba(216, 196, 241, 0.05); }
+
+notebook > header tab:backdrop { color: #7b7484; }
+
+notebook > header tab:backdrop.reorderable-page { background-color: transparent; }
+
+notebook > header tab:checked { color: #d8c4f1; background-color: #3d3745; box-shadow: 0 2px 4px rgba(26, 24, 30, 0.075); }
+
+notebook > header tab:backdrop:checked { color: #7b7484; background-color: #2b282f; box-shadow: 0 1px 2px rgba(22, 21, 25, 0.075); }
+
+notebook > header tab:backdrop:checked.reorderable-page { background-color: #2b282f; }
+
+notebook > header tab button.flat { border-radius: 999px; padding: 0; margin-top: 2px; margin-bottom: 2px; min-width: 20px; min-height: 20px; }
+
+notebook > header tab button.flat:hover { color: currentColor; }
+
+notebook > header tab button.flat, notebook > header tab button.flat:backdrop { color: alpha(currentColor,0.3); }
+
+notebook > header tab button.flat:last-child { margin-left: 4px; margin-right: -4px; }
+
+notebook > header tab button.flat:first-child { margin-left: -4px; margin-right: 4px; }
+
+notebook > stack:not(:only-child) { background-color: transparent; }
+
+notebook > stack:not(:only-child):backdrop { background-color: transparent; }
+
+/************** Scrollbars * */
+scrollbar { background-color: transparent; transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border-radius: 8px; }
+
+* { -GtkScrollbar-has-backward-stepper: false; -GtkScrollbar-has-forward-stepper: false; }
+
+scrollbar:backdrop { border-color: #2c2930; transition: 150ms ease-out; }
+
+scrollbar slider { min-width: 6px; min-height: 6px; margin: -1px; border: 4px solid transparent; border-radius: 8px; background-clip: padding-box; background-color: #8f82a0; }
+
+scrollbar slider:hover { background-color: #b4a3c8; }
+
+scrollbar slider:hover:active { background-color: #d8c4f1; }
+
+scrollbar slider:backdrop { background-color: #5f5966; }
+
+scrollbar slider:disabled { background-color: transparent; }
+
+scrollbar.fine-tune slider { min-width: 4px; min-height: 4px; }
+
+scrollbar.fine-tune.horizontal slider { border-width: 5px 4px; }
+
+scrollbar.fine-tune.vertical slider { border-width: 4px 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) { border-color: transparent; opacity: 0.4; background-color: transparent; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider { margin: 0; min-width: 3px; min-height: 3px; background-color: #d8c4f1; border: 1px solid black; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) button { min-width: 5px; min-height: 5px; background-color: #d8c4f1; background-clip: padding-box; border-radius: 100%; border: 1px solid black; -gtk-icon-source: none; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider { margin: 0 2px; min-width: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal button { margin: 1px 2px; min-width: 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider { margin: 2px 0; min-height: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical button { margin: 2px 1px; min-height: 5px; }
+
+scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering { opacity: 0.8; }
+
+scrollbar.horizontal slider { min-width: 40px; }
+
+scrollbar.vertical slider { min-height: 40px; }
+
+scrollbar button { padding: 0; min-width: 12px; min-height: 12px; border-style: none; border-radius: 0; transition-property: min-height, min-width, color; background-color: transparent; background-image: none; background-image: none; color: #8f82a0; }
+
+scrollbar button:hover { background-color: transparent; background-image: none; background-image: none; color: #b4a3c8; }
+
+scrollbar button:active, scrollbar button:checked { background-color: transparent; background-image: none; background-image: none; color: #d8c4f1; }
+
+scrollbar button:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(143, 130, 160, 0.2); }
+
+scrollbar button:backdrop { background-color: transparent; background-image: none; background-image: none; color: #5f5966; }
+
+scrollbar button:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(95, 89, 102, 0.2); }
+
+scrollbar.vertical button.down { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+scrollbar.vertical button.up { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+scrollbar.horizontal button.down { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+scrollbar.horizontal button.up { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+/********** Switch * */
+switch { font-size: 0; outline-offset: -4px; min-width: 36px; min-height: 18px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border: none; padding: 2px; border-radius: 999px; background-color: #47404f; background-image: none; color: transparent; }
+
+switch:checked { background-color: #d8c4f1; background: image(#d8c4f1); }
+
+switch:disabled { background-color: #302b36; background-image: none; }
+
+switch:disabled:checked { background-color: #63596e; background-image: none; }
+
+switch:backdrop { background-color: #3f3a44; background-image: none; transition: 150ms ease-out; }
+
+switch:backdrop:checked { background-color: #8d839a; background-image: none; }
+
+switch:backdrop:disabled { background-color: #2c2930; background-image: none; }
+
+switch:backdrop:disabled:checked { background-color: #443f49; background-image: none; }
+
+switch slider { margin: 2px; min-width: 18px; min-height: 18px; border: none; border-radius: 999px; -gtk-outline-radius: 999px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-color: #1a181e; box-shadow: 0 2px 4px rgba(26, 24, 30, 0.075); }
+
+switch:disabled slider { background-color: #221f26; box-shadow: none; }
+
+switch:backdrop slider { transition: 150ms ease-out; background-color: #1d1b20; box-shadow: 0 2px 4px rgba(22, 21, 25, 0.075); }
+
+switch:checked slider { background-color: #1a181e; box-shadow: none; }
+
+switch:backdrop:checked slider { background-color: #161519; }
+
+row:selected switch { box-shadow: none; box-shadow: inset 0 0 0 1px #1a181e; }
+
+/************************* Check and Radio items * */
+.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view:not(list) check { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view:not(list) check:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view:not(list) check:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view:not(list) check:backdrop { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view:not(list) check:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view:not(list) check:checked:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view:not(list) check:checked:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view:not(list) check:backdrop:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+checkbutton.text-button, radiobutton.text-button { padding: 2px 0; outline-offset: 0; }
+
+checkbutton.text-button label:not(:only-child):first-child, radiobutton.text-button label:not(:only-child):first-child { margin-left: 4px; }
+
+checkbutton.text-button label:not(:only-child):last-child, radiobutton.text-button label:not(:only-child):last-child { margin-right: 4px; }
+
+check, radio { margin: 0 4px; min-height: 14px; min-width: 14px; padding: 1px; border: none; -gtk-icon-source: none; }
+
+check:only-child, radio:only-child { margin: 0; }
+
+popover check.left:dir(rtl), popover radio.left:dir(rtl) { margin-left: 0; margin-right: 12px; }
+
+popover check.right:dir(ltr), popover radio.right:dir(ltr) { margin-left: 12px; margin-right: 0; }
+
+check, radio { background-clip: padding-box; background: image(#1a181e); box-shadow: inset 0 0 0 1px #47404f; color: #d8c4f1; }
+
+check:hover, radio:hover { background: image(#242129); }
+
+check:active, radio:active { background: image(#2d2933); }
+
+check:disabled, radio:disabled { box-shadow: none; background-image: none; background-color: #1e1b22; color: rgba(216, 196, 241, 0.7); }
+
+check:backdrop, radio:backdrop { background-image: none; background-color: #1b1a1e; box-shadow: inset 0 0 0 1px #47424d; color: #d8c4f1; }
+
+check:backdrop:disabled, radio:backdrop:disabled { box-shadow: none; background-image: none; background-color: #1e1c21; color: rgba(216, 196, 241, 0.7); }
+
+check:checked, radio:checked { background-clip: border-box; background: image(#d8c4f1); box-shadow: none; color: #1a181e; }
+
+check:checked:hover, radio:checked:hover { background: image(#d8c4f1); }
+
+check:checked:active, radio:checked:active { background: image(#d8c4f1); }
+
+check:checked:disabled, radio:checked:disabled { box-shadow: none; background-image: none; background-color: #7d718c; color: rgba(26, 24, 30, 0.7); }
+
+check:checked:backdrop, radio:checked:backdrop { background-image: none; background-color: #a094af; box-shadow: none; color: #1a181e; }
+
+check:checked:backdrop:disabled, radio:checked:backdrop:disabled { box-shadow: none; background-image: none; background-color: #7d7588; color: rgba(26, 24, 30, 0.7); }
+
+check:indeterminate, radio:indeterminate { background-clip: border-box; background: image(#d8c4f1); box-shadow: none; color: #1a181e; }
+
+check:indeterminate:hover, radio:indeterminate:hover { background: image(#d8c4f1); }
+
+check:indeterminate:active, radio:indeterminate:active { background: image(#d8c4f1); }
+
+check:indeterminate:disabled, radio:indeterminate:disabled { box-shadow: none; background-image: none; background-color: #7d718c; color: rgba(26, 24, 30, 0.7); }
+
+check:indeterminate:backdrop, radio:indeterminate:backdrop { background-image: none; background-color: #a094af; box-shadow: none; color: #1a181e; }
+
+check:indeterminate:backdrop:disabled, radio:indeterminate:backdrop:disabled { box-shadow: none; background-image: none; background-color: #7d7588; color: rgba(26, 24, 30, 0.7); }
+
+check:backdrop, radio:backdrop { transition: 150ms ease-out; }
+
+menu menuitem check, menu menuitem radio { margin: 0; }
+
+menu menuitem check, menu menuitem check:hover, menu menuitem check:disabled, menu menuitem check:checked, menu menuitem check:checked:hover, menu menuitem check:checked:disabled, menu menuitem check:indeterminate, menu menuitem check:indeterminate:hover, menu menuitem check:indeterminate:disabled, menu menuitem radio, menu menuitem radio:hover, menu menuitem radio:disabled, menu menuitem radio:checked, menu menuitem radio:checked:hover, menu menuitem radio:checked:disabled, menu menuitem radio:indeterminate, menu menuitem radio:indeterminate:hover, menu menuitem radio:indeterminate:disabled { min-height: 14px; min-width: 14px; background-image: none; background-color: transparent; box-shadow: none; -gtk-icon-shadow: none; color: inherit; border: 1px solid currentColor; padding: 0; }
+
+check { border-radius: 4px; }
+
+check:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/check-symbolic.svg")), -gtk-recolor(url("assets/check-symbolic.symbolic.png"))); }
+
+check:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+treeview.view radio:selected:focus, treeview.view radio:selected, radio { border-radius: 100%; }
+
+treeview.view radio:checked:selected, radio:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/bullet-symbolic.svg")), -gtk-recolor(url("assets/bullet-symbolic.symbolic.png"))); }
+
+treeview.view radio:indeterminate:selected, radio:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+radio:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: scale(0); }
+
+check:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: translate(6px, -3px) rotate(-45deg) scaleY(0.2) rotate(45deg) scaleX(0); }
+
+radio:active, check:active { -gtk-icon-transform: scale(0, 1); }
+
+radio:checked:not(:backdrop), radio:indeterminate:not(:backdrop), check:checked:not(:backdrop), check:indeterminate:not(:backdrop) { -gtk-icon-transform: unset; transition: 400ms; }
+
+menu menuitem radio:checked:not(:backdrop), menu menuitem radio:indeterminate:not(:backdrop), menu menuitem check:checked:not(:backdrop), menu menuitem check:indeterminate:not(:backdrop) { transition: none; }
+
+treeview.view check:selected:focus, treeview.view check:selected, treeview.view radio:selected:focus, treeview.view radio:selected { color: #1a181e; border: 1px solid #c8b5df; }
+
+treeview.view check:selected:focus:backdrop, treeview.view check:selected:backdrop, treeview.view radio:selected:focus:backdrop, treeview.view radio:selected:backdrop { border-color: #a697b8; }
+
+/************ GtkScale * */
+levelbar block.empty, progressbar trough, scale fill, scale trough { border: none; border-radius: 8px; background-color: #302b36; }
+
+levelbar block.empty:disabled, progressbar trough:disabled, scale fill:disabled, scale trough:disabled { background-color: #302b36; }
+
+levelbar block.empty:backdrop, progressbar trough:backdrop, scale fill:backdrop, scale trough:backdrop { background-color: #2c2930; transition: 150ms ease-out; }
+
+levelbar block.empty:backdrop:disabled, progressbar trough:backdrop:disabled, scale fill:backdrop:disabled, scale trough:backdrop:disabled { background-color: #2c2930; }
+
+row:selected levelbar block.empty, levelbar row:selected block.empty, row:selected progressbar trough, progressbar row:selected trough, row:selected scale fill, scale row:selected fill, row:selected scale trough, scale row:selected trough { border: 1px solid #1a181e; }
+
+progressbar progress, scale highlight { border: none; border-radius: 8px; background-color: #d8c4f1; background: image(#d8c4f1); }
+
+scale.vertical progressbar progress, progressbar scale.vertical progress, scale.vertical highlight, progressbar.vertical progress, progressbar.vertical scale highlight, scale progressbar.vertical highlight { background: image(#d8c4f1); }
+
+progressbar progress:disabled, scale highlight:disabled { background-image: none; background-color: #47404f; }
+
+progressbar progress:backdrop, scale highlight:backdrop { background-image: none; background-color: #8d839a; }
+
+progressbar progress:backdrop:disabled, scale highlight:backdrop:disabled { background-image: none; background-color: #3f3a44; }
+
+row:selected progressbar progress, progressbar row:selected progress, row:selected scale highlight, scale row:selected highlight { border: 1px solid #1a181e; }
+
+scale { min-height: 10px; min-width: 10px; padding: 12px; }
+
+scale slider { min-height: 16px; min-width: 16px; margin: -8px; }
+
+scale.fine-tune.horizontal { padding-top: 9px; padding-bottom: 9px; min-height: 16px; }
+
+scale.fine-tune.vertical { padding-left: 9px; padding-right: 9px; min-width: 16px; }
+
+scale.fine-tune slider { margin: -6px; }
+
+scale.fine-tune fill, scale.fine-tune highlight, scale.fine-tune trough { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+scale trough { outline-offset: 2px; -gtk-outline-radius: 8px; }
+
+scale fill:backdrop, scale fill { background-color: #302b36; }
+
+scale fill:disabled:backdrop, scale fill:disabled { border-color: transparent; background-color: transparent; }
+
+scale slider { border: 2px solid #d8c4f1; border-radius: 100%; background-color: #221f26; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-property: background, border, box-shadow; }
+
+row scale slider, popover scale slider { background-color: #1a181e; }
+
+scale slider:hover { background-color: #1a181e; }
+
+row scale slider:hover, popover scale slider:hover { background-color: #221f26; }
+
+scale slider:active, row scale slider:active, popover scale slider:active { background-color: #d8c4f1; }
+
+scale slider:disabled { border-color: #47404f; }
+
+scale slider:backdrop { background-color: #1d1b20; border-color: #8d839a; transition: 150ms ease-out; }
+
+scale slider:backdrop:disabled { border-color: #3f3a44; }
+
+row:selected scale slider:disabled, row:selected scale slider { border-color: #c8b5df; }
+
+scale marks, scale value { color: alpha(currentColor,0.55); font-feature-settings: "tnum"; }
+
+scale.horizontal marks.top { margin-bottom: 6px; margin-top: -12px; }
+
+scale.horizontal.fine-tune marks.top { margin-bottom: 6px; margin-top: -9px; }
+
+scale.horizontal marks.bottom { margin-top: 6px; margin-bottom: -12px; }
+
+scale.horizontal.fine-tune marks.bottom { margin-top: 6px; margin-bottom: -9px; }
+
+scale.vertical marks.top { margin-right: 6px; margin-left: -12px; }
+
+scale.vertical.fine-tune marks.top { margin-right: 6px; margin-left: -9px; }
+
+scale.vertical marks.bottom { margin-left: 6px; margin-right: -12px; }
+
+scale.vertical.fine-tune marks.bottom { margin-left: 6px; margin-right: -9px; }
+
+scale.horizontal indicator { min-height: 6px; min-width: 1px; }
+
+scale.horizontal.fine-tune indicator { min-height: 3px; }
+
+scale.vertical indicator { min-height: 1px; min-width: 6px; }
+
+scale.vertical.fine-tune indicator { min-width: 3px; }
+
+scale.horizontal.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #d8c4f1; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-top: -13px; background-position: top; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:hover { color: #e6d9f6; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:active { color: #d8c4f1; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:disabled { color: #47404f; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop { color: #8d839a; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop:disabled { color: #3f3a44; }
+
+scale.horizontal.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-top: -11px; }
+
+scale.horizontal.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #d8c4f1; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-bottom: -13px; background-position: bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:hover { color: #e6d9f6; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:active { color: #d8c4f1; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:disabled { color: #47404f; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop { color: #8d839a; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop:disabled { color: #3f3a44; }
+
+scale.horizontal.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-bottom: -11px; }
+
+scale.vertical.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #d8c4f1; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-left: -13px; background-position: left bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-before:not(.marks-after) slider:hover { color: #e6d9f6; }
+
+scale.vertical.marks-before:not(.marks-after) slider:active { color: #d8c4f1; }
+
+scale.vertical.marks-before:not(.marks-after) slider:disabled { color: #47404f; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop { color: #8d839a; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop:disabled { color: #3f3a44; }
+
+scale.vertical.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-left: -11px; }
+
+scale.vertical.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #d8c4f1; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-right: -13px; background-position: right bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-after:not(.marks-before) slider:hover { color: #e6d9f6; }
+
+scale.vertical.marks-after:not(.marks-before) slider:active { color: #d8c4f1; }
+
+scale.vertical.marks-after:not(.marks-before) slider:disabled { color: #47404f; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop { color: #8d839a; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop:disabled { color: #3f3a44; }
+
+scale.vertical.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-right: -11px; }
+
+scale.color { min-height: 0; min-width: 0; }
+
+scale.color trough { background-color: transparent; }
+
+scale.color.horizontal { padding: 0 0 15px 0; }
+
+scale.color.horizontal trough { padding-bottom: 4px; background-position: 0 -3px; border-top-left-radius: 0; border-top-right-radius: 0; }
+
+scale.color.horizontal slider:dir(ltr):hover, scale.color.horizontal slider:dir(ltr):backdrop, scale.color.horizontal slider:dir(ltr):disabled, scale.color.horizontal slider:dir(ltr):backdrop:disabled, scale.color.horizontal slider:dir(ltr), scale.color.horizontal slider:dir(rtl):hover, scale.color.horizontal slider:dir(rtl):backdrop, scale.color.horizontal slider:dir(rtl):disabled, scale.color.horizontal slider:dir(rtl):backdrop:disabled, scale.color.horizontal slider:dir(rtl) { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.vertical:dir(ltr) { padding: 0 0 0 15px; }
+
+scale.color.vertical:dir(ltr) trough { padding-left: 4px; background-position: 3px 0; border-bottom-right-radius: 0; border-top-right-radius: 0; }
+
+scale.color.vertical:dir(ltr) slider:hover, scale.color.vertical:dir(ltr) slider:backdrop, scale.color.vertical:dir(ltr) slider:disabled, scale.color.vertical:dir(ltr) slider:backdrop:disabled, scale.color.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.vertical:dir(rtl) { padding: 0 15px 0 0; }
+
+scale.color.vertical:dir(rtl) trough { padding-right: 4px; background-position: -3px 0; border-bottom-left-radius: 0; border-top-left-radius: 0; }
+
+scale.color.vertical:dir(rtl) slider:hover, scale.color.vertical:dir(rtl) slider:backdrop, scale.color.vertical:dir(rtl) slider:disabled, scale.color.vertical:dir(rtl) slider:backdrop:disabled, scale.color.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr), scale.color.fine-tune.horizontal:dir(rtl) { padding: 0 0 12px 0; }
+
+scale.color.fine-tune.horizontal:dir(ltr) trough, scale.color.fine-tune.horizontal:dir(rtl) trough { padding-bottom: 7px; background-position: 0 -6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr) slider, scale.color.fine-tune.horizontal:dir(rtl) slider { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.fine-tune.vertical:dir(ltr) { padding: 0 0 0 12px; }
+
+scale.color.fine-tune.vertical:dir(ltr) trough { padding-left: 7px; background-position: 6px 0; }
+
+scale.color.fine-tune.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.fine-tune.vertical:dir(rtl) { padding: 0 12px 0 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) trough { padding-right: 7px; background-position: -6px 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+/***************** Progress bars * */
+@keyframes progress { from { background-position: 0, calc(0% - 64px), 0%; }
+  to { background-position: 0, calc(100% + 64px), 0%; } }
+
+progressbar { font-size: smaller; color: rgba(216, 196, 241, 0.4); font-feature-settings: "tnum"; }
+
+progressbar.horizontal trough, progressbar.horizontal progress { min-height: 4px; }
+
+progressbar.vertical trough, progressbar.vertical progress { min-width: 4px; }
+
+progressbar:backdrop { box-shadow: none; transition: 150ms ease-out; }
+
+progressbar trough { border-radius: 999px; }
+
+progressbar progress { background-image: none; background-color: #d8c4f1; border-radius: 999px; }
+
+progressbar progress, progressbar progress:backdrop, .horizontal progressbar progress { animation: none; }
+
+progressbar.horizontal progress { margin: 0 -1px; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled) { animation: progress 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite; background-size: cover, 64px 100%; background-repeat: no-repeat; background-image: linear-gradient(to bottom, alpha(@progress_bg_color, 0.2), rgba(180, 163, 200, 0)), linear-gradient(to right, rgba(180, 163, 200, 0), #b4a3c8 60%, rgba(180, 163, 200, 0)); }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled).right { animation-direction: reverse; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled):backdrop { animation: none; background-image: none; }
+
+progressbar.vertical progress { margin: -1px 0; }
+
+progressbar.osd { min-width: 4px; min-height: 4px; background-color: transparent; }
+
+progressbar.osd trough { border-style: none; border-radius: 0; background-color: transparent; box-shadow: none; }
+
+progressbar.osd progress { border-style: none; border-radius: 0; }
+
+progressbar trough.empty progress { all: unset; }
+
+/************* Level Bar * */
+levelbar.horizontal block { min-height: 4px; }
+
+levelbar.horizontal.discrete block { margin: 0 2px; min-width: 32px; }
+
+levelbar.horizontal.discrete block:first-child { margin-left: 0; }
+
+levelbar.horizontal.discrete block:last-child { margin-right: 0; }
+
+levelbar.vertical block { min-width: 4px; }
+
+levelbar.vertical.discrete block { margin: 2px 0; min-height: 32px; }
+
+levelbar.vertical.discrete block:first-child { margin-top: 0; }
+
+levelbar.vertical.discrete block:last-child { margin-bottom: 0; }
+
+levelbar:backdrop { transition: 150ms ease-out; }
+
+levelbar trough { border: none; padding: 0; background-color: transparent; }
+
+levelbar block { border: none; border-radius: 999px; }
+
+levelbar block.warning-battery-offset { background-color: #fb7c7c; background: image(#fb7c7c); }
+
+levelbar block.warning-battery-offset:backdrop { background-image: none; background-color: #8d839a; }
+
+levelbar block.low, levelbar block.low-battery-offset { background-color: #faa483; background: image(#faa483); }
+
+levelbar block.low:backdrop, levelbar block.low-battery-offset:backdrop { background-image: none; background-color: #8d839a; }
+
+levelbar block.high, levelbar block:not(.empty) { background-color: #d8c4f1; background: image(#d8c4f1); }
+
+levelbar block.high:backdrop, levelbar block:not(.empty):backdrop { background-image: none; background-color: #8d839a; }
+
+levelbar block.full, levelbar block.high-battery-offset { background-color: #6ee1b6; background: image(#6ee1b6); }
+
+levelbar block.full:backdrop, levelbar block.high-battery-offset:backdrop { background-image: none; background-color: #8d839a; }
+
+levelbar block.empty { background-image: none; }
+
+levelbar block:disabled { background-image: none; background-color: #47404f; }
+
+levelbar block:disabled:backdrop { background-image: none; background-color: #3f3a44; }
+
+/**************** Print dialog * */
+printdialog paper { color: black; border: 1px solid #595959; background: white; padding: 0; }
+
+printdialog paper:backdrop { color: #595959; border: 1px solid #262626; }
+
+printdialog .dialog-action-box { margin: 12px; }
+
+/********** Frames * */
+frame > border, .frame { box-shadow: none; margin: 0; padding: 0; border-radius: 10px; border: 1px solid #221f26; }
+
+frame > border.flat, .frame.flat { border-style: none; }
+
+frame > border:backdrop, .frame:backdrop { border-color: #1d1b20; }
+
+.background.csd revealer > actionbar { border-radius: 0 0 10px 10px; }
+
+actionbar > revealer > box { padding: 6px; border-top: 1px solid #302b36; }
+
+actionbar > revealer > box:backdrop { border-color: #2c2930; }
+
+scrolledwindow { background-color: transparent; border-radius: 0 0 8px 8px; }
+
+scrolledwindow viewport.frame { border-style: none; }
+
+scrolledwindow overshoot.top { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(rgba(216, 196, 241, 0.5)), to(rgba(216, 196, 241, 0))), -gtk-gradient(radial, center top, 0, center top, 0.6, from(rgba(216, 196, 241, 0.1)), to(rgba(216, 196, 241, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.top:backdrop { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(#2c2930), to(rgba(44, 41, 48, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(rgba(216, 196, 241, 0.5)), to(rgba(216, 196, 241, 0))), -gtk-gradient(radial, center bottom, 0, center bottom, 0.6, from(rgba(216, 196, 241, 0.1)), to(rgba(216, 196, 241, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom:backdrop { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(#2c2930), to(rgba(44, 41, 48, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(rgba(216, 196, 241, 0.5)), to(rgba(216, 196, 241, 0))), -gtk-gradient(radial, left center, 0, left center, 0.6, from(rgba(216, 196, 241, 0.1)), to(rgba(216, 196, 241, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left:backdrop { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(#2c2930), to(rgba(44, 41, 48, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(rgba(216, 196, 241, 0.5)), to(rgba(216, 196, 241, 0))), -gtk-gradient(radial, right center, 0, right center, 0.6, from(rgba(216, 196, 241, 0.1)), to(rgba(216, 196, 241, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right:backdrop { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(#2c2930), to(rgba(44, 41, 48, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+scrolledwindow junction { border-color: transparent; border-image: linear-gradient(to bottom, #302b36 1px, transparent 1px) 0 0 0 1/0 1px stretch; background-color: transparent; }
+
+scrolledwindow junction:dir(rtl) { border-image-slice: 0 1 0 0; }
+
+scrolledwindow junction:backdrop { border-image-source: linear-gradient(to bottom, #2c2930 1px, transparent 1px); background-color: transparent; transition: 150ms ease-out; }
+
+separator { background: #302b36; min-width: 1px; min-height: 1px; }
+
+/********* Lists * */
+list { color: #d8c4f1; background-color: #1a181e; border-color: transparent; border-radius: 10px; }
+
+list, list.frame { padding-top: 4px; padding-bottom: 4px; }
+
+list.content, list.content list { background-color: transparent; padding: 0; }
+
+list:backdrop { background-color: #161519; color: #7b7484; border-color: transparent; }
+
+list separator.horizontal { margin: 1px 16px; }
+
+list separator.vertical { margin: 16px 1px; }
+
+list row { padding: 2px; }
+
+row { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+list:not(.content) row { border-radius: 8px; margin: 1px 6px; }
+
+list.content row { background-color: #1a181e; }
+
+list.content row:backdrop { background-color: #161519; }
+
+list.content row:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+list.content row:last-child { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+row.expander { padding: 0px; }
+
+row:hover { transition: none; }
+
+row:backdrop { transition: 150ms ease-out; }
+
+row.activatable { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+row.activatable.has-open-popup, row.activatable:hover { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #302b36; background-image: none; background-color: rgba(216, 196, 241, 0.05); }
+
+row.activatable:active { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #3d3745; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, rgba(216, 196, 241, 0.15) 10%, transparent 0%); background-size: 0% 0%; }
+
+row.activatable:backdrop:hover { background-color: transparent; background-image: none; background-image: none; color: #7b7484; }
+
+row.activatable:selected { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; background: image(#d8c4f1); box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); }
+
+row.activatable:selected label { color: #1a181e; }
+
+row.activatable:selected:active { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); }
+
+row.activatable:selected:backdrop { background-color: #8d839a; background-image: none; box-shadow: none; }
+
+row.activatable:selected:backdrop label, row.activatable:selected:backdrop { color: #161519; }
+
+/********************* App Notifications * */
+.app-notification, .app-notification.frame { padding: 10px; margin: 8px; border-radius: 30px; border: 1px solid rgba(48, 43, 54, 0.75); box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification:backdrop, .app-notification.frame:backdrop { background-color: #161519; transition: 150ms ease-out; border-color: rgba(44, 41, 48, 0.75); box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification border, .app-notification.frame border { border: none; }
+
+.app-notification button:not(.linked), .app-notification.frame button:not(.linked) { border-radius: 999px; -gtk-outline-radius: 999px; }
+
+/************* Expanders * */
+expander title > arrow { min-width: 16px; min-height: 16px; -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+expander title > arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+expander title > arrow:hover { color: white; }
+
+expander title > arrow:disabled { color: #7d718c; }
+
+expander title > arrow:disabled:backdrop { color: #433e49; }
+
+expander title > arrow:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+/************ Calendar * */
+calendar { color: #d8c4f1; }
+
+calendar:selected { border-radius: 8px; }
+
+calendar.header { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.header:backdrop { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.button { color: rgba(216, 196, 241, 0.45); }
+
+calendar.button:hover { color: #d8c4f1; }
+
+calendar.button:backdrop { color: rgba(123, 116, 132, 0.45); }
+
+calendar.button:disabled { color: rgba(125, 113, 140, 0.45); }
+
+calendar.highlight { color: #7d718c; }
+
+calendar.highlight:backdrop { color: #433e49; }
+
+calendar:backdrop { color: #7b7484; border-color: #2c2930; }
+
+calendar:indeterminate { color: alpha(currentColor,0.1); }
+
+/*********** Dialogs * */
+messagedialog .titlebar { min-height: 20px; background-image: none; background-color: #221f26; border-style: none; border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+messagedialog.csd.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button { padding: 10px 14px; border-right-style: none; border-bottom-style: none; border-radius: 0; margin: 0 2px 0 0; -gtk-outline-radius: 0; }
+
+messagedialog.csd .dialog-action-area button:first-child { border-left-style: none; border-bottom-left-radius: 10px; -gtk-outline-bottom-left-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button:last-child { border-bottom-right-radius: 10px; margin-right: 0; -gtk-outline-bottom-right-radius: 10px; }
+
+filechooser .dialog-action-box { border-top: 1px solid #302b36; }
+
+filechooser .dialog-action-box:backdrop { border-top-color: #2c2930; }
+
+filechooser #pathbarbox { border: none; }
+
+filechooser #pathbarbox:backdrop { background-color: #1d1b20; }
+
+filechooserbutton:drop(active) { box-shadow: none; border-color: transparent; }
+
+/*********** Sidebar * */
+.sidebar { border-style: none; background-color: transparent; border-radius: 0 0 10px 10px; }
+
+stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:not(separator):dir(ltr), .sidebar:not(separator).left { border-right: 1px solid #302b36; border-left-style: none; }
+
+stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:not(separator):dir(rtl), .sidebar:not(separator).right { border-left: 1px solid #302b36; border-right-style: none; }
+
+.sidebar:backdrop { border-color: #2c2930; transition: 150ms ease-out; }
+
+.sidebar list { background-color: transparent; }
+
+paned .sidebar.left, paned .sidebar.right, paned .sidebar.left:dir(rtl), paned .sidebar:dir(rtl), paned .sidebar:dir(ltr), paned .sidebar { border-style: none; }
+
+stacksidebar row { padding: 10px 4px; }
+
+stacksidebar row > label { padding-left: 6px; padding-right: 6px; }
+
+stacksidebar row.needs-attention > label { background-size: 6px 6px, 0 0; }
+
+separator.sidebar { background-color: #302b36; }
+
+separator.sidebar:backdrop { background-color: #2c2930; }
+
+separator.sidebar.selection-mode, .selection-mode separator.sidebar { background-color: #c8b5df; }
+
+/**************** File chooser * */
+row image.sidebar-icon { opacity: 0.7; }
+
+placessidebar > viewport.frame { border-style: none; background-color: transparent; }
+
+placessidebar undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+placessidebar list { padding-top: 0; }
+
+placessidebar row { min-height: 36px; padding: 0px; margin-top: 0; margin-bottom: 0; }
+
+placessidebar row:first-child { margin-top: 0; }
+
+placessidebar row > revealer { padding: 0 8px; }
+
+placessidebar row:selected { color: #1a181e; }
+
+placessidebar row:disabled { color: #7d718c; }
+
+placessidebar row:backdrop { color: #7b7484; }
+
+placessidebar row:backdrop:selected { color: #161519; }
+
+placessidebar row:backdrop:disabled { color: #433e49; }
+
+placessidebar row image.sidebar-icon:dir(ltr) { padding-right: 8px; }
+
+placessidebar row image.sidebar-icon:dir(rtl) { padding-left: 8px; }
+
+placessidebar row label.sidebar-label:dir(ltr) { padding-right: 2px; }
+
+placessidebar row label.sidebar-label:dir(rtl) { padding-left: 2px; }
+
+button.sidebar-button { min-height: 26px; min-width: 26px; margin: 0; padding: 0; border-radius: 100%; -gtk-outline-radius: 100%; }
+
+button.sidebar-button:not(:hover):not(:active) > image, button.sidebar-button:backdrop > image { opacity: 0.7; }
+
+placessidebar row:selected:active { box-shadow: none; }
+
+placessidebar row.sidebar-placeholder-row { padding: 0 8px; min-height: 2px; background-image: image(#4cd9a4); background-clip: content-box; }
+
+placessidebar row.sidebar-new-bookmark-row { color: #d8c4f1; }
+
+placessidebar row:drop(active):not(:disabled) { color: #4cd9a4; box-shadow: inset 0 0 0 2px #4cd9a4; }
+
+placessidebar row:drop(active):not(:disabled):selected { color: #1a181e; background-color: #4cd9a4; }
+
+placesview list { background-color: #221f26; border-radius: 0 0 10px 0; }
+
+placesview list:backdrop { background-color: #1d1b20; }
+
+placesview .server-list-button > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(0turn); }
+
+placesview .server-list-button:checked > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(-0.5turn); }
+
+placesview row.activatable:hover { background-color: transparent; }
+
+placesview > actionbar > revealer > box > label { padding-left: 8px; padding-right: 8px; }
+
+/********* Paned * */
+paned > separator { min-width: 1px; min-height: 1px; -gtk-icon-source: none; border-style: none; background-color: transparent; background-image: image(#302b36); background-size: 1px 1px; }
+
+paned > separator:selected { background-image: image(#d8c4f1); }
+
+paned > separator:backdrop { background-image: image(#2c2930); }
+
+paned > separator.wide { min-width: 5px; min-height: 5px; background-color: #221f26; background-image: image(#302b36), image(#302b36); background-size: 1px 1px, 1px 1px; }
+
+paned > separator.wide:backdrop { background-color: #1d1b20; background-image: image(#2c2930), image(#2c2930); }
+
+paned.horizontal > separator { background-repeat: repeat-y; }
+
+paned.horizontal > separator:dir(ltr) { margin: 0 -8px 0 0; padding: 0 8px 0 0; background-position: left; }
+
+paned.horizontal > separator:dir(rtl) { margin: 0 0 0 -8px; padding: 0 0 0 8px; background-position: right; }
+
+paned.horizontal > separator.wide { margin: 0; padding: 0; background-repeat: repeat-y, repeat-y; background-position: left, right; }
+
+paned.vertical > separator { margin: 0 0 -8px 0; padding: 0 0 8px 0; background-repeat: repeat-x; background-position: top; }
+
+paned.vertical > separator.wide { margin: 0; padding: 0; background-repeat: repeat-x, repeat-x; background-position: bottom, top; }
+
+/************** GtkInfoBar * */
+infobar { border-style: none; }
+
+infobar.action:hover > revealer > box { background-color: #2c1d17; border-bottom: 1px solid #221f26; }
+
+infobar.info, infobar.question, infobar.warning, infobar.error { text-shadow: none; }
+
+infobar.info:backdrop > revealer > box, infobar.info > revealer > box, infobar.question:backdrop > revealer > box, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box, infobar.error > revealer > box { background-color: #32211a; border-bottom: 1px solid #221f26; }
+
+infobar.info:backdrop > revealer > box label, infobar.info:backdrop > revealer > box, infobar.info > revealer > box label, infobar.info > revealer > box, infobar.question:backdrop > revealer > box label, infobar.question:backdrop > revealer > box, infobar.question > revealer > box label, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box label, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box label, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box label, infobar.error:backdrop > revealer > box, infobar.error > revealer > box label, infobar.error > revealer > box { color: #faa483; }
+
+infobar.info:backdrop, infobar.question:backdrop, infobar.warning:backdrop, infobar.error:backdrop { text-shadow: none; }
+
+infobar.info button, infobar.question button, infobar.warning button, infobar.error button { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #412b22; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #50352a; background-image: none; }
+
+infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #5a3b2f; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #6e483a 10%, transparent 0%); background-size: 0% 0%; }
+
+infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; background: image(#d8c4f1); box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); }
+
+infobar.info button:checked:active, infobar.question button:checked:active, infobar.warning button:checked:active, infobar.error button:checked:active { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); }
+
+infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled { color: #7d718c; background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop, infobar.question button:backdrop, infobar.warning button:backdrop, infobar.error button:backdrop { background-color: #242228; background-image: none; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.error button:backdrop label, infobar.error button:backdrop { color: #7b7484; }
+
+infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop:disabled label, infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled label, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled label, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled label, infobar.error button:backdrop:disabled { color: #433e49; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.info button label, infobar.info button, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.question button label, infobar.question button, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.warning button label, infobar.warning button, infobar.error button:backdrop label, infobar.error button:backdrop, infobar.error button label, infobar.error button { color: #faa483; }
+
+infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection { background-color: #09080a; }
+
+infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link { color: #f3edfb; }
+
+/************ Tooltips * */
+tooltip { padding: 4px; /* not working */ border-radius: 10px; box-shadow: none; }
+
+tooltip.background, tooltip.background.csd { border-radius: 10px; background-color: rgba(0, 0, 0, 0.8); background-clip: padding-box; border: 1px solid rgba(255, 255, 255, 0.1); }
+
+tooltip decoration { background-color: transparent; }
+
+tooltip * { padding: 4px; background-color: transparent; color: white; }
+
+/***************** Color Chooser * */
+colorswatch:drop(active), colorswatch { border-style: none; }
+
+colorswatch.top { border-top-left-radius: 8.5px; border-top-right-radius: 8.5px; }
+
+colorswatch.top overlay { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+colorswatch.bottom { border-bottom-left-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.bottom overlay { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.left, colorswatch:first-child:not(.top) { border-top-left-radius: 8.5px; border-bottom-left-radius: 8.5px; }
+
+colorswatch.left overlay, colorswatch:first-child:not(.top) overlay { border-top-left-radius: 8px; border-bottom-left-radius: 8px; }
+
+colorswatch.right, colorswatch:last-child:not(.bottom) { border-top-right-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.right overlay, colorswatch:last-child:not(.bottom) overlay { border-top-right-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.dark { outline-color: rgba(255, 255, 255, 0.6); }
+
+colorswatch.dark overlay { color: white; }
+
+colorswatch.dark overlay:backdrop { color: rgba(255, 255, 255, 0.5); }
+
+colorswatch.light { outline-color: rgba(0, 0, 0, 0.6); }
+
+colorswatch.light overlay { color: black; }
+
+colorswatch.light overlay:backdrop { color: rgba(0, 0, 0, 0.5); }
+
+colorswatch:drop(active) { box-shadow: none; }
+
+colorswatch:drop(active).light overlay { border-color: #4cd9a4; }
+
+colorswatch:drop(active).dark overlay { border-color: #4cd9a4; }
+
+colorswatch overlay { border: 1px solid transparent; }
+
+colorswatch#add-color-button { border-radius: 8px 8px 0 0; }
+
+colorswatch#add-color-button:only-child { border-radius: 8px; }
+
+colorswatch#add-color-button overlay { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #302b36; background-image: none; }
+
+colorswatch#add-color-button overlay:hover { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-color: #3d3745; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop { background-color: #242228; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop label, colorswatch#add-color-button overlay:backdrop { color: #7b7484; }
+
+colorswatch:disabled { opacity: 0.5; }
+
+colorswatch:disabled overlay { border-color: rgba(0, 0, 0, 0.6); box-shadow: none; }
+
+row:selected colorswatch { box-shadow: 0 0 0 2px #1a181e; }
+
+colorswatch#editor-color-sample { border-radius: 8px; }
+
+colorswatch#editor-color-sample overlay { border-radius: 8.5px; }
+
+colorchooser .popover.osd { border-radius: 8px; }
+
+/******** Misc * */
+.content-view { background-color: #1c191f; }
+
+.content-view:hover { -gtk-icon-effect: highlight; }
+
+.content-view:backdrop { background-color: #171519; }
+
+.osd .scale-popup button.flat { border-style: none; border-radius: 8px; }
+
+.scale-popup button:hover { background-color: rgba(216, 196, 241, 0.15); border-radius: 8px; }
+
+/********************** Window Decorations * */
+decoration { border-radius: 10px; border-width: 0px; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(216, 196, 241, 0.1); margin: 10px; }
+
+decoration:backdrop { box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(123, 116, 132, 0.125); transition: 150ms ease-out; }
+
+.maximized decoration, .fullscreen decoration, .tiled decoration, .tiled-top decoration, .tiled-right decoration, .tiled-bottom decoration, .tiled-left decoration { border-radius: 0; }
+
+.popup decoration { box-shadow: none; }
+
+.ssd decoration { box-shadow: 0 0 0 1px rgba(216, 196, 241, 0.1); }
+
+.csd.popup decoration { border-radius: 8px; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(216, 196, 241, 0.1); }
+
+.csd.popup decoration:backdrop { box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(123, 116, 132, 0.125); }
+
+tooltip.csd decoration { border-radius: 10px; box-shadow: none; }
+
+messagedialog.csd decoration { border-radius: 10px; box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(216, 196, 241, 0.1); }
+
+messagedialog.csd decoration:backdrop { box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(123, 116, 132, 0.125); }
+
+.solid-csd decoration { margin: 0; padding: 4px; background-color: #302b36; border: solid 1px #302b36; border-radius: 0; box-shadow: none; }
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized), window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration, window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration-overlay { border-radius: 10px; }
+
+button.titlebutton:not(.appmenu) { border-radius: 9999px; padding: 6px; margin: 0 2px; min-width: 0; min-height: 0; }
+
+button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.selection-mode headerbar button.titlebutton:backdrop, .selection-mode .titlebar button.titlebutton:backdrop, headerbar.selection-mode button.titlebutton:backdrop, .titlebar.selection-mode button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { background-color: #d8c4f1; }
+
+.selection-mode button.titlebutton, .view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { color: #1a181e; }
+
+.selection-mode button.titlebutton:disabled, .view:disabled:selected, textview text:disabled:selected:focus, .view text:disabled:selected, textview text:disabled:selected, iconview:disabled:selected:focus, iconview:disabled:selected, flowbox flowboxchild:disabled:selected, modelbutton.flat:disabled:selected, .menuitem.button.flat:disabled:selected, treeview.view:disabled:selected, row:disabled:selected, calendar:disabled:selected { color: #796e87; }
+
+.selection-mode button.titlebutton:backdrop, .view:backdrop:selected, textview text:backdrop:selected:focus, .view text:backdrop:selected, textview text:backdrop:selected, iconview:backdrop:selected:focus, iconview:backdrop:selected, flowbox flowboxchild:backdrop:selected, modelbutton.flat:backdrop:selected, .menuitem.button.flat:backdrop:selected, treeview.view:backdrop:selected, row:backdrop:selected, calendar:backdrop:selected { color: #161519; background-color: #8d839a; }
+
+.selection-mode button.titlebutton:backdrop:disabled, .view:backdrop:disabled:selected, .view text:backdrop:disabled:selected, textview text:backdrop:disabled:selected, iconview:backdrop:disabled:selected, flowbox flowboxchild:backdrop:disabled:selected, modelbutton.flat:backdrop:disabled:selected, .menuitem.button.flat:backdrop:disabled:selected, row:backdrop:disabled:selected, calendar:backdrop:disabled:selected { color: #9e90b0; }
+
+.view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { background-color: #4b4454; }
+
+label:selected, .view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { color: #d8c4f1; }
+
+label:disabled selection, label:disabled:selected, .view text selection:disabled, textview text selection:disabled:focus, textview text selection:disabled, iconview text selection:disabled:focus, iconview text selection:disabled, label selection:disabled, entry selection:disabled, spinbutton:not(.vertical) selection:disabled { color: #867996; }
+
+label:backdrop selection, label:backdrop:selected, .view text selection:backdrop, textview text selection:backdrop:focus, textview text selection:backdrop, iconview text selection:backdrop:focus, iconview text selection:backdrop, label selection:backdrop, entry selection:backdrop, spinbutton:not(.vertical) selection:backdrop { background-color: #36323b; color: #7d7586; }
+
+label:backdrop selection:disabled, label:backdrop:disabled:selected, .view text selection:backdrop:disabled, textview text selection:backdrop:disabled, iconview text selection:backdrop:disabled, label selection:backdrop:disabled, entry selection:backdrop:disabled, spinbutton:not(.vertical) selection:backdrop:disabled { color: #4a4552; }
+
+.monospace { font-family: monospace; }
+
+/********************** Touch Copy & Paste * */
+cursor-handle { background-color: transparent; background-image: none; box-shadow: none; border-style: none; color: #d8c4f1; }
+
+cursor-handle:hover { color: white; }
+
+cursor-handle:active { color: #d8c4f1; }
+
+cursor-handle.top:dir(ltr), cursor-handle.bottom:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-start-symbolic.svg")), -gtk-recolor(url("assets/text-select-start-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.bottom:dir(ltr), cursor-handle.top:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-end-symbolic.svg")), -gtk-recolor(url("assets/text-select-end-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); }
+
+.context-menu { font: initial; }
+
+.keycap { min-width: 20px; min-height: 25px; margin-top: 2px; padding-bottom: 3px; padding-left: 6px; padding-right: 6px; color: #d8c4f1; background-color: #1a181e; border: 1px solid; border-color: #302b36; border-radius: 4px; box-shadow: inset 0 -3px #27232c; font-size: smaller; }
+
+.keycap:backdrop { background-color: #161519; color: #7b7484; transition: 150ms ease-out; }
+
+:not(decoration):not(window):drop(active):focus, :not(decoration):not(window):drop(active) { border-color: #4cd9a4; box-shadow: inset 0 0 0 1px #4cd9a4; caret-color: #4cd9a4; }
+
+stackswitcher button.text-button { min-width: 100px; }
+
+stackswitcher button.circular, stackswitcher button.text-button.circular { min-width: 32px; min-height: 32px; padding: 0; }
+
+/************* App Icons * */
+/* Outline for low res icons */
+.lowres-icon { -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/* Dropshadow for large icons */
+.icon-dropshadow { -gtk-icon-shadow: 0 1px 12px rgba(0, 0, 0, 0.05), 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/********* Emoji * */
+popover.emoji-picker { padding-left: 0; padding-right: 0; }
+
+popover.emoji-picker entry.search { margin: 3px 5px 5px 5px; }
+
+button.emoji-section { border-color: transparent; border-width: 3px; border-style: none none solid; border-radius: 0; margin: 2px 4px 2px 4px; padding: 3px 0 0; min-width: 32px; min-height: 28px; /* reset props inherited from the button style */ background: none; box-shadow: none; text-shadow: none; outline-offset: -5px; }
+
+button.emoji-section:first-child { margin-left: 7px; }
+
+button.emoji-section:last-child { margin-right: 7px; }
+
+button.emoji-section:backdrop:not(:checked) { border-color: transparent; }
+
+button.emoji-section:hover { border-color: #302b36; }
+
+button.emoji-section:checked { color: #d8c4f1; border-color: #d8c4f1; }
+
+button.emoji-section:checked:backdrop { color: #7b7484; background-color: transparent; }
+
+button.emoji-section label { padding: 0; opacity: 0.55; }
+
+button.emoji-section:hover label { opacity: 0.775; }
+
+button.emoji-section:checked label { opacity: 1; }
+
+popover.emoji-picker .emoji { font-size: x-large; padding: 6px; }
+
+popover.emoji-picker .emoji :hover { background: #d8c4f1; border-radius: 8px; }
+
+popover.emoji-completion arrow { border: none; background: none; }
+
+popover.emoji-completion contents row box { padding: 2px 10px; }
+
+popover.emoji-completion .emoji:hover { background: #302b36; }
+
+/***************** View Switcher * */
+viewswitcher button { margin: 0; padding: 0; border-radius: 0; border: none; box-shadow: none; }
+
+viewswitcher button:checked { box-shadow: none; }
+
+viewswitcher button stack > box.narrow { font-size: smaller; padding-top: 6px; padding-bottom: 6px; }
+
+viewswitcher button stack > box.narrow image, viewswitcher button stack > box.narrow label { padding-left: 6px; padding-right: 6px; }
+
+viewswitcher button stack > box.wide { padding: 0 12px; }
+
+viewswitcherbar > actionbar > revealer > box { padding: 0; }
+
+viewswitcherbar > actionbar > revealer > box viewswitcher button:not(:checked):not(:hover) { background: transparent; }
+
+headerbar viewswitcher > box > button:first-child { border-bottom-left-radius: 8px; }
+
+headerbar viewswitcher > box > button:last-child { border-bottom-right-radius: 8px; }
+
+/*********** Chromium * */
+window.background.chromium { background-color: #1a181e; }
+
+window.background.chromium headerbar.titlebar button.toggle, window.background.chromium headerbar.titlebar button.titlebutton { border: none; }
+
+window.background.chromium headerbar.titlebar button.titlebutton { background-image: none; }
+
+window.background.chromium button { border-style: solid; border-width: 1px; border-color: #302b36; }
+
+window.background.chromium > textview.view { background-color: #221f26; }
+
+/*********** Firefox * */
+#MozillaGtkWidget.background { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+
+#MozillaGtkWidget.background scrollbar { background-color: transparent; border-color: transparent; }
+
+/****************** Gnome Calendar * */
+window.background.csd.org-gnome-Calendar > overlay > box.vertical > stack.view { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > button.text-button { margin: 0; border-bottom-right-radius: 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > stack > .sidebar.vertical { border-radius: 0; }
+
+window.background.csd.org-gnome-Calendar.maximized calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.tiled calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.fullscreen calendar-view.year-view > box.vertical > button.text-button { border-bottom-right-radius: 0; }
+
+/*************** LibreOffice * */
+toolbutton > button.image-button.text-button.flat button { background-color: transparent; background-image: none; background-image: none; }
+
+toolbutton > button.image-button.text-button.flat button:hover { background-color: #302b36; }
+
+toolbutton > button.image-button.text-button.flat button:active, toolbutton > button.image-button.text-button.flat button:checked { background-color: #3d3745; box-shadow: none; }
+
+window.background:not(.solid-csd) > notebook:not(.frame) tab { margin-bottom: 4px; }
+
+/************ Nautilus * */
+.nautilus-window .floating-bar { min-height: 32px; padding: 0; border-radius: 10px 10px 0 0; background-color: #1a181e; background-clip: padding-box; }
+
+.nautilus-window .floating-bar.bottom.left { margin-right: 7px; border-top-left-radius: 0; border-bottom-left-radius: 10px; }
+
+.nautilus-window .floating-bar.bottom.right { margin-left: 7px; border-top-right-radius: 0; border-bottom-right-radius: 10px; }
+
+.nautilus-window .floating-bar button { padding: 0; }
+
+.nautilus-window .nautilus-list-view { background-color: #1a181e; border-radius: 0 0 10px 10px; }
+
+.nautilus-window .nautilus-list-view treeview.view:not(:hover):not(:active):not(:selected) { background-color: transparent; border-radius: 0; }
+
+.nautilus-window.maximized .floating-bar, .nautilus-window.maximized .nautilus-list-view, .nautilus-window.tiled .floating-bar, .nautilus-window.tiled .nautilus-list-view, .nautilus-window.fullscreen .floating-bar, .nautilus-window.fullscreen .nautilus-list-view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.nautilus-window headerbar .path-bar-box { color: transparent; background: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; background: image(#d8c4f1); box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child:active { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { background-color: #8d839a; background-image: none; box-shadow: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child label, .nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { color: #161519; }
+
+.nautilus-window notebook > header.top:dir(ltr) { border-top-left-radius: 0; }
+
+.nautilus-window notebook > header.top:dir(rtl) { border-top-right-radius: 0; }
+
+.nautilus-canvas-item { border-radius: 8px; }
+
+.nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator, headerbar .nautilus-canvas-item.subtitle, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle, popover.background label.nautilus-canvas-item.separator, .nautilus-list-dim-label { color: #867a96; }
+
+.nautilus-canvas-item.dim-label:backdrop, label.nautilus-canvas-item.separator:backdrop, headerbar .nautilus-canvas-item.subtitle:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:backdrop, popover.background label.nautilus-canvas-item.separator:backdrop, .nautilus-list-dim-label:backdrop { color: #514c57; }
+
+.nautilus-canvas-item.dim-label:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected, label.nautilus-canvas-item.separator:selected:focus, headerbar .nautilus-canvas-item.subtitle:selected, headerbar .nautilus-canvas-item.subtitle:selected:focus, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus, popover.background label.nautilus-canvas-item.separator:selected, popover.background label.nautilus-canvas-item.separator:selected:focus, .nautilus-list-dim-label:selected, .nautilus-list-dim-label:selected:focus { color: rgba(26, 24, 30, 0.45); }
+
+.nautilus-canvas-item.dim-label:selected:backdrop, .nautilus-canvas-item.dim-label:selected:focus:backdrop, label.nautilus-canvas-item.separator:selected:backdrop, label.nautilus-canvas-item.separator:selected:focus:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:focus:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus:backdrop, popover.background label.nautilus-canvas-item.separator:selected:backdrop, popover.background label.nautilus-canvas-item.separator:selected:focus:backdrop, .nautilus-list-dim-label:selected:backdrop, .nautilus-list-dim-label:selected:focus:backdrop { color: rgba(22, 21, 25, 0.45); }
+
+.disk-space-display.unknown { background-color: rgba(216, 196, 241, 0.4); color: rgba(216, 196, 241, 0.4); }
+
+.disk-space-display.used { background-color: #d8c4f1; color: #d8c4f1; }
+
+.disk-space-display.free { background-color: rgba(216, 196, 241, 0.1); color: rgba(216, 196, 241, 0.1); }
+
+dialog > box > grid > scrolledwindow > viewport > box > list { padding: 0; background-color: transparent; border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list:backdrop { background-color: transparent; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list > row { border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list separator.horizontal { margin: 0; }
+
+/**************************************************** documents-scrolledwin (Totem, Documents, EvView) * */
+.documents-scrolledwin:backdrop, .documents-scrolledwin { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover), .documents-scrolledwin .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin .content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:hover, .documents-scrolledwin .content-view:hover { background-color: rgba(216, 196, 241, 0.075); }
+
+.documents-scrolledwin:backdrop viewport.frame, .documents-scrolledwin viewport.frame { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover), .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover) border, .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) border { border: none; }
+
+/******************* Document Viewer * */
+window.background.csd > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { background-color: transparent; border-radius: 10px; }
+
+window.background.csd > box.vertical > paned.horizontal > box.vertical > scrolledwindow > treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+window.background.csd evview.view.content-view { background-color: transparent; border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.maximized > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { border-radius: 0; }
+
+window.background.csd.maximized evview.view.content-view, window.background.csd.tiled evview.view.content-view, window.background.csd.fullscreen evview.view.content-view { border-radius: 0; }
+
+/******************* Archive Manager * */
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow { border-radius: 0 0 10px 10px; background-color: #1a181e; }
+
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-radius: 0 0 0 10px; background-color: #221f26; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/********* Geary * */
+frame.geary-conversation-frame scrolledwindow treeview.view:not(:selected) { background: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected { color: #1a181e; outline-color: rgba(26, 24, 30, 0.3); background-color: #d8c4f1; background: image(#d8c4f1); box-shadow: 0 2px 4px rgba(216, 196, 241, 0.2); box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { background-color: #8d839a; background-image: none; box-shadow: none; box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop label, frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { color: #161519; }
+
+.geary_email { padding-bottom: 6px; border-radius: 8px; }
+
+.geary_email .geary-message { border-radius: 8px; }
+
+.geary-attachment-pane > separator.horizontal { margin: 0; }
+
+.geary-attachment-pane flowboxchild { border-radius: 8px; }
+
+.geary-attachment-pane > actionbar { background-color: #1a181e; }
+
+.geary-attachment-pane > actionbar:backdrop { background-color: #161519; }
+
+/********* Gedit * */
+window.org-gnome-gedit stack scrolledwindow viewport.frame list.gedit-document-panel { background-color: transparent; }
+
+window.org-gnome-gedit .gedit-search-entry-occurrences-tag { border: none; box-shadow: none; margin: 2px; padding: 2px; }
+
+/******************** Gnome Calculator * */
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list { padding: 0; border-radius: 0; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry { margin: 0; border-radius: 0; background-color: #221f26; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry:backdrop { background-color: #1d1b20; }
+
+grid > viewport > box > scrolledwindow.display-scrolled > .sourceview.view > text, grid > viewport > box > scrolledwindow.display-scrolled > iconview.sourceview > text { border-radius: 10px 10px 0 0; }
+
+grid > viewport > box box > textview.view.info-view > text { border-radius: 0 0 10px 10px; }
+
+/************************ Gnome Control Center * */
+window.background.csd > leaflet > stack.background, window.background.csd > hdyleaflet > stack.background, window.background.csd > box.horizontal > stack.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-left-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+window.background.csd.maximized > leaflet > stack.background, window.background.csd.maximized > hdyleaflet > stack.background, window.background.csd.maximized > box.horizontal > stack.background, window.background.csd.maximized > leaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.tiled > leaflet > stack.background, window.background.csd.tiled > hdyleaflet > stack.background, window.background.csd.tiled > box.horizontal > stack.background, window.background.csd.tiled > leaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > leaflet > stack.background, window.background.csd.fullscreen > hdyleaflet > stack.background, window.background.csd.fullscreen > box.horizontal > stack.background, window.background.csd.fullscreen > leaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+window.background.csd > leaflet > stack.background > widget > box > box > scrolledwindow > viewport.frame > box.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+/************** Gnome Maps * */
+popover.maps-popover > grid > button.radio.layer-radio-button { border-radius: 4px; color: transparent; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:active { color: #d8c4f1; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:checked { color: #d8c4f1; }
+
+/*************** Gnome Music * */
+window.background.csd > box.vertical > overlay > stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > overlay > stack.background, window.background.csd.tiled > box.vertical > overlay > stack.background, window.background.csd.fullscreen > box.vertical > overlay > stack.background { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/****************** Gnome Software * */
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal { border-radius: 8px; background-color: #1a181e; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal:backdrop { background-color: #161519; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal list.app-updates-section { border: none; border-radius: 10px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software { padding-top: 2px; padding-bottom: 2px; margin: 4px 2px; min-height: 24px; min-width: 54px; border-radius: 8px; -gtk-outline-radius: 8px; background-color: transparent; color: #b2a2c6; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(ltr) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(rtl) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(ltr) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(rtl) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:hover { color: #d8c4f1; background-color: rgba(216, 196, 241, 0.05); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:checked { color: #d8c4f1; outline-color: rgba(216, 196, 241, 0.3); background-image: none; background-color: #3d3745; box-shadow: 0 2px 4px rgba(26, 24, 30, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop { color: #7b7484; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:hover { background-color: transparent; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { background-image: none; background-color: #2b282f; box-shadow: 0 1px 2px rgba(22, 21, 25, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked label, window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { color: #7b7484; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal button:checked + button { border-image: none; }
+
+window.background.csd button.text-button.content-rating { color: #1a181e; }
+
+window.background.csd button.text-button.content-rating:backdrop { color: #161519; }
+
+/****************** Gnome Terminal * */
+terminal-window.background.csd { border-radius: 0; }
+
+terminal-window decoration { background-color: #221f26; border-radius: 10px 10px 0 0; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(216, 196, 241, 0.1), 0 0 0 1px #221f26; }
+
+terminal-window decoration:backdrop { background-color: #1d1b20; box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(123, 116, 132, 0.125), 0 0 0 1px #1d1b20; }
+
+terminal-window .terminal-screen { background-color: #221f26; color: #d8c4f1; }
+
+terminal-window .terminal-screen:backdrop { background-color: #1d1b20; color: #7b7484; }
+
+/*************** Gnome Todo * */
+window.background.csd.org-gnome-Todo > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Todo.maximized > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.maximized stack.background, window.background.csd.org-gnome-Todo.tiled > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.tiled stack.background, window.background.csd.org-gnome-Todo.fullscreen > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.fullscreen stack.background { border-radius: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row { box-shadow: none; padding: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row entry, window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row button { margin: 0; border-radius: 2.5px; }
+
+/**************** Gnome Tweaks * */
+hdyleaflet list.tweak-categories, leaflet list.tweak-categories { background-color: transparent; }
+
+hdyleaflet list.tweak-categories > separator, leaflet list.tweak-categories > separator { background-color: transparent; min-height: 0; }
+
+row#AutostartTitle.tweak { padding: 8px 8px 0 8px; }
+
+.tweak-group-startup { background-color: #1a181e; }
+
+.tweak-group-startup:backdrop { background-color: #161519; }
+
+/***************** Gnome Weather * */
+#weather-page, #weekly-forecast-frame { border-bottom-right-radius: 10px; }
+
+#weather-page-content-view { border-bottom-right-radius: 10px; border-bottom-left-radius: 10px; }
+
+/************ Ubiquity * */
+#live_installer #stepPartAuto #partition_container #resizewidget separator { background-image: none; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > * { background-color: transparent; border-radius: 0; border-color: #302b36; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > *:backdrop { border-color: #2c2930; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box { background-color: #1a181e; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box:backdrop { background-color: #161519; }
+
+/******************** Zorin Appearance * */
+stacksidebar.sidebar > scrolledwindow > viewport.frame > list { border-radius: 0; }
+
+/********** Thunar * */
+.thunar .sidebar.frame { border: none; }
+
+.thunar .sidebar .view, .thunar .sidebar iconview { background-color: #221f26; border: none; }
+
+.thunar .sidebar .view:selected, .thunar .sidebar iconview:selected { background-color: #3d3745; color: #d8c4f1; }
+
+.thunar .sidebar .view:backdrop, .thunar .sidebar iconview:backdrop { background-color: #1d1b20; }
+
+.thunar .sidebar .view:backdrop:selected, .thunar .sidebar iconview:backdrop:selected { background-color: #2b282f; color: #7b7484; }
+
+.thunar .standard-view > .view, .thunar .standard-view > iconview { border-radius: 0; }
+
+/*********************** LightDM Gtk Greeter * */
+.lightdm-gtk-greeter #panel_window { border-radius: 0; border: none; background-color: #221f26; }
+
+.lightdm-gtk-greeter #panel_window menubar { font-weight: bold; }
+
+.lightdm-gtk-greeter #panel_window menubar menu menuitem { font-weight: normal; }
+
+.lightdm-gtk-greeter #buttonbox_frame { padding-top: 20px; }
+
+.lightdm-gtk-greeter #login_window, .lightdm-gtk-greeter #shutdown_dialog, .lightdm-gtk-greeter #restart_dialog { border-style: none; border-radius: 10px; background-color: #221f26; color: #d8c4f1; box-shadow: none; }
+
+.lightdm-gtk-greeter #login_window menu { border-radius: 0; }
+
+/******** XFCE * */
+.xfce4-panel.background { background-color: #1a181e; }
+
+.xfce4-panel.background button { border-radius: 0; margin: 0; font-weight: bold; }
+
+.xfce4-panel.background button menuitem { font-weight: normal; }
+
+.xfce4-panel.background button:hover { background-color: #302b36; }
+
+.xfce4-panel.background button:active, .xfce4-panel.background button:checked { color: #d8c4f1; background-color: #3d3745; background-image: none; }
+
+.xfce4-panel.background button.flat image, .xfce4-panel.background button.image-button image { -gtk-icon-transform: scale(1); transition: none; }
+
+.xfce4-panel.background button.flat:active image, .xfce4-panel.background button.image-button:active image { -gtk-icon-transform: scale(1); }
+
+.tasklist button.toggle { background-color: transparent; border-top-width: 0; border-bottom-width: 0; }
+
+.tasklist button.toggle:checked { background: none; box-shadow: inset 0 -3px #d8c4f1; }
+
+wnck-pager { background-color: #28252e; }
+
+wnck-pager:hover { background-color: #37323e; }
+
+wnck-pager:selected { background-color: #403a48; }
+
+XfdesktopIconView.view { background: transparent; color: white; }
+
+XfdesktopIconView.view:active { background: #d8c4f1; color: #1a181e; text-shadow: none; }
+
+XfdesktopIconView.view .label { text-shadow: 1px 1px 2px black; }
+
+#XfceNotifyWindow { background-color: #1a181e; border: none; box-shadow: inset 0 0 0 1px rgba(48, 43, 54, 0.75); border-radius: 10px; }
+
+#XfceNotifyWindow label#summary { font-weight: bold; }
+
+#XfceNotifyWindow progressbar progress { animation: none; background-image: none; background: image(#d8c4f1); }
+
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin { border-radius: 10px; }
+
+/* GTK NAMED COLORS ---------------- use responsibly! */
+/*
+widget text/foreground color */
+@define-color theme_fg_color #d8c4f1;
+/*
+text color for entries, views and content in general */
+@define-color theme_text_color #d8c4f1;
+/*
+widget base background color */
+@define-color theme_bg_color #221f26;
+/*
+text widgets and the like base background color */
+@define-color theme_base_color #1a181e;
+/*
+base background color of selections */
+@define-color theme_selected_bg_color #c6b4dc;
+/* Tinting in dark variant to avoid a white selection on white page background when highlighting text in Evince when using Grey-Dark theme */
+/*
+text/foreground color of selections */
+@define-color theme_selected_fg_color #1a181e;
+/*
+base background color of insensitive widgets */
+@define-color insensitive_bg_color #221f26;
+/*
+text foreground color of insensitive widgets */
+@define-color insensitive_fg_color #7d718c;
+/*
+insensitive text widgets and the like base background color */
+@define-color insensitive_base_color #1a181e;
+/*
+widget text/foreground color on backdrop windows */
+@define-color theme_unfocused_fg_color #7b7484;
+/*
+text color for entries, views and content in general on backdrop windows */
+@define-color theme_unfocused_text_color #d8c4f1;
+/*
+widget base background color on backdrop windows */
+@define-color theme_unfocused_bg_color #1d1b20;
+/*
+text widgets and the like base background color on backdrop windows */
+@define-color theme_unfocused_base_color #161519;
+/*
+base background color of selections on backdrop windows */
+@define-color theme_unfocused_selected_bg_color #d8c4f1;
+/*
+text/foreground color of selections on backdrop windows */
+@define-color theme_unfocused_selected_fg_color #1a181e;
+/*
+insensitive color on backdrop windows*/
+@define-color unfocused_insensitive_color #433e49;
+/*
+widgets main borders color */
+@define-color borders #302b36;
+/*
+widgets main borders color on backdrop windows */
+@define-color unfocused_borders #2c2930;
+/*
+these are pretty self explicative */
+@define-color placeholder_text_color #796e87;
+@define-color warning_color #faa483;
+@define-color error_color #fb7c7c;
+@define-color success_color #6ee1b6;
+/*
+these colors are exported for the window manager and shouldn't be used in applications,
+read if you used those and something break with a version upgrade you're on your own... */
+@define-color wm_title shade(#d8c4f1, 1.8);
+@define-color wm_unfocused_title #7b7484;
+@define-color wm_highlight transparent;
+@define-color wm_borders_edge rgba(216, 196, 241, 0.07);
+@define-color wm_bg_a shade(#221f26, 1.2);
+@define-color wm_bg_b #221f26;
+@define-color wm_shadow alpha(black, 0.35);
+@define-color wm_border alpha(black, 0.18);
+@define-color wm_button_hover_color_a shade(#221f26, 1.3);
+@define-color wm_button_hover_color_b #221f26;
+@define-color wm_button_active_color_a shade(#221f26, 0.85);
+@define-color wm_button_active_color_b shade(#221f26, 0.89);
+@define-color wm_button_active_color_c shade(#221f26, 0.9);
+/* content view background such as thumbnails view in Photos or Boxes */
+@define-color content_view_bg #1a181e;
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #1a181e;

--- a/ZorinRed-Dark/gtk-3.0/gtk-dark.css
+++ b/ZorinRed-Dark/gtk-3.0/gtk-dark.css
@@ -1,0 +1,2308 @@
+/*************************** Check and Radio buttons * */
+@keyframes ripple_effect { to { background-size: 1000% 1000%; } }
+
+* { padding: 0; -GtkToolButton-icon-spacing: 4; -GtkTextView-error-underline-color: #fb7c7c; -GtkScrolledWindow-scrollbar-spacing: 0; -GtkToolItemGroup-expander-size: 11; -GtkWidget-text-handle-width: 20; -GtkWidget-text-handle-height: 24; -GtkDialog-button-spacing: 4; -GtkDialog-action-area-border: 0; outline-color: alpha(currentColor,0.3); outline-style: dashed; outline-offset: -3px; outline-width: 1px; -gtk-outline-radius: 8px; -gtk-secondary-caret-color: #fdb4b4; }
+
+/*************** Base States * */
+.background { color: #fdb4b4; background-color: #271b1b; }
+
+.background.csd { border-radius: 0 0 10px 10px; }
+
+.background.maximized, .background.solid-csd, .background.fullscreen, .background.tiled, .background.tiled-top, .background.tiled-right, .background.tiled-bottom, .background.tiled-left { border-radius: 0; }
+
+.background:backdrop { color: #8b6a6a; background-color: #211818; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* These wildcard seems unavoidable, need to investigate. Wildcards are bad and troublesome, use them with care, or better, just don't. Everytime a wildcard is used a kitten dies, painfully. */
+*:disabled { -gtk-icon-effect: dim; }
+
+.gtkstyle-fallback { color: #fdb4b4; background-color: #271b1b; }
+
+.gtkstyle-fallback:hover { color: #fdb4b4; background-color: #462f2f; }
+
+.gtkstyle-fallback:active { color: #fdb4b4; background-color: #090606; }
+
+.gtkstyle-fallback:disabled { color: #926767; background-color: #271b1b; }
+
+.gtkstyle-fallback:selected { color: #1e1515; background-color: #fdb4b4; }
+
+.view, iconview, .view text, iconview text, textview text { color: #fdb4b4; background-color: #1e1515; border-radius: 10px; }
+
+.view:disabled, iconview:disabled, .view text:disabled, iconview text:disabled, textview text:disabled { color: #926767; background-color: #271b1b; }
+
+.view:backdrop, iconview:backdrop, .view text:backdrop, iconview text:backdrop, textview text:backdrop { color: #8b6a6a; background-color: #1a1313; }
+
+.view:backdrop:disabled, iconview:backdrop:disabled, .view text:backdrop:disabled, iconview text:backdrop:disabled, textview text:backdrop:disabled { color: #4d3838; background-color: #211818; }
+
+.view:selected:focus, iconview:selected:focus, .view:selected, iconview:selected, .view text:selected:focus, iconview text:selected:focus, textview text:selected:focus, .view text:selected, iconview text:selected, textview text:selected { border-radius: 8px; }
+
+.view.sourceview, iconview.sourceview, .view.sourceview > *, iconview.sourceview > *, textview.sourceview, textview.sourceview > * { border-radius: 0; }
+
+textview border { background-color: #231818; }
+
+iconview { border-radius: 0 0 10px 10px; }
+
+iconview, iconview:hover, iconview:selected { border-radius: 8px; }
+
+.rubberband, rubberband, XfdesktopIconView.view .rubberband, .content-view rubberband, .content-view .rubberband, treeview.view rubberband, flowbox rubberband { border: 1px solid #fc8282; background-color: rgba(252, 130, 130, 0.2); border-radius: 0; }
+
+flowbox flowboxchild { padding: 3px; }
+
+flowbox flowboxchild:selected { outline-offset: -2px; }
+
+.content-view .tile { margin: 2px; background-color: transparent; border-radius: 0; padding: 0; }
+
+label { caret-color: currentColor; }
+
+label:disabled { color: #926767; }
+
+button label:disabled { color: inherit; }
+
+label:disabled:backdrop { color: #4d3838; }
+
+button label:disabled:backdrop { color: inherit; }
+
+label.error { color: #fb7c7c; }
+
+label.error:disabled { color: rgba(251, 124, 124, 0.5); }
+
+label.error:disabled:backdrop { color: rgba(251, 124, 124, 0.4); }
+
+.accent { color: #fdb4b4; }
+
+.dim-label, .titlebar:not(headerbar) .subtitle, headerbar .subtitle, label.separator { opacity: 0.55; text-shadow: none; }
+
+assistant .sidebar { background-color: #271b1b; border-top: 1px solid #372626; }
+
+assistant .sidebar:backdrop { background-color: #211818; border-color: #312424; }
+
+assistant.csd .sidebar { border-top-style: none; }
+
+assistant .sidebar label { padding: 6px 12px; }
+
+assistant .sidebar label.highlight { background-color: #523939; }
+
+.osd .scale-popup, .app-notification, .app-notification.frame, .osd { border: none; background-color: #1e1515; background-clip: padding-box; border-radius: 8px; box-shadow: inset 0 0 0 1px rgba(55, 38, 38, 0.75); }
+
+.osd .scale-popup:backdrop, .app-notification:backdrop, .osd:backdrop { background-color: #1a1313; box-shadow: inset 0 0 0 1px rgba(49, 36, 36, 0.75); }
+
+.osd .scale-popup:disabled, .app-notification:disabled, .osd:disabled { box-shadow: none; }
+
+/********************* Spinner Animation * */
+@keyframes spin { to { -gtk-icon-transform: rotate(1turn); } }
+
+spinner { background: none; opacity: 0; -gtk-icon-source: -gtk-icontheme("process-working-symbolic"); }
+
+spinner:backdrop { color: #8b6a6a; }
+
+spinner:checked { opacity: 1; animation: spin 1s linear infinite; }
+
+spinner:checked:disabled { opacity: 0.5; }
+
+/********************** General Typography * */
+.large-title { font-weight: 300; font-size: 24pt; }
+
+.title-1, .h1 { font-weight: 800; font-size: 20pt; }
+
+.title-2, .h2 { font-weight: 800; font-size: 15pt; }
+
+.title-3, .h3 { font-weight: 700; font-size: 15pt; }
+
+.title-4, .h4 { font-weight: 700; font-size: 13pt; }
+
+.heading { font-weight: 700; font-size: 11pt; }
+
+.body { font-weight: 400; font-size: 11pt; }
+
+.caption-heading { font-weight: 700; font-size: 9pt; }
+
+.caption { font-weight: 400; font-size: 9pt; }
+
+.category-label { color: rgba(253, 180, 180, 0.8); font-weight: 700; }
+
+/**************** Text Entries * */
+spinbutton:not(.vertical), entry { min-height: 32px; padding-left: 8px; padding-right: 8px; margin: 1px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); color: #fdb4b4; background-color: #1e1515; box-shadow: inset 0 0 0 1px #372626; }
+
+spinbutton:not(.vertical) image.left, entry image.left { margin-right: 6px; }
+
+spinbutton:not(.vertical) image.right, entry image.right { margin-left: 6px; }
+
+spinbutton.flat:not(.vertical), entry.flat:focus, entry.flat:backdrop, entry.flat:disabled, entry.flat { min-height: 0; padding: 2px; background-color: transparent; border-color: transparent; border-radius: 0; }
+
+spinbutton:focus:not(.vertical), entry:focus { color: #fdb4b4; background-color: #1e1515; box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2), inset 0 0 0 2px #fdb4b4; }
+
+spinbutton:disabled:not(.vertical), entry:disabled { color: #926767; background-color: transparent; box-shadow: none; }
+
+spinbutton:backdrop:not(.vertical), entry:backdrop { color: #8b6a6a; background-color: #1a1313; box-shadow: inset 0 0 0 1px #312424; border-color: #211818; transition: 150ms ease-out; }
+
+spinbutton:backdrop:disabled:not(.vertical), entry:backdrop:disabled { color: #4d3838; background-color: transparent; box-shadow: none; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; border-color: transparent; }
+
+spinbutton.error:focus:not(.vertical), entry.error:focus { color: #fb7c7c; background-color: #1e1515; box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2), inset 0 0 0 2px #fdb4b4; }
+
+spinbutton.error:not(.vertical) selection, entry.error selection { color: #1e1515; background-color: #fb7c7c; }
+
+spinbutton.warning:not(.vertical), entry.warning { color: #faa483; border-color: transparent; }
+
+spinbutton.warning:focus:not(.vertical), entry.warning:focus { color: #faa483; background-color: #1e1515; box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2), inset 0 0 0 2px #fdb4b4; }
+
+spinbutton.warning:not(.vertical) selection, entry.warning selection { color: #1e1515; background-color: #faa483; }
+
+spinbutton:not(.vertical) image, entry image { color: #d09494; }
+
+spinbutton:not(.vertical) image:hover, entry image:hover { color: #fdb4b4; }
+
+spinbutton:not(.vertical) image:active, entry image:active { color: #fdb4b4; }
+
+spinbutton:not(.vertical) image:backdrop, entry image:backdrop { color: #755858; }
+
+spinbutton:drop(active):not(.vertical), entry:drop(active):focus, entry:drop(active) { color: #4cd9a4; border-color: transparent; background-color: #2f4136; }
+
+spinbutton:not(.vertical) progress, entry progress { margin: 1px -6px; background-color: transparent; background-image: none; border-radius: 3px; border-width: 0 0 3px; border-color: #fdb4b4; border-style: solid; box-shadow: none; }
+
+spinbutton:not(.vertical) progress:backdrop, entry progress:backdrop { background-color: transparent; }
+
+spinbutton.error:not(.vertical), entry.error { color: #fb7c7c; }
+
+treeview entry:focus:dir(rtl), treeview entry:focus:dir(ltr) { background-color: #1e1515; transition-property: color, background; }
+
+treeview entry.flat, treeview entry { border: none; border-radius: 0; background-image: none; background-color: #1e1515; }
+
+.entry-tag { padding: 5px; margin-top: 4px; margin-bottom: 4px; border-style: none; color: #1e1515; background-color: #fdb4b4; }
+
+:dir(ltr) .entry-tag { margin-left: 8px; margin-right: -5px; }
+
+:dir(rtl) .entry-tag { margin-left: -5px; margin-right: 8px; }
+
+.entry-tag:hover { background-color: #fee5e5; }
+
+:backdrop .entry-tag { color: #1a1313; background-color: #fdb4b4; }
+
+.entry-tag.button { background-color: transparent; color: rgba(30, 21, 21, 0.7); }
+
+:not(:backdrop) .entry-tag.button:hover { border: 1px solid #fdb4b4; color: #1e1515; }
+
+:not(:backdrop) .entry-tag.button:active { background-color: #fdb4b4; color: #1e1515; }
+
+/*********** Buttons * */
+@keyframes needs_attention { from { background-image: -gtk-gradient(radial, center center, 0, center center, 0.01, to(#fdb4b4), to(transparent)); }
+  to { background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#fdb4b4), to(transparent)); } }
+
+button.titlebutton, notebook > header > tabs > arrow, button { min-height: 24px; min-width: 16px; margin: 1px; padding: 4px 9px; border: none; border-radius: 8px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #372626; background-image: none; }
+
+button.titlebutton, button.sidebar-button, notebook > header > tabs > arrow, notebook > header > tabs > arrow.flat, button.flat { background-color: transparent; background-image: none; background-image: none; transition: none; }
+
+button.titlebutton:hover, button.sidebar-button:hover, notebook > header > tabs > arrow:hover, button.flat:hover { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-duration: 500ms; }
+
+button.titlebutton:hover:active, button.sidebar-button:hover:active, notebook > header > tabs > arrow:hover:active, button.flat:hover:active { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header > tabs > arrow:hover, button:hover { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #473232; background-image: none; }
+
+notebook > header > tabs > arrow:active, button:active { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #523939; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #674949 10%, transparent 0%); background-size: 0% 0%; }
+
+notebook > header > tabs > arrow:checked, button:checked { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; background: image(#fdb4b4); box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); }
+
+notebook > header > tabs > arrow:checked:active, button:checked:active { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); }
+
+notebook > header > tabs > arrow:backdrop, button:backdrop.flat, button:backdrop { background-color: #291e1e; background-image: none; transition: 150ms ease-out; -gtk-icon-effect: none; }
+
+notebook > header > tabs > arrow:backdrop label, notebook > header > tabs > arrow:backdrop, button:backdrop.flat label, button:backdrop.flat, button:backdrop label, button:backdrop { color: #8b6a6a; }
+
+notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active, button:backdrop:active { background-color: #362828; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:active label, notebook > header > tabs > arrow:backdrop:active, button:backdrop.flat:active label, button:backdrop.flat:active, button:backdrop:active label, button:backdrop:active { color: #8b6a6a; }
+
+notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked, button:backdrop:checked { background-color: #a27878; background-image: none; box-shadow: none; }
+
+notebook > header > tabs > arrow:backdrop:checked label, notebook > header > tabs > arrow:backdrop:checked, button:backdrop.flat:checked label, button:backdrop.flat:checked, button:backdrop:checked label, button:backdrop:checked { color: #1a1313; }
+
+notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled, button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled label, notebook > header > tabs > arrow:backdrop:disabled, button:backdrop.flat:disabled label, button:backdrop.flat:disabled, button:backdrop:disabled label, button:backdrop:disabled { color: #4d3838; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active, button:backdrop:disabled:checked { background-color: #312323; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow:backdrop:disabled:active label, notebook > header > tabs > arrow:backdrop:disabled:active, notebook > header > tabs > arrow:backdrop:disabled:checked label, notebook > header > tabs > arrow:backdrop:disabled:checked, button:backdrop.flat:disabled:active label, button:backdrop.flat:disabled:active, button:backdrop.flat:disabled:checked label, button:backdrop.flat:disabled:checked, button:backdrop:disabled:active label, button:backdrop:disabled:active, button:backdrop:disabled:checked label, button:backdrop:disabled:checked { color: #4d3838; }
+
+button.titlebutton:backdrop, button.sidebar-button:backdrop, notebook > header > tabs > arrow:backdrop, button.titlebutton:disabled, button.sidebar-button:disabled, notebook > header > tabs > arrow:disabled, button.flat:backdrop, button.flat:disabled, button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+notebook > header > tabs > arrow:disabled, button:disabled { color: #926767; background-color: transparent; background-image: none; }
+
+notebook > header > tabs > arrow:disabled:active, notebook > header > tabs > arrow:disabled:checked, button:disabled:active, button:disabled:checked { color: #926767; background-color: #2d1f1f; box-shadow: none; background-image: none; }
+
+notebook > header > tabs > arrow.image-button, button.image-button { min-width: 24px; padding-left: 5px; padding-right: 5px; }
+
+notebook > header > tabs > arrow.flat image, notebook > header > tabs > arrow.image-button image, button.flat image, button.image-button image { -gtk-icon-transform: scale(1); transition: -gtk-icon-transform 150ms ease; }
+
+notebook > header > tabs > arrow.flat:active image, notebook > header > tabs > arrow.image-button:active image, button.flat:active image, button.image-button:active image { -gtk-icon-transform: scale(0.85); }
+
+notebook > header > tabs > arrow.text-button, button.text-button { padding-left: 16px; padding-right: 16px; }
+
+notebook > header > tabs > arrow.text-button.image-button, button.text-button.image-button { padding-left: 8px; padding-right: 8px; }
+
+notebook > header > tabs > arrow.text-button.image-button label, button.text-button.image-button label { padding-left: 8px; padding-right: 8px; }
+
+combobox:drop(active) button.combo, notebook > header > tabs > arrow:drop(active), button:drop(active) { color: #1e1515; border-color: transparent; background-color: #4cd9a4; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled), row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled) { color: #1e1515; border-color: transparent; }
+
+row:selected button.sidebar-button:not(:active):not(:checked):not(:hover):not(disabled):backdrop, row:selected button.flat:not(:active):not(:checked):not(:hover):not(disabled):backdrop { color: #1a1313; }
+
+button.osd { min-width: 26px; min-height: 32px; border-radius: 8px; border: none; }
+
+button.osd.image-button { min-width: 34px; }
+
+button.suggested-action { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; background: image(#fdb4b4); font-weight: 700; }
+
+button.suggested-action.flat { background-color: transparent; background-image: none; background-image: none; color: #fdb4b4; }
+
+button.suggested-action:hover { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background: image(#ffcbd0); background-color: #ffcbd0; }
+
+button.suggested-action:active, button.suggested-action:checked { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-image: none; background-color: #fc8282; box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); }
+
+button.suggested-action:backdrop, button.suggested-action.flat:backdrop { background-color: #fcb5b5; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop label, button.suggested-action:backdrop, button.suggested-action.flat:backdrop label, button.suggested-action.flat:backdrop { color: #1a1313; }
+
+button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked { background-color: #fa8484; background-image: none; box-shadow: none; }
+
+button.suggested-action:backdrop:active label, button.suggested-action:backdrop:active, button.suggested-action:backdrop:checked label, button.suggested-action:backdrop:checked, button.suggested-action.flat:backdrop:active label, button.suggested-action.flat:backdrop:active, button.suggested-action.flat:backdrop:checked label, button.suggested-action.flat:backdrop:checked { color: #1a1313; }
+
+button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.suggested-action:backdrop:disabled label, button.suggested-action:backdrop:disabled, button.suggested-action.flat:backdrop:disabled label, button.suggested-action.flat:backdrop:disabled { color: #4d3838; }
+
+button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked { background-color: #f1adad; box-shadow: none; background-image: none; }
+
+button.suggested-action:backdrop:disabled:active label, button.suggested-action:backdrop:disabled:active, button.suggested-action:backdrop:disabled:checked label, button.suggested-action:backdrop:disabled:checked, button.suggested-action.flat:backdrop:disabled:active label, button.suggested-action.flat:backdrop:disabled:active, button.suggested-action.flat:backdrop:disabled:checked label, button.suggested-action.flat:backdrop:disabled:checked { color: #4d3838; }
+
+button.suggested-action.flat:backdrop, button.suggested-action.flat:disabled, button.suggested-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(253, 180, 180, 0.8); }
+
+button.suggested-action:disabled { color: #926767; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.suggested-action:disabled:active, button.suggested-action:disabled:checked { color: #926767; background-color: #f7b0b0; box-shadow: none; background-image: none; }
+
+button.destructive-action { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fb7c7c; background: image(#fb7c7c); font-weight: 700; }
+
+button.destructive-action.flat { background-color: transparent; background-image: none; background-image: none; color: #fb7c7c; }
+
+button.destructive-action:hover { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background: image(#ff929b); background-color: #ff929b; }
+
+button.destructive-action:active, button.destructive-action:checked { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-image: none; background-color: #fa4a4a; box-shadow: 0 2px 4px rgba(251, 124, 124, 0.2); }
+
+button.destructive-action:backdrop, button.destructive-action.flat:backdrop { background-color: #f97e7e; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop label, button.destructive-action:backdrop, button.destructive-action.flat:backdrop label, button.destructive-action.flat:backdrop { color: #1a1313; }
+
+button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked { background-color: #f74d4d; background-image: none; box-shadow: none; }
+
+button.destructive-action:backdrop:active label, button.destructive-action:backdrop:active, button.destructive-action:backdrop:checked label, button.destructive-action:backdrop:checked, button.destructive-action.flat:backdrop:active label, button.destructive-action.flat:backdrop:active, button.destructive-action.flat:backdrop:checked label, button.destructive-action.flat:backdrop:checked { color: #1a1313; }
+
+button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; }
+
+button.destructive-action:backdrop:disabled label, button.destructive-action:backdrop:disabled, button.destructive-action.flat:backdrop:disabled label, button.destructive-action.flat:backdrop:disabled { color: #4d3838; }
+
+button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked { background-color: #ee7979; box-shadow: none; background-image: none; }
+
+button.destructive-action:backdrop:disabled:active label, button.destructive-action:backdrop:disabled:active, button.destructive-action:backdrop:disabled:checked label, button.destructive-action:backdrop:disabled:checked, button.destructive-action.flat:backdrop:disabled:active label, button.destructive-action.flat:backdrop:disabled:active, button.destructive-action.flat:backdrop:disabled:checked label, button.destructive-action.flat:backdrop:disabled:checked { color: #4d3838; }
+
+button.destructive-action.flat:backdrop, button.destructive-action.flat:disabled, button.destructive-action.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(251, 124, 124, 0.8); }
+
+button.destructive-action:disabled { color: #926767; background-color: transparent; background-image: none; box-shadow: none; }
+
+button.destructive-action:disabled:active, button.destructive-action:disabled:checked { color: #926767; background-color: #f67979; box-shadow: none; background-image: none; }
+
+.stack-switcher > button, stackswitcher > button { padding-top: 2px; padding-bottom: 2px; margin: 2px 1px; background-color: transparent; color: #d09494; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; outline-offset: -3px; }
+
+.stack-switcher > button:first-child:dir(ltr), stackswitcher > button:first-child:dir(ltr) { margin-left: 2px; }
+
+.stack-switcher > button:first-child:dir(rtl), stackswitcher > button:first-child:dir(rtl) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(ltr), stackswitcher > button:last-child:dir(ltr) { margin-right: 2px; }
+
+.stack-switcher > button:last-child:dir(rtl), stackswitcher > button:last-child:dir(rtl) { margin-left: 2px; }
+
+.stack-switcher > button:hover, stackswitcher > button:hover { color: #fdb4b4; background-color: rgba(253, 180, 180, 0.05); }
+
+.stack-switcher > button:checked, stackswitcher > button:checked { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-image: none; background-color: #473232; box-shadow: 0 2px 4px rgba(30, 21, 21, 0.075); }
+
+.stack-switcher > button:backdrop, stackswitcher > button:backdrop { color: #8b6a6a; }
+
+.stack-switcher > button:backdrop:hover, stackswitcher > button:backdrop:hover { background-color: transparent; }
+
+.stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked { background-image: none; background-color: #312424; box-shadow: 0 1px 2px rgba(26, 19, 19, 0.075); }
+
+.stack-switcher > button:backdrop:checked label, .stack-switcher > button:backdrop:checked, stackswitcher > button:backdrop:checked label, stackswitcher > button:backdrop:checked { color: #8b6a6a; }
+
+.stack-switcher > button > label, stackswitcher > button > label { padding-left: 6px; padding-right: 6px; }
+
+.stack-switcher > button > image, stackswitcher > button > image { padding-left: 6px; padding-right: 6px; padding-top: 3px; padding-bottom: 3px; }
+
+.stack-switcher > button.text-button, stackswitcher > button.text-button { padding-left: 10px; padding-right: 10px; }
+
+.stack-switcher > button.image-button, stackswitcher > button.image-button { padding-left: 2px; padding-right: 2px; }
+
+.stack-switcher > button.needs-attention:active > label, .stack-switcher > button.needs-attention:active > image, .stack-switcher > button.needs-attention:checked > label, .stack-switcher > button.needs-attention:checked > image, stackswitcher > button.needs-attention:active > label, stackswitcher > button.needs-attention:active > image, stackswitcher > button.needs-attention:checked > label, stackswitcher > button.needs-attention:checked > image { animation: none; background-image: none; }
+
+button.font separator, button.file separator { background-color: transparent; }
+
+button.font > box > box > label { font-weight: bold; }
+
+.primary-toolbar button { -gtk-icon-shadow: none; }
+
+button.circular { border-radius: 9999px; -gtk-outline-radius: 9999px; }
+
+button.circular label { padding: 0; }
+
+stacksidebar row.needs-attention > label, .stack-switcher > button.needs-attention > label, .stack-switcher > button.needs-attention > image, stackswitcher > button.needs-attention > label, stackswitcher > button.needs-attention > image { animation: needs_attention 150ms ease-in; background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#fdb4b4), to(transparent)), -gtk-gradient(radial, center center, 0, center center, 0.45, to(rgba(0, 0, 0, 0.896471)), to(transparent)); background-size: 6px 6px, 6px 6px; background-repeat: no-repeat; background-position: right 3px, right 2px; }
+
+stacksidebar row.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > label:backdrop, .stack-switcher > button.needs-attention > image:backdrop, stackswitcher > button.needs-attention > label:backdrop, stackswitcher > button.needs-attention > image:backdrop { background-size: 6px 6px, 0 0; }
+
+stacksidebar row.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), stackswitcher > button.needs-attention > label:dir(rtl), stackswitcher > button.needs-attention > image:dir(rtl) { background-position: left 3px, left 2px; }
+
+.inline-toolbar toolbutton > button { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #372626; background-image: none; }
+
+.inline-toolbar toolbutton > button:hover { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #473232; background-image: none; }
+
+.inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #523939; }
+
+.inline-toolbar toolbutton > button:disabled { color: #926767; background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:disabled:active, .inline-toolbar toolbutton > button:disabled:checked { color: #926767; background-color: #2d1f1f; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop { background-color: #291e1e; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop label, .inline-toolbar toolbutton > button:backdrop { color: #8b6a6a; }
+
+.inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked { background-color: #362828; background-image: none; box-shadow: none; }
+
+.inline-toolbar toolbutton > button:backdrop:active label, .inline-toolbar toolbutton > button:backdrop:active, .inline-toolbar toolbutton > button:backdrop:checked label, .inline-toolbar toolbutton > button:backdrop:checked { color: #8b6a6a; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled label, .inline-toolbar toolbutton > button:backdrop:disabled { color: #4d3838; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked { background-color: #312323; box-shadow: none; background-image: none; }
+
+.inline-toolbar toolbutton > button:backdrop:disabled:active label, .inline-toolbar toolbutton > button:backdrop:disabled:active, .inline-toolbar toolbutton > button:backdrop:disabled:checked label, .inline-toolbar toolbutton > button:backdrop:disabled:checked { color: #4d3838; }
+
+.linked:not(.vertical) > combobox > box > button.combo, filechooser .path-bar.linked > button, .linked:not(.vertical) > spinbutton:not(.vertical), .linked:not(.vertical) > entry, .inline-toolbar button, .linked > button, toolbar.inline-toolbar toolbutton > button.flat { border-right-style: none; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked:not(.vertical) > combobox:first-child > box > button.combo, combobox.linked button:nth-child(2):dir(rtl), filechooser .path-bar.linked > button:dir(rtl):last-child, filechooser .path-bar.linked > button:dir(ltr):first-child, .linked:not(.vertical) > spinbutton:first-child:not(.vertical), .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat { border-top-left-radius: 8px; border-bottom-left-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-bottom-left-radius: 8px; }
+
+.linked:not(.vertical) > combobox:last-child > box > button.combo, combobox.linked button:nth-child(2):dir(ltr), filechooser .path-bar.linked > button:dir(rtl):first-child, filechooser .path-bar.linked > button:dir(ltr):last-child, .linked:not(.vertical) > spinbutton:last-child:not(.vertical), .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat { border-right-style: solid; border-top-right-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-top-right-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked:not(.vertical) > combobox:only-child > box > button.combo, filechooser .path-bar.linked > button:only-child, .linked:not(.vertical) > spinbutton:only-child:not(.vertical), .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.linked.vertical > combobox > box > button.combo, .linked.vertical > spinbutton:not(.vertical), .linked.vertical > entry, .linked.vertical > button { border-style: solid solid none solid; border-radius: 0; -gtk-outline-radius: 0; }
+
+.linked.vertical > combobox:first-child > box > button.combo, .linked.vertical > spinbutton:first-child:not(.vertical), .linked.vertical > entry:first-child, .linked.vertical > button:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; -gtk-outline-top-left-radius: 8px; -gtk-outline-top-right-radius: 8px; }
+
+.linked.vertical > combobox:last-child > box > button.combo, .linked.vertical > spinbutton:last-child:not(.vertical), .linked.vertical > entry:last-child, .linked.vertical > button:last-child { border-bottom-style: solid; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; -gtk-outline-bottom-left-radius: 8px; -gtk-outline-bottom-right-radius: 8px; }
+
+.linked.vertical > combobox:only-child > box > button.combo, .linked.vertical > spinbutton:only-child:not(.vertical), .linked.vertical > entry:only-child, .linked.vertical > button:only-child { border-style: solid; border-radius: 8px; -gtk-outline-radius: 8px; }
+
+.scale-popup button:backdrop:hover, .scale-popup button:backdrop:disabled, .scale-popup button:backdrop, .scale-popup button:hover, calendar.button, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, button:link, button:visited, modelbutton.flat:backdrop, modelbutton.flat:backdrop:hover, modelbutton.flat, .menuitem.button.flat { background-color: transparent; background-image: none; border-color: transparent; text-shadow: none; -gtk-icon-shadow: none; }
+
+/* menu buttons */
+modelbutton.flat, .menuitem.button.flat { min-height: 26px; padding-left: 5px; padding-right: 5px; border-radius: 8px; outline-offset: -2px; }
+
+modelbutton.flat:hover, .menuitem.button.flat:hover { background-color: #372626; }
+
+modelbutton.flat arrow { background: none; }
+
+modelbutton.flat arrow:hover { background: none; }
+
+modelbutton.flat arrow.left { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+modelbutton.flat arrow.right { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+button.color { padding: 4px; box-shadow: none; }
+
+button.color colorswatch:only-child, button.color colorswatch:only-child overlay { border-radius: 0; }
+
+/********* Links * */
+button:link > label, button:visited > label, button:link, button:visited, *:link { color: #fee5e5; }
+
+button:link > label:visited, button:visited > label:visited, button:visited, *:link:visited { color: white; }
+
+*:selected button:link > label:visited, *:selected button:visited > label:visited, *:selected button:visited, *:selected *:link:visited { color: #787373; }
+
+button:link > label:hover, button:visited > label:hover, button:hover:link, button:hover:visited, *:link:hover { color: white; }
+
+*:selected button:link > label:hover, *:selected button:visited > label:hover, *:selected button:hover:link, *:selected button:hover:visited, *:selected *:link:hover { color: #352c2c; }
+
+button:link > label:active, button:visited > label:active, button:active:link, button:active:visited, *:link:active { color: #fee5e5; }
+
+*:selected button:link > label:active, *:selected button:visited > label:active, *:selected button:active:link, *:selected button:active:visited, *:selected *:link:active { color: #4b3f3f; }
+
+button:link > label:disabled, button:visited > label:disabled, button:disabled:link, button:disabled:visited, *:link:disabled, *:link:disabled:backdrop { color: rgba(242, 242, 242, 0.8); }
+
+button:link > label:backdrop, button:visited > label:backdrop, button:backdrop:link, button:backdrop:visited, *:link:backdrop:backdrop:hover, *:link:backdrop:backdrop:hover:selected, *:link:backdrop { color: rgba(254, 229, 229, 0.9); }
+
+.selection-mode .titlebar:not(headerbar) .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link, .selection-mode headerbar .subtitle:link, headerbar.selection-mode .subtitle:link, button:link > label:selected, button:visited > label:selected, button:selected:link, button:selected:visited, *:selected button:link > label, *:selected button:visited > label, *:selected button:link, *:selected button:visited, *:link:selected, *:selected *:link { color: #4b3f3f; }
+
+button:link, button:visited { text-shadow: none; }
+
+button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked { text-shadow: none; }
+
+button:link > label, button:visited > label { text-decoration-line: underline; }
+
+/****************** Stack Switcher * */
+stackswitcher, .stack-switcher { border-radius: 8px; background-color: #1e1515; }
+
+stackswitcher:backdrop, .stack-switcher:backdrop { background-color: #1a1313; }
+
+stackswitcher > button, .stack-switcher > button { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+/***************** GtkSpinButton * */
+spinbutton { font-feature-settings: "tnum"; }
+
+spinbutton:not(.vertical) { padding: 0; }
+
+spinbutton:not(.vertical) entry { min-width: 28px; margin: 0; background: none; background-color: transparent; border: none; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) entry:backdrop:disabled { background-color: transparent; }
+
+spinbutton:not(.vertical) button { min-height: 16px; margin: 0; padding-bottom: 0; padding-top: 0; color: #fdb4b4; background-image: none; border-style: none none none solid; border-color: transparent; border-radius: 0; box-shadow: none; }
+
+spinbutton:not(.vertical) button:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:disabled { color: #926767; background-color: #271b1b; }
+
+spinbutton:not(.vertical) button:backdrop:disabled { color: #4d3838; background-color: #211818; background-image: none; border-style: none none none solid; }
+
+spinbutton:not(.vertical) button:backdrop:disabled:dir(rtl) { border-style: none solid none none; }
+
+spinbutton:not(.vertical) button:dir(ltr):last-child { border-radius: 0 7px 7px 0; }
+
+spinbutton:not(.vertical) button:dir(rtl):first-child { border-radius: 7px 0 0 7px; }
+
+spinbutton.vertical:disabled { color: #926767; }
+
+spinbutton.vertical:backdrop:disabled { color: #4d3838; }
+
+spinbutton.vertical:drop(active) { border-color: transparent; box-shadow: none; }
+
+spinbutton.vertical entry { min-height: 32px; min-width: 32px; padding: 0; border-radius: 0; }
+
+spinbutton.vertical button { min-height: 32px; min-width: 32px; padding: 0; }
+
+spinbutton.vertical button.up { border-radius: 8px 8px 0 0; border-style: solid solid none solid; }
+
+spinbutton.vertical button.down { border-radius: 0 0 8px 8px; border-style: none solid solid solid; }
+
+treeview spinbutton:not(.vertical) { min-height: 0; border-style: none; border-radius: 0; }
+
+treeview spinbutton:not(.vertical) entry { min-height: 0; padding: 1px 2px; }
+
+/************** ComboBoxes * */
+combobox arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); min-height: 16px; min-width: 16px; }
+
+combobox:drop(active) { box-shadow: none; }
+
+/************ Toolbars * */
+searchbar > revealer > box, .location-bar, .inline-toolbar, toolbar { -GtkWidget-window-dragging: true; padding: 4px; background-color: #271b1b; }
+
+searchbar > revealer > box:backdrop, .location-bar:backdrop, .inline-toolbar:backdrop, toolbar:backdrop { background-color: #211818; }
+
+toolbar { padding: 4px 3px 3px 4px; }
+
+.osd toolbar { background-color: transparent; }
+
+toolbar.osd { padding: 13px; border: none; border-radius: 8px; }
+
+toolbar.osd.left, toolbar.osd.right, toolbar.osd.top, toolbar.osd.bottom { border-radius: 0; }
+
+toolbar.horizontal separator { margin: 0 7px 1px 6px; }
+
+toolbar.vertical separator { margin: 6px 1px 7px 0; }
+
+toolbar:not(.inline-toolbar):not(.osd) > *:not(.toggle):not(.popup) > * { margin-right: 1px; margin-bottom: 1px; }
+
+.inline-toolbar { padding: 3px; border-width: 0 1px 1px; border-radius: 0 0 8px 8px; }
+
+.background.csd .inline-toolbar { border-radius: 0 0 10px 10px; }
+
+searchbar > revealer > box, .location-bar { border-width: 0 0 1px; padding: 3px; }
+
+searchbar > revealer > box { margin: -6px; padding: 6px; }
+
+revealer box.view { background-color: transparent; }
+
+.inline-toolbar, searchbar > revealer > box, .location-bar { border-style: none; background-color: #271b1b; }
+
+.inline-toolbar:backdrop, searchbar > revealer > box:backdrop, .location-bar:backdrop { background-color: #211818; }
+
+/*************** Header bars * */
+@keyframes header_ripple_effect { from { background-image: radial-gradient(circle farthest-corner at center, #271b1b 0%, transparent 0%); }
+  to { background-image: radial-gradient(circle farthest-corner at center, #fdb4b4 100%, transparent 0%); } }
+
+.titlebar:not(headerbar), headerbar { padding: 0 6px; min-height: 46px; border: none; border-radius: 0; background-color: #271b1b; /* hide the close button separator */ }
+
+.titlebar:backdrop:not(headerbar), headerbar:backdrop { background-color: #211818; background-image: none; }
+
+.titlebar:not(headerbar) .title, headerbar .title { padding-left: 12px; padding-right: 12px; font-weight: bold; }
+
+.titlebar:not(headerbar) .subtitle, headerbar .subtitle { font-size: smaller; padding-left: 12px; padding-right: 12px; }
+
+.selection-mode .titlebar:not(headerbar), .selection-mode.titlebar:not(headerbar), .selection-mode headerbar, headerbar.selection-mode { color: #1e1515; border-color: transparent; background-color: #fdb4b4; transition: background-color 0.00001s 150ms, color 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); animation: header_ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+.selection-mode .titlebar:backdrop:not(headerbar), .selection-mode.titlebar:backdrop:not(headerbar), .selection-mode headerbar:backdrop, headerbar.selection-mode:backdrop { color: #1e1515; background-color: #fdb4b4; background-image: none; }
+
+.selection-mode .titlebar:backdrop:not(headerbar) label, .selection-mode.titlebar:backdrop:not(headerbar) label, .selection-mode headerbar:backdrop label, headerbar.selection-mode:backdrop label { text-shadow: none; color: #1e1515; }
+
+.selection-mode .titlebar:not(headerbar) button, .selection-mode.titlebar:not(headerbar) button, .selection-mode headerbar button, headerbar.selection-mode button { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #eca8a8; background-image: none; }
+
+.selection-mode button.titlebutton, .selection-mode .titlebar:not(headerbar) button.flat, .selection-mode.titlebar:not(headerbar) button.flat, .selection-mode headerbar button.flat, headerbar.selection-mode button.flat { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:hover, .selection-mode.titlebar:not(headerbar) button:hover, .selection-mode headerbar button:hover, headerbar.selection-mode button:hover { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #dc9c9c; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:active, .selection-mode .titlebar:not(headerbar) button:checked, .selection-mode.titlebar:not(headerbar) button:active, .selection-mode.titlebar:not(headerbar) button:checked, .selection-mode headerbar button:active, .selection-mode headerbar button:checked, .selection-mode headerbar button.toggle:checked, .selection-mode headerbar button.toggle:active, headerbar.selection-mode button:active, headerbar.selection-mode button:checked, headerbar.selection-mode button.toggle:checked, headerbar.selection-mode button.toggle:active { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #d09494; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop { background-color: #291e1e; background-image: none; -gtk-icon-effect: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop label, .selection-mode .titlebar:not(headerbar) button:backdrop, .selection-mode.titlebar:not(headerbar) button:backdrop label, .selection-mode.titlebar:not(headerbar) button:backdrop, .selection-mode headerbar button:backdrop.flat label, .selection-mode headerbar button:backdrop.flat, .selection-mode headerbar button:backdrop label, .selection-mode headerbar button:backdrop, headerbar.selection-mode button:backdrop.flat label, headerbar.selection-mode button:backdrop.flat, headerbar.selection-mode button:backdrop label, headerbar.selection-mode button:backdrop { color: #8b6a6a; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked { background-color: #362828; background-image: none; box-shadow: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:active, .selection-mode .titlebar:not(headerbar) button:backdrop:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:active, .selection-mode.titlebar:not(headerbar) button:backdrop:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:checked, .selection-mode headerbar button:backdrop.flat:active label, .selection-mode headerbar button:backdrop.flat:active, .selection-mode headerbar button:backdrop.flat:checked label, .selection-mode headerbar button:backdrop.flat:checked, .selection-mode headerbar button:backdrop:active label, .selection-mode headerbar button:backdrop:active, .selection-mode headerbar button:backdrop:checked label, .selection-mode headerbar button:backdrop:checked, headerbar.selection-mode button:backdrop.flat:active label, headerbar.selection-mode button:backdrop.flat:active, headerbar.selection-mode button:backdrop.flat:checked label, headerbar.selection-mode button:backdrop.flat:checked, headerbar.selection-mode button:backdrop:active label, headerbar.selection-mode button:backdrop:active, headerbar.selection-mode button:backdrop:checked label, headerbar.selection-mode button:backdrop:checked { color: #8b6a6a; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled, .selection-mode headerbar button:backdrop.flat:disabled label, .selection-mode headerbar button:backdrop.flat:disabled, .selection-mode headerbar button:backdrop:disabled label, .selection-mode headerbar button:backdrop:disabled, headerbar.selection-mode button:backdrop.flat:disabled label, headerbar.selection-mode button:backdrop.flat:disabled, headerbar.selection-mode button:backdrop:disabled label, headerbar.selection-mode button:backdrop:disabled { color: #4d3838; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked { background-color: #f1adad; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode .titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:active, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked label, .selection-mode.titlebar:not(headerbar) button:backdrop:disabled:checked, .selection-mode headerbar button:backdrop:disabled:active label, .selection-mode headerbar button:backdrop:disabled:active, .selection-mode headerbar button:backdrop:disabled:checked label, .selection-mode headerbar button:backdrop:disabled:checked, headerbar.selection-mode button:backdrop:disabled:active label, headerbar.selection-mode button:backdrop:disabled:active, headerbar.selection-mode button:backdrop:disabled:checked label, headerbar.selection-mode button:backdrop:disabled:checked { color: #4d3838; }
+
+.selection-mode button.titlebutton:backdrop, .selection-mode button.titlebutton:disabled, .selection-mode .titlebar:not(headerbar) button.flat:backdrop, .selection-mode .titlebar:not(headerbar) button.flat:disabled, .selection-mode.titlebar:not(headerbar) button.flat:backdrop, .selection-mode.titlebar:not(headerbar) button.flat:disabled, .selection-mode headerbar button.flat:backdrop, .selection-mode headerbar button.flat:disabled, .selection-mode headerbar button.flat:backdrop:disabled, headerbar.selection-mode button.flat:backdrop, headerbar.selection-mode button.flat:disabled, headerbar.selection-mode button.flat:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled, .selection-mode.titlebar:not(headerbar) button:disabled, .selection-mode headerbar button:disabled, headerbar.selection-mode button:disabled { color: #926767; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button:disabled:active, .selection-mode .titlebar:not(headerbar) button:disabled:checked, .selection-mode.titlebar:not(headerbar) button:disabled:active, .selection-mode.titlebar:not(headerbar) button:disabled:checked, .selection-mode headerbar button:disabled:active, .selection-mode headerbar button:disabled:checked, headerbar.selection-mode button:disabled:active, headerbar.selection-mode button:disabled:checked { color: #926767; background-color: #f7b0b0; box-shadow: none; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action, .selection-mode.titlebar:not(headerbar) button.suggested-action, .selection-mode headerbar button.suggested-action, headerbar.selection-mode button.suggested-action { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #372626; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:hover, .selection-mode.titlebar:not(headerbar) button.suggested-action:hover, .selection-mode headerbar button.suggested-action:hover, headerbar.selection-mode button.suggested-action:hover { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #473232; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:active, .selection-mode.titlebar:not(headerbar) button.suggested-action:active, .selection-mode headerbar button.suggested-action:active, headerbar.selection-mode button.suggested-action:active { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #523939; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:disabled, .selection-mode headerbar button.suggested-action:disabled, headerbar.selection-mode button.suggested-action:disabled { color: #926767; background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop { background-color: #291e1e; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop, .selection-mode headerbar button.suggested-action:backdrop label, .selection-mode headerbar button.suggested-action:backdrop, headerbar.selection-mode button.suggested-action:backdrop label, headerbar.selection-mode button.suggested-action:backdrop { color: #8b6a6a; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled { background-color: transparent; background-image: none; }
+
+.selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode .titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled label, .selection-mode.titlebar:not(headerbar) button.suggested-action:backdrop:disabled, .selection-mode headerbar button.suggested-action:backdrop:disabled label, .selection-mode headerbar button.suggested-action:backdrop:disabled, headerbar.selection-mode button.suggested-action:backdrop:disabled label, headerbar.selection-mode button.suggested-action:backdrop:disabled { color: #4d3838; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu, .selection-mode.titlebar:not(headerbar) .selection-menu, .selection-mode headerbar .selection-menu:backdrop, .selection-mode headerbar .selection-menu, headerbar.selection-mode .selection-menu:backdrop, headerbar.selection-mode .selection-menu { border-color: rgba(253, 180, 180, 0); background-color: rgba(253, 180, 180, 0); background-image: none; box-shadow: none; min-height: 20px; padding: 6px 10px; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu arrow, .selection-mode.titlebar:not(headerbar) .selection-menu arrow, .selection-mode headerbar .selection-menu:backdrop arrow, .selection-mode headerbar .selection-menu arrow, headerbar.selection-mode .selection-menu:backdrop arrow, headerbar.selection-mode .selection-menu arrow { -GtkArrow-arrow-scaling: 1; }
+
+.selection-mode .titlebar:not(headerbar) .selection-menu .arrow, .selection-mode.titlebar:not(headerbar) .selection-menu .arrow, .selection-mode headerbar .selection-menu:backdrop .arrow, .selection-mode headerbar .selection-menu .arrow, headerbar.selection-mode .selection-menu:backdrop .arrow, headerbar.selection-mode .selection-menu .arrow { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); color: rgba(30, 21, 21, 0.5); -gtk-icon-shadow: none; }
+
+.tiled .titlebar:not(headerbar), .tiled-top .titlebar:not(headerbar), .tiled-right .titlebar:not(headerbar), .tiled-bottom .titlebar:not(headerbar), .tiled-left .titlebar:not(headerbar), .maximized .titlebar:not(headerbar), .fullscreen .titlebar:not(headerbar), .tiled headerbar, .tiled-top headerbar, .tiled-right headerbar, .tiled-bottom headerbar, .tiled-left headerbar, .maximized headerbar, .fullscreen headerbar { border-radius: 0; }
+
+.default-decoration.titlebar:not(headerbar), headerbar.default-decoration { min-height: 28px; padding: 4px; border-color: transparent; }
+
+.default-decoration.titlebar:not(headerbar) button.titlebutton, headerbar.default-decoration button.titlebutton { min-height: 26px; min-width: 26px; margin: 0; padding: 0; }
+
+.titlebar:not(headerbar) separator.titlebutton, headerbar separator.titlebutton { opacity: 0; }
+
+.solid-csd .titlebar:dir(rtl):not(headerbar), .solid-csd .titlebar:dir(ltr):not(headerbar), .solid-csd headerbar:backdrop:dir(rtl), .solid-csd headerbar:backdrop:dir(ltr), .solid-csd headerbar:dir(rtl), .solid-csd headerbar:dir(ltr) { margin-left: -1px; margin-right: -1px; margin-top: -1px; border-radius: 0; box-shadow: none; }
+
+headerbar entry, headerbar spinbutton, headerbar separator:not(.sidebar), headerbar button { margin-top: 6px; margin-bottom: 6px; }
+
+headerbar switch { margin-top: 10px; margin-bottom: 10px; }
+
+headerbar stackswitcher button, headerbar .stack-switcher button { min-height: 24px; min-width: 80px; margin: 4px 2px; }
+
+headerbar stackswitcher button:first-child:dir(ltr), headerbar .stack-switcher button:first-child:dir(ltr) { margin-left: 4px; }
+
+headerbar stackswitcher button:first-child:dir(rtl), headerbar .stack-switcher button:first-child:dir(rtl) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(ltr), headerbar .stack-switcher button:last-child:dir(ltr) { margin-right: 4px; }
+
+headerbar stackswitcher button:last-child:dir(rtl), headerbar .stack-switcher button:last-child:dir(rtl) { margin-left: 4px; }
+
+#MozillaGtkWidget.background headerbar button.close:hover, headerbar button.close:hover { color: #fb7c7c; background-color: #472929; }
+
+#MozillaGtkWidget.background headerbar button.close:active, #MozillaGtkWidget.background headerbar button.close:checked, headerbar button.close:active, headerbar button.close:checked { color: #fb7c7c; background-color: #522e2e; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #522e2e 10%, transparent 0%); background-size: 0% 0%; }
+
+headerbar.titlebar headerbar:not(.titlebar) { background: none; box-shadow: none; }
+
+.background .titlebar:backdrop, .background .titlebar { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+.background.tiled .titlebar:backdrop, .background.tiled .titlebar, .background.tiled-top .titlebar:backdrop, .background.tiled-top .titlebar, .background.tiled-right .titlebar:backdrop, .background.tiled-right .titlebar, .background.tiled-bottom .titlebar:backdrop, .background.tiled-bottom .titlebar, .background.tiled-left .titlebar:backdrop, .background.tiled-left .titlebar, .background.maximized .titlebar:backdrop, .background.maximized .titlebar, .background.solid-csd .titlebar:backdrop, .background.solid-csd .titlebar { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window separator:first-child + headerbar:backdrop, window separator:first-child + headerbar, window headerbar:first-child:backdrop, window headerbar:first-child { border-top-left-radius: 10px; }
+
+window headerbar:last-child:backdrop, window headerbar:last-child { border-top-right-radius: 10px; }
+
+window stack headerbar:first-child:backdrop, window stack headerbar:first-child, window stack headerbar:last-child:backdrop, window stack headerbar:last-child { border-top-left-radius: 10px; border-top-right-radius: 10px; }
+
+window.tiled headerbar, window.tiled headerbar:first-child, window.tiled headerbar:last-child, window.tiled headerbar:only-child, window.tiled headerbar:backdrop, window.tiled headerbar:backdrop:first-child, window.tiled headerbar:backdrop:last-child, window.tiled headerbar:backdrop:only-child, window.tiled-top headerbar, window.tiled-top headerbar:first-child, window.tiled-top headerbar:last-child, window.tiled-top headerbar:only-child, window.tiled-top headerbar:backdrop, window.tiled-top headerbar:backdrop:first-child, window.tiled-top headerbar:backdrop:last-child, window.tiled-top headerbar:backdrop:only-child, window.tiled-right headerbar, window.tiled-right headerbar:first-child, window.tiled-right headerbar:last-child, window.tiled-right headerbar:only-child, window.tiled-right headerbar:backdrop, window.tiled-right headerbar:backdrop:first-child, window.tiled-right headerbar:backdrop:last-child, window.tiled-right headerbar:backdrop:only-child, window.tiled-bottom headerbar, window.tiled-bottom headerbar:first-child, window.tiled-bottom headerbar:last-child, window.tiled-bottom headerbar:only-child, window.tiled-bottom headerbar:backdrop, window.tiled-bottom headerbar:backdrop:first-child, window.tiled-bottom headerbar:backdrop:last-child, window.tiled-bottom headerbar:backdrop:only-child, window.tiled-left headerbar, window.tiled-left headerbar:first-child, window.tiled-left headerbar:last-child, window.tiled-left headerbar:only-child, window.tiled-left headerbar:backdrop, window.tiled-left headerbar:backdrop:first-child, window.tiled-left headerbar:backdrop:last-child, window.tiled-left headerbar:backdrop:only-child, window.maximized headerbar, window.maximized headerbar:first-child, window.maximized headerbar:last-child, window.maximized headerbar:only-child, window.maximized headerbar:backdrop, window.maximized headerbar:backdrop:first-child, window.maximized headerbar:backdrop:last-child, window.maximized headerbar:backdrop:only-child, window.fullscreen headerbar, window.fullscreen headerbar:first-child, window.fullscreen headerbar:last-child, window.fullscreen headerbar:only-child, window.fullscreen headerbar:backdrop, window.fullscreen headerbar:backdrop:first-child, window.fullscreen headerbar:backdrop:last-child, window.fullscreen headerbar:backdrop:only-child, window.solid-csd headerbar, window.solid-csd headerbar:first-child, window.solid-csd headerbar:last-child, window.solid-csd headerbar:only-child, window.solid-csd headerbar:backdrop, window.solid-csd headerbar:backdrop:first-child, window.solid-csd headerbar:backdrop:last-child, window.solid-csd headerbar:backdrop:only-child { border-top-left-radius: 0; border-top-right-radius: 0; }
+
+window.csd > .titlebar:not(headerbar) { padding: 0; background-color: transparent; background-image: none; border-style: none; border-color: transparent; box-shadow: none; }
+
+.titlebar:not(headerbar) separator { background-color: #271b1b; }
+
+.titlebar:not(headerbar) separator:backdrop { background-color: #211818; }
+
+window.devel headerbar.titlebar:not(.selection-mode) { background: #271b1b cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, linear-gradient(to right, transparent 65%, rgba(253, 180, 180, 0.15)); }
+
+window.devel headerbar.titlebar:not(.selection-mode):backdrop { background: #271b1b cross-fade(10% -gtk-icontheme("system-run-symbolic"), image(transparent)) 90% 0/256px 256px no-repeat, image(#271b1b); /* background-color would flash */ }
+
+/************ Pathbars * */
+.path-bar button.text-button, .path-bar button.image-button, .path-bar button { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.text-button.image-button label { padding-left: 0; padding-right: 0; }
+
+.path-bar button.text-button.image-button label:last-child, .path-bar button label:last-child { padding-right: 8px; }
+
+.path-bar button.text-button.image-button label:first-child, .path-bar button label:first-child { padding-left: 8px; }
+
+.path-bar button image { padding-left: 4px; padding-right: 4px; }
+
+.path-bar button.slider-button { padding-left: 0; padding-right: 0; }
+
+/************** Tree Views * */
+treeview.view { border-left-color: rgba(253, 180, 180, 0.15); border-top-color: #271b1b; border-radius: 0px; }
+
+* { -GtkTreeView-horizontal-separator: 4; -GtkTreeView-grid-line-width: 1; -GtkTreeView-grid-line-pattern: ''; -GtkTreeView-tree-line-width: 1; -GtkTreeView-tree-line-pattern: ''; -GtkTreeView-expander-size: 16; }
+
+treeview.view:selected:focus, treeview.view:selected { border-radius: 0; }
+
+treeview.view:selected:backdrop, treeview.view:selected { border-left-color: #604747; border-top-color: rgba(139, 106, 106, 0.1); }
+
+treeview.view:disabled { color: #926767; }
+
+treeview.view:disabled:selected { color: #a47474; }
+
+treeview.view:disabled:selected:backdrop { color: #795a5a; }
+
+treeview.view:disabled:backdrop { color: #4d3838; }
+
+treeview.view.separator { min-height: 2px; color: #271b1b; }
+
+treeview.view.separator:backdrop { color: #211818; }
+
+treeview.view:backdrop { border-left-color: #564141; border-top: #211818; }
+
+treeview.view:drop(active) { border-style: solid none; border-width: 1px; border-color: #eaa6a6; }
+
+treeview.view:drop(active).after { border-top-style: none; }
+
+treeview.view:drop(active).before { border-bottom-style: none; }
+
+treeview.view.expander { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); color: #ba8484; }
+
+treeview.view.expander:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+treeview.view.expander:hover { color: #fdb4b4; }
+
+treeview.view.expander:selected { color: #614545; }
+
+treeview.view.expander:selected:hover { color: #1e1515; }
+
+treeview.view.expander:selected:backdrop { color: #433131; }
+
+treeview.view.expander:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+treeview.view.expander:backdrop { color: #695050; }
+
+treeview.view.progressbar { color: #1e1515; background-color: #fdb4b4; background: image(#fdb4b4); box-shadow: none; border-radius: 8px; }
+
+treeview.view.progressbar:backdrop { color: #1a1313; background-color: #a27878; background-image: none; }
+
+treeview.view.progressbar:selected:focus, treeview.view.progressbar:selected { border-radius: 8px; color: #fdb4b4; background-color: #1e1515; background-image: none; }
+
+treeview.view.progressbar:selected:backdrop { color: #a27878; background-color: #1a1313; }
+
+treeview.view.trough { background-color: rgba(253, 180, 180, 0.1); border-radius: 8px; }
+
+treeview.view.trough:backdrop { background-color: rgba(139, 106, 106, 0.1); }
+
+treeview.view.trough:selected { border-radius: 8px; }
+
+treeview.view.trough:selected:focus, treeview.view.trough:selected { background-color: rgba(30, 21, 21, 0.3); }
+
+treeview.view.trough:selected:backdrop { background-color: rgba(30, 21, 21, 0.3); }
+
+treeview.view header button { color: #8d6464; background-color: #1e1515; font-weight: bold; text-shadow: none; box-shadow: none; margin: 0 1px 1px 0; }
+
+treeview.view header button:last-child { margin-right: 0; }
+
+treeview.view header button:hover { color: #c58c8c; box-shadow: none; transition: none; }
+
+treeview.view header button:active { color: #fdb4b4; transition: none; }
+
+treeview.view button.dnd:active, treeview.view button.dnd:selected, treeview.view button.dnd:hover, treeview.view button.dnd, treeview.view header.button.dnd:active, treeview.view header.button.dnd:selected, treeview.view header.button.dnd:hover, treeview.view header.button.dnd { padding: 0 6px; color: #1e1515; background-image: none; background-color: #fdb4b4; border-style: none; border-radius: 0; box-shadow: inset 0 0 0 1px #1e1515; text-shadow: none; transition: none; }
+
+treeview.view acceleditor > label { background-color: #fdb4b4; }
+
+treeview.view header button, treeview.view header button:hover, treeview.view header button:active { padding: 0 6px; background-image: none; border-style: none solid solid none; border-color: #271b1b; border-radius: 0; text-shadow: none; }
+
+treeview.view header button:disabled { border-color: #271b1b; background-image: none; }
+
+treeview.view header button:backdrop { color: #564141; border-color: #211818; border-style: none solid solid none; background-image: none; background-color: #1a1313; }
+
+treeview.view header button:backdrop:disabled { border-color: #211818; background-image: none; }
+
+treeview.view header button:last-child { border-right-style: none; }
+
+/********* Menus * */
+menubar, .menubar { -GtkWidget-window-dragging: true; padding: 0px; }
+
+menubar:backdrop, .menubar:backdrop { background-color: #211818; }
+
+menubar > menuitem, .menubar > menuitem { min-height: 16px; padding: 4px 8px; }
+
+menubar > menuitem menu:dir(rtl), menubar > menuitem menu:dir(ltr), .menubar > menuitem menu:dir(rtl), .menubar > menuitem menu:dir(ltr) { border-radius: 0; padding: 0; }
+
+menubar > menuitem:hover, .menubar > menuitem:hover { box-shadow: inset 0 -3px #fdb4b4; color: #fee5e5; }
+
+menubar > menuitem:disabled, .menubar > menuitem:disabled { color: #926767; box-shadow: none; }
+
+menubar .csd.popup decoration, .menubar .csd.popup decoration { border-radius: 0; }
+
+.background.popup { background-color: transparent; }
+
+menu, .menu, .context-menu { margin: 8px; padding: 8px 0px; background-color: #1e1515; border: 1px solid rgba(55, 38, 38, 0.75); }
+
+.csd menu, .csd .menu, .csd .context-menu { border: none; border-radius: 8px; }
+
+menu:backdrop, .menu:backdrop, .context-menu:backdrop { background-color: #1a1313; border-color: rgba(49, 36, 36, 0.75); }
+
+menu menuitem, .menu menuitem, .context-menu menuitem { min-height: 16px; min-width: 40px; padding: 4px 6px; text-shadow: none; }
+
+menu menuitem:hover, .menu menuitem:hover, .context-menu menuitem:hover { color: #1e1515; background-color: #fdb4b4; background: image(#fdb4b4); }
+
+menu menuitem:disabled, .menu menuitem:disabled, .context-menu menuitem:disabled { color: #926767; }
+
+menu menuitem:disabled:backdrop, .menu menuitem:disabled:backdrop, .context-menu menuitem:disabled:backdrop { color: #4d3838; }
+
+menu menuitem:backdrop, menu menuitem:backdrop:hover, .menu menuitem:backdrop, .menu menuitem:backdrop:hover, .context-menu menuitem:backdrop, .context-menu menuitem:backdrop:hover { color: #8b6a6a; background-color: transparent; }
+
+menu menuitem arrow, .menu menuitem arrow, .context-menu menuitem arrow { min-height: 16px; min-width: 16px; }
+
+menu menuitem arrow:dir(ltr), .menu menuitem arrow:dir(ltr), .context-menu menuitem arrow:dir(ltr) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); margin-left: 10px; }
+
+menu menuitem arrow:dir(rtl), .menu menuitem arrow:dir(rtl), .context-menu menuitem arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); margin-right: 10px; }
+
+menu menuitem label:dir(rtl), menu menuitem label:dir(ltr), .menu menuitem label:dir(rtl), .menu menuitem label:dir(ltr), .context-menu menuitem label:dir(rtl), .context-menu menuitem label:dir(ltr) { color: inherit; }
+
+menu separator, .menu separator, .context-menu separator { margin: 3px 16px; }
+
+menu > arrow, .menu > arrow, .context-menu > arrow { background-color: transparent; background-image: none; background-image: none; min-height: 16px; min-width: 16px; padding: 4px; background-color: #1e1515; border-radius: 0; }
+
+menu > arrow.top, .menu > arrow.top, .context-menu > arrow.top { margin-top: -8px; border-bottom: 1px solid #342525; border-top-right-radius: 8px; border-top-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+menu > arrow.bottom, .menu > arrow.bottom, .context-menu > arrow.bottom { margin-top: 16px; margin-bottom: -24px; border-top: 1px solid #342525; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+menu > arrow:hover, .menu > arrow:hover, .context-menu > arrow:hover { background-color: #3f2d2d; }
+
+menu > arrow:backdrop, .menu > arrow:backdrop, .context-menu > arrow:backdrop { background-color: #1a1313; }
+
+menu > arrow:disabled, .menu > arrow:disabled, .context-menu > arrow:disabled { color: transparent; background-color: transparent; border-color: transparent; }
+
+menuitem accelerator { color: alpha(currentColor,0.55); }
+
+menuitem check, menuitem radio { min-height: 16px; min-width: 16px; }
+
+menuitem check:dir(ltr), menuitem radio:dir(ltr) { margin-right: 7px; }
+
+menuitem check:dir(rtl), menuitem radio:dir(rtl) { margin-left: 7px; }
+
+/*************** Popovers   * */
+popover.background { padding: 2px; background-color: #1e1515; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.csd popover.background, popover.background { border: 1px solid rgba(55, 38, 38, 0.75); border-radius: 10px; }
+
+.csd popover.background { background-clip: padding-box; }
+
+popover.background:backdrop { background-color: #1a1313; box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); border-color: rgba(49, 36, 36, 0.75); }
+
+popover.background > list, popover.background > .view, popover.background > iconview, popover.background > toolbar { border-style: none; background-color: transparent; }
+
+popover.background separator { margin: 3px; }
+
+popover.background list separator { margin: 0px; }
+
+/************* Notebooks * */
+notebook > header { padding: 2px; border-style: none; background-color: #1e1515; }
+
+notebook > header:backdrop { background-color: #1a1313; }
+
+notebook > header.top { border-radius: 8px 8px 0 0; }
+
+notebook > header.bottom { border-radius: 0 0 8px 8px; }
+
+notebook > header.left { border-radius: 8px 0 0 8px; }
+
+notebook > header.right { border-radius: 0 8px 8px 0; }
+
+notebook > header > button { padding: 2px 9px; margin: 2px; }
+
+notebook > header.left > tabs > arrow, notebook > header.right > tabs > arrow { margin-top: -5px; margin-bottom: -5px; padding-top: 4px; padding-bottom: 4px; }
+
+notebook > header.left > tabs > arrow.down, notebook > header.right > tabs > arrow.down { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+notebook > header.left > tabs > arrow.up, notebook > header.right > tabs > arrow.up { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+notebook > header > tabs > arrow { transition: none; min-height: 16px; min-width: 16px; }
+
+notebook > header > tabs > arrow:hover:not(:active):not(:backdrop) { background-clip: padding-box; background-image: none; border-color: transparent; box-shadow: none; transition: none; }
+
+notebook > header > tabs > arrow:disabled { color: #926767; background-color: transparent; background-image: none; }
+
+notebook > header tab { min-height: 24px; min-width: 30px; padding: 2px 9px; margin: 2px; outline-offset: -3px; border-radius: 8px; color: #d09494; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+notebook > header tab:hover { color: #fdb4b4; background-color: rgba(253, 180, 180, 0.05); }
+
+notebook > header tab:backdrop { color: #8b6a6a; }
+
+notebook > header tab:backdrop.reorderable-page { background-color: transparent; }
+
+notebook > header tab:checked { color: #fdb4b4; background-color: #473232; box-shadow: 0 2px 4px rgba(30, 21, 21, 0.075); }
+
+notebook > header tab:backdrop:checked { color: #8b6a6a; background-color: #312424; box-shadow: 0 1px 2px rgba(26, 19, 19, 0.075); }
+
+notebook > header tab:backdrop:checked.reorderable-page { background-color: #312424; }
+
+notebook > header tab button.flat { border-radius: 999px; padding: 0; margin-top: 2px; margin-bottom: 2px; min-width: 20px; min-height: 20px; }
+
+notebook > header tab button.flat:hover { color: currentColor; }
+
+notebook > header tab button.flat, notebook > header tab button.flat:backdrop { color: alpha(currentColor,0.3); }
+
+notebook > header tab button.flat:last-child { margin-left: 4px; margin-right: -4px; }
+
+notebook > header tab button.flat:first-child { margin-left: -4px; margin-right: 4px; }
+
+notebook > stack:not(:only-child) { background-color: transparent; }
+
+notebook > stack:not(:only-child):backdrop { background-color: transparent; }
+
+/************** Scrollbars * */
+scrollbar { background-color: transparent; transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border-radius: 8px; }
+
+* { -GtkScrollbar-has-backward-stepper: false; -GtkScrollbar-has-forward-stepper: false; }
+
+scrollbar:backdrop { border-color: #312424; transition: 150ms ease-out; }
+
+scrollbar slider { min-width: 6px; min-height: 6px; margin: -1px; border: 4px solid transparent; border-radius: 8px; background-clip: padding-box; background-color: #a87777; }
+
+scrollbar slider:hover { background-color: #d29595; }
+
+scrollbar slider:hover:active { background-color: #fdb4b4; }
+
+scrollbar slider:backdrop { background-color: #6b5151; }
+
+scrollbar slider:disabled { background-color: transparent; }
+
+scrollbar.fine-tune slider { min-width: 4px; min-height: 4px; }
+
+scrollbar.fine-tune.horizontal slider { border-width: 5px 4px; }
+
+scrollbar.fine-tune.vertical slider { border-width: 4px 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) { border-color: transparent; opacity: 0.4; background-color: transparent; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider { margin: 0; min-width: 3px; min-height: 3px; background-color: #fdb4b4; border: 1px solid black; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering) button { min-width: 5px; min-height: 5px; background-color: #fdb4b4; background-clip: padding-box; border-radius: 100%; border: 1px solid black; -gtk-icon-source: none; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider { margin: 0 2px; min-width: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal button { margin: 1px 2px; min-width: 5px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider { margin: 2px 0; min-height: 40px; }
+
+scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical button { margin: 2px 1px; min-height: 5px; }
+
+scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering { opacity: 0.8; }
+
+scrollbar.horizontal slider { min-width: 40px; }
+
+scrollbar.vertical slider { min-height: 40px; }
+
+scrollbar button { padding: 0; min-width: 12px; min-height: 12px; border-style: none; border-radius: 0; transition-property: min-height, min-width, color; background-color: transparent; background-image: none; background-image: none; color: #a87777; }
+
+scrollbar button:hover { background-color: transparent; background-image: none; background-image: none; color: #d29595; }
+
+scrollbar button:active, scrollbar button:checked { background-color: transparent; background-image: none; background-image: none; color: #fdb4b4; }
+
+scrollbar button:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(168, 119, 119, 0.2); }
+
+scrollbar button:backdrop { background-color: transparent; background-image: none; background-image: none; color: #6b5151; }
+
+scrollbar button:backdrop:disabled { background-color: transparent; background-image: none; background-image: none; color: rgba(107, 81, 81, 0.2); }
+
+scrollbar.vertical button.down { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+scrollbar.vertical button.up { -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+
+scrollbar.horizontal button.down { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+scrollbar.horizontal button.up { -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+
+/********** Switch * */
+switch { font-size: 0; outline-offset: -4px; min-width: 36px; min-height: 18px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); border: none; padding: 2px; border-radius: 999px; background-color: #523939; background-image: none; color: transparent; }
+
+switch:checked { background-color: #fdb4b4; background: image(#fdb4b4); }
+
+switch:disabled { background-color: #372626; background-image: none; }
+
+switch:disabled:checked { background-color: #725151; background-image: none; }
+
+switch:backdrop { background-color: #473434; background-image: none; transition: 150ms ease-out; }
+
+switch:backdrop:checked { background-color: #a27878; background-image: none; }
+
+switch:backdrop:disabled { background-color: #312424; background-image: none; }
+
+switch:backdrop:disabled:checked { background-color: #4c3939; background-image: none; }
+
+switch slider { margin: 2px; min-width: 18px; min-height: 18px; border: none; border-radius: 999px; -gtk-outline-radius: 999px; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-color: #1e1515; box-shadow: 0 2px 4px rgba(30, 21, 21, 0.075); }
+
+switch:disabled slider { background-color: #271b1b; box-shadow: none; }
+
+switch:backdrop slider { transition: 150ms ease-out; background-color: #211818; box-shadow: 0 2px 4px rgba(26, 19, 19, 0.075); }
+
+switch:checked slider { background-color: #1e1515; box-shadow: none; }
+
+switch:backdrop:checked slider { background-color: #1a1313; }
+
+row:selected switch { box-shadow: none; box-shadow: inset 0 0 0 1px #1e1515; }
+
+/************************* Check and Radio items * */
+.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view:not(list) check { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view:not(list) check:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view:not(list) check:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view:not(list) check:backdrop { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view:not(list) check:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view:not(list) check:checked:hover { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view:not(list) check:checked:active { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view:not(list) check:backdrop:checked { margin: 4px; min-width: 32px; min-height: 32px; border-radius: 8px; transition: 150ms; padding: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+
+checkbutton.text-button, radiobutton.text-button { padding: 2px 0; outline-offset: 0; }
+
+checkbutton.text-button label:not(:only-child):first-child, radiobutton.text-button label:not(:only-child):first-child { margin-left: 4px; }
+
+checkbutton.text-button label:not(:only-child):last-child, radiobutton.text-button label:not(:only-child):last-child { margin-right: 4px; }
+
+check, radio { margin: 0 4px; min-height: 14px; min-width: 14px; padding: 1px; border: none; -gtk-icon-source: none; }
+
+check:only-child, radio:only-child { margin: 0; }
+
+popover check.left:dir(rtl), popover radio.left:dir(rtl) { margin-left: 0; margin-right: 12px; }
+
+popover check.right:dir(ltr), popover radio.right:dir(ltr) { margin-left: 12px; margin-right: 0; }
+
+check, radio { background-clip: padding-box; background: image(#1e1515); box-shadow: inset 0 0 0 1px #523939; color: #fdb4b4; }
+
+check:hover, radio:hover { background: image(#291d1d); }
+
+check:active, radio:active { background: image(#342525); }
+
+check:disabled, radio:disabled { box-shadow: none; background-image: none; background-color: #231818; color: rgba(253, 180, 180, 0.7); }
+
+check:backdrop, radio:backdrop { background-image: none; background-color: #1e1717; box-shadow: inset 0 0 0 1px #503b3b; color: #fdb4b4; }
+
+check:backdrop:disabled, radio:backdrop:disabled { box-shadow: none; background-image: none; background-color: #221919; color: rgba(253, 180, 180, 0.7); }
+
+check:checked, radio:checked { background-clip: border-box; background: image(#fdb4b4); box-shadow: none; color: #1e1515; }
+
+check:checked:hover, radio:checked:hover { background: image(#fdb4b4); }
+
+check:checked:active, radio:checked:active { background: image(#fdb4b4); }
+
+check:checked:disabled, radio:checked:disabled { box-shadow: none; background-image: none; background-color: #926767; color: rgba(30, 21, 21, 0.7); }
+
+check:checked:backdrop, radio:checked:backdrop { background-image: none; background-color: #b88888; box-shadow: none; color: #1e1515; }
+
+check:checked:backdrop:disabled, radio:checked:backdrop:disabled { box-shadow: none; background-image: none; background-color: #8e6b6b; color: rgba(30, 21, 21, 0.7); }
+
+check:indeterminate, radio:indeterminate { background-clip: border-box; background: image(#fdb4b4); box-shadow: none; color: #1e1515; }
+
+check:indeterminate:hover, radio:indeterminate:hover { background: image(#fdb4b4); }
+
+check:indeterminate:active, radio:indeterminate:active { background: image(#fdb4b4); }
+
+check:indeterminate:disabled, radio:indeterminate:disabled { box-shadow: none; background-image: none; background-color: #926767; color: rgba(30, 21, 21, 0.7); }
+
+check:indeterminate:backdrop, radio:indeterminate:backdrop { background-image: none; background-color: #b88888; box-shadow: none; color: #1e1515; }
+
+check:indeterminate:backdrop:disabled, radio:indeterminate:backdrop:disabled { box-shadow: none; background-image: none; background-color: #8e6b6b; color: rgba(30, 21, 21, 0.7); }
+
+check:backdrop, radio:backdrop { transition: 150ms ease-out; }
+
+menu menuitem check, menu menuitem radio { margin: 0; }
+
+menu menuitem check, menu menuitem check:hover, menu menuitem check:disabled, menu menuitem check:checked, menu menuitem check:checked:hover, menu menuitem check:checked:disabled, menu menuitem check:indeterminate, menu menuitem check:indeterminate:hover, menu menuitem check:indeterminate:disabled, menu menuitem radio, menu menuitem radio:hover, menu menuitem radio:disabled, menu menuitem radio:checked, menu menuitem radio:checked:hover, menu menuitem radio:checked:disabled, menu menuitem radio:indeterminate, menu menuitem radio:indeterminate:hover, menu menuitem radio:indeterminate:disabled { min-height: 14px; min-width: 14px; background-image: none; background-color: transparent; box-shadow: none; -gtk-icon-shadow: none; color: inherit; border: 1px solid currentColor; padding: 0; }
+
+check { border-radius: 4px; }
+
+check:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/check-symbolic.svg")), -gtk-recolor(url("assets/check-symbolic.symbolic.png"))); }
+
+check:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+treeview.view radio:selected:focus, treeview.view radio:selected, radio { border-radius: 100%; }
+
+treeview.view radio:checked:selected, radio:checked { -gtk-icon-source: image(-gtk-recolor(url("assets/bullet-symbolic.svg")), -gtk-recolor(url("assets/bullet-symbolic.symbolic.png"))); }
+
+treeview.view radio:indeterminate:selected, radio:indeterminate { -gtk-icon-source: image(-gtk-recolor(url("assets/dash-symbolic.svg")), -gtk-recolor(url("assets/dash-symbolic.symbolic.png"))); }
+
+radio:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: scale(0); }
+
+check:not(:indeterminate):not(:checked):active:not(:backdrop) { -gtk-icon-transform: translate(6px, -3px) rotate(-45deg) scaleY(0.2) rotate(45deg) scaleX(0); }
+
+radio:active, check:active { -gtk-icon-transform: scale(0, 1); }
+
+radio:checked:not(:backdrop), radio:indeterminate:not(:backdrop), check:checked:not(:backdrop), check:indeterminate:not(:backdrop) { -gtk-icon-transform: unset; transition: 400ms; }
+
+menu menuitem radio:checked:not(:backdrop), menu menuitem radio:indeterminate:not(:backdrop), menu menuitem check:checked:not(:backdrop), menu menuitem check:indeterminate:not(:backdrop) { transition: none; }
+
+treeview.view check:selected:focus, treeview.view check:selected, treeview.view radio:selected:focus, treeview.view radio:selected { color: #1e1515; border: 1px solid #eaa6a6; }
+
+treeview.view check:selected:focus:backdrop, treeview.view check:selected:backdrop, treeview.view radio:selected:focus:backdrop, treeview.view radio:selected:backdrop { border-color: #c08b8b; }
+
+/************ GtkScale * */
+levelbar block.empty, progressbar trough, scale fill, scale trough { border: none; border-radius: 8px; background-color: #372626; }
+
+levelbar block.empty:disabled, progressbar trough:disabled, scale fill:disabled, scale trough:disabled { background-color: #372626; }
+
+levelbar block.empty:backdrop, progressbar trough:backdrop, scale fill:backdrop, scale trough:backdrop { background-color: #312424; transition: 150ms ease-out; }
+
+levelbar block.empty:backdrop:disabled, progressbar trough:backdrop:disabled, scale fill:backdrop:disabled, scale trough:backdrop:disabled { background-color: #312424; }
+
+row:selected levelbar block.empty, levelbar row:selected block.empty, row:selected progressbar trough, progressbar row:selected trough, row:selected scale fill, scale row:selected fill, row:selected scale trough, scale row:selected trough { border: 1px solid #1e1515; }
+
+progressbar progress, scale highlight { border: none; border-radius: 8px; background-color: #fdb4b4; background: image(#fdb4b4); }
+
+scale.vertical progressbar progress, progressbar scale.vertical progress, scale.vertical highlight, progressbar.vertical progress, progressbar.vertical scale highlight, scale progressbar.vertical highlight { background: image(#fdb4b4); }
+
+progressbar progress:disabled, scale highlight:disabled { background-image: none; background-color: #523939; }
+
+progressbar progress:backdrop, scale highlight:backdrop { background-image: none; background-color: #a27878; }
+
+progressbar progress:backdrop:disabled, scale highlight:backdrop:disabled { background-image: none; background-color: #473434; }
+
+row:selected progressbar progress, progressbar row:selected progress, row:selected scale highlight, scale row:selected highlight { border: 1px solid #1e1515; }
+
+scale { min-height: 10px; min-width: 10px; padding: 12px; }
+
+scale slider { min-height: 16px; min-width: 16px; margin: -8px; }
+
+scale.fine-tune.horizontal { padding-top: 9px; padding-bottom: 9px; min-height: 16px; }
+
+scale.fine-tune.vertical { padding-left: 9px; padding-right: 9px; min-width: 16px; }
+
+scale.fine-tune slider { margin: -6px; }
+
+scale.fine-tune fill, scale.fine-tune highlight, scale.fine-tune trough { border-radius: 8px; -gtk-outline-radius: 8px; }
+
+scale trough { outline-offset: 2px; -gtk-outline-radius: 8px; }
+
+scale fill:backdrop, scale fill { background-color: #372626; }
+
+scale fill:disabled:backdrop, scale fill:disabled { border-color: transparent; background-color: transparent; }
+
+scale slider { border: 2px solid #fdb4b4; border-radius: 100%; background-color: #271b1b; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); transition-property: background, border, box-shadow; }
+
+row scale slider, popover scale slider { background-color: #1e1515; }
+
+scale slider:hover { background-color: #1e1515; }
+
+row scale slider:hover, popover scale slider:hover { background-color: #271b1b; }
+
+scale slider:active, row scale slider:active, popover scale slider:active { background-color: #fdb4b4; }
+
+scale slider:disabled { border-color: #523939; }
+
+scale slider:backdrop { background-color: #211818; border-color: #a27878; transition: 150ms ease-out; }
+
+scale slider:backdrop:disabled { border-color: #473434; }
+
+row:selected scale slider:disabled, row:selected scale slider { border-color: #eaa6a6; }
+
+scale marks, scale value { color: alpha(currentColor,0.55); font-feature-settings: "tnum"; }
+
+scale.horizontal marks.top { margin-bottom: 6px; margin-top: -12px; }
+
+scale.horizontal.fine-tune marks.top { margin-bottom: 6px; margin-top: -9px; }
+
+scale.horizontal marks.bottom { margin-top: 6px; margin-bottom: -12px; }
+
+scale.horizontal.fine-tune marks.bottom { margin-top: 6px; margin-bottom: -9px; }
+
+scale.vertical marks.top { margin-right: 6px; margin-left: -12px; }
+
+scale.vertical.fine-tune marks.top { margin-right: 6px; margin-left: -9px; }
+
+scale.vertical marks.bottom { margin-left: 6px; margin-right: -12px; }
+
+scale.vertical.fine-tune marks.bottom { margin-left: 6px; margin-right: -9px; }
+
+scale.horizontal indicator { min-height: 6px; min-width: 1px; }
+
+scale.horizontal.fine-tune indicator { min-height: 3px; }
+
+scale.vertical indicator { min-height: 1px; min-width: 6px; }
+
+scale.vertical.fine-tune indicator { min-width: 3px; }
+
+scale.horizontal.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #fdb4b4; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-top: -13px; background-position: top; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:hover { color: #fecdcd; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:active { color: #fdb4b4; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:disabled { color: #523939; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop { color: #a27878; }
+
+scale.horizontal.marks-before:not(.marks-after) slider:backdrop:disabled { color: #473434; }
+
+scale.horizontal.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-top: -11px; }
+
+scale.horizontal.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #fdb4b4; background-image: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 26px; min-width: 22px; margin-bottom: -13px; background-position: bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:hover { color: #fecdcd; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:active { color: #fdb4b4; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:disabled { color: #523939; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop { color: #a27878; }
+
+scale.horizontal.marks-after:not(.marks-before) slider:backdrop:disabled { color: #473434; }
+
+scale.horizontal.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-bottom: -11px; }
+
+scale.vertical.marks-before:not(.marks-after) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #fdb4b4; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-above-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-left: -13px; background-position: left bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-before:not(.marks-after) slider:hover { color: #fecdcd; }
+
+scale.vertical.marks-before:not(.marks-after) slider:active { color: #fdb4b4; }
+
+scale.vertical.marks-before:not(.marks-after) slider:disabled { color: #523939; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop { color: #a27878; }
+
+scale.vertical.marks-before:not(.marks-after) slider:backdrop:disabled { color: #473434; }
+
+scale.vertical.marks-before:not(.marks-after).fine-tune slider { margin: -7px; margin-left: -11px; }
+
+scale.vertical.marks-after:not(.marks-before) slider { margin: -9px; border-style: none; border-radius: 0; background-color: transparent; color: #fdb4b4; background-image: image(-gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.svg")), -gtk-recolor(url("assets/slider-vert-scale-has-marks-below-symbolic.symbolic.png"))); min-height: 22px; min-width: 26px; margin-right: -13px; background-position: right bottom; background-repeat: no-repeat; box-shadow: none; }
+
+scale.vertical.marks-after:not(.marks-before) slider:hover { color: #fecdcd; }
+
+scale.vertical.marks-after:not(.marks-before) slider:active { color: #fdb4b4; }
+
+scale.vertical.marks-after:not(.marks-before) slider:disabled { color: #523939; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop { color: #a27878; }
+
+scale.vertical.marks-after:not(.marks-before) slider:backdrop:disabled { color: #473434; }
+
+scale.vertical.marks-after:not(.marks-before).fine-tune slider { margin: -7px; margin-right: -11px; }
+
+scale.color { min-height: 0; min-width: 0; }
+
+scale.color trough { background-color: transparent; }
+
+scale.color.horizontal { padding: 0 0 15px 0; }
+
+scale.color.horizontal trough { padding-bottom: 4px; background-position: 0 -3px; border-top-left-radius: 0; border-top-right-radius: 0; }
+
+scale.color.horizontal slider:dir(ltr):hover, scale.color.horizontal slider:dir(ltr):backdrop, scale.color.horizontal slider:dir(ltr):disabled, scale.color.horizontal slider:dir(ltr):backdrop:disabled, scale.color.horizontal slider:dir(ltr), scale.color.horizontal slider:dir(rtl):hover, scale.color.horizontal slider:dir(rtl):backdrop, scale.color.horizontal slider:dir(rtl):disabled, scale.color.horizontal slider:dir(rtl):backdrop:disabled, scale.color.horizontal slider:dir(rtl) { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.vertical:dir(ltr) { padding: 0 0 0 15px; }
+
+scale.color.vertical:dir(ltr) trough { padding-left: 4px; background-position: 3px 0; border-bottom-right-radius: 0; border-top-right-radius: 0; }
+
+scale.color.vertical:dir(ltr) slider:hover, scale.color.vertical:dir(ltr) slider:backdrop, scale.color.vertical:dir(ltr) slider:disabled, scale.color.vertical:dir(ltr) slider:backdrop:disabled, scale.color.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.vertical:dir(rtl) { padding: 0 15px 0 0; }
+
+scale.color.vertical:dir(rtl) trough { padding-right: 4px; background-position: -3px 0; border-bottom-left-radius: 0; border-top-left-radius: 0; }
+
+scale.color.vertical:dir(rtl) slider:hover, scale.color.vertical:dir(rtl) slider:backdrop, scale.color.vertical:dir(rtl) slider:disabled, scale.color.vertical:dir(rtl) slider:backdrop:disabled, scale.color.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr), scale.color.fine-tune.horizontal:dir(rtl) { padding: 0 0 12px 0; }
+
+scale.color.fine-tune.horizontal:dir(ltr) trough, scale.color.fine-tune.horizontal:dir(rtl) trough { padding-bottom: 7px; background-position: 0 -6px; }
+
+scale.color.fine-tune.horizontal:dir(ltr) slider, scale.color.fine-tune.horizontal:dir(rtl) slider { margin-bottom: -15px; margin-top: 6px; }
+
+scale.color.fine-tune.vertical:dir(ltr) { padding: 0 0 0 12px; }
+
+scale.color.fine-tune.vertical:dir(ltr) trough { padding-left: 7px; background-position: 6px 0; }
+
+scale.color.fine-tune.vertical:dir(ltr) slider { margin-left: -15px; margin-right: 6px; }
+
+scale.color.fine-tune.vertical:dir(rtl) { padding: 0 12px 0 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) trough { padding-right: 7px; background-position: -6px 0; }
+
+scale.color.fine-tune.vertical:dir(rtl) slider { margin-right: -15px; margin-left: 6px; }
+
+/***************** Progress bars * */
+@keyframes progress { from { background-position: 0, calc(0% - 64px), 0%; }
+  to { background-position: 0, calc(100% + 64px), 0%; } }
+
+progressbar { font-size: smaller; color: rgba(253, 180, 180, 0.4); font-feature-settings: "tnum"; }
+
+progressbar.horizontal trough, progressbar.horizontal progress { min-height: 4px; }
+
+progressbar.vertical trough, progressbar.vertical progress { min-width: 4px; }
+
+progressbar:backdrop { box-shadow: none; transition: 150ms ease-out; }
+
+progressbar trough { border-radius: 999px; }
+
+progressbar progress { background-image: none; background-color: #fdb4b4; border-radius: 999px; }
+
+progressbar progress, progressbar progress:backdrop, .horizontal progressbar progress { animation: none; }
+
+progressbar.horizontal progress { margin: 0 -1px; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled) { animation: progress 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite; background-size: cover, 64px 100%; background-repeat: no-repeat; background-image: linear-gradient(to bottom, alpha(@progress_bg_color, 0.2), rgba(210, 149, 149, 0)), linear-gradient(to right, rgba(210, 149, 149, 0), #d29595 60%, rgba(210, 149, 149, 0)); }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled).right { animation-direction: reverse; }
+
+progressbar.horizontal progress:not(.pulse):not(:disabled):backdrop { animation: none; background-image: none; }
+
+progressbar.vertical progress { margin: -1px 0; }
+
+progressbar.osd { min-width: 4px; min-height: 4px; background-color: transparent; }
+
+progressbar.osd trough { border-style: none; border-radius: 0; background-color: transparent; box-shadow: none; }
+
+progressbar.osd progress { border-style: none; border-radius: 0; }
+
+progressbar trough.empty progress { all: unset; }
+
+/************* Level Bar * */
+levelbar.horizontal block { min-height: 4px; }
+
+levelbar.horizontal.discrete block { margin: 0 2px; min-width: 32px; }
+
+levelbar.horizontal.discrete block:first-child { margin-left: 0; }
+
+levelbar.horizontal.discrete block:last-child { margin-right: 0; }
+
+levelbar.vertical block { min-width: 4px; }
+
+levelbar.vertical.discrete block { margin: 2px 0; min-height: 32px; }
+
+levelbar.vertical.discrete block:first-child { margin-top: 0; }
+
+levelbar.vertical.discrete block:last-child { margin-bottom: 0; }
+
+levelbar:backdrop { transition: 150ms ease-out; }
+
+levelbar trough { border: none; padding: 0; background-color: transparent; }
+
+levelbar block { border: none; border-radius: 999px; }
+
+levelbar block.warning-battery-offset { background-color: #fb7c7c; background: image(#fb7c7c); }
+
+levelbar block.warning-battery-offset:backdrop { background-image: none; background-color: #a27878; }
+
+levelbar block.low, levelbar block.low-battery-offset { background-color: #faa483; background: image(#faa483); }
+
+levelbar block.low:backdrop, levelbar block.low-battery-offset:backdrop { background-image: none; background-color: #a27878; }
+
+levelbar block.high, levelbar block:not(.empty) { background-color: #fdb4b4; background: image(#fdb4b4); }
+
+levelbar block.high:backdrop, levelbar block:not(.empty):backdrop { background-image: none; background-color: #a27878; }
+
+levelbar block.full, levelbar block.high-battery-offset { background-color: #6ee1b6; background: image(#6ee1b6); }
+
+levelbar block.full:backdrop, levelbar block.high-battery-offset:backdrop { background-image: none; background-color: #a27878; }
+
+levelbar block.empty { background-image: none; }
+
+levelbar block:disabled { background-image: none; background-color: #523939; }
+
+levelbar block:disabled:backdrop { background-image: none; background-color: #473434; }
+
+/**************** Print dialog * */
+printdialog paper { color: black; border: 1px solid #595959; background: white; padding: 0; }
+
+printdialog paper:backdrop { color: #595959; border: 1px solid #262626; }
+
+printdialog .dialog-action-box { margin: 12px; }
+
+/********** Frames * */
+frame > border, .frame { box-shadow: none; margin: 0; padding: 0; border-radius: 10px; border: 1px solid #271b1b; }
+
+frame > border.flat, .frame.flat { border-style: none; }
+
+frame > border:backdrop, .frame:backdrop { border-color: #211818; }
+
+.background.csd revealer > actionbar { border-radius: 0 0 10px 10px; }
+
+actionbar > revealer > box { padding: 6px; border-top: 1px solid #372626; }
+
+actionbar > revealer > box:backdrop { border-color: #312424; }
+
+scrolledwindow { background-color: transparent; border-radius: 0 0 8px 8px; }
+
+scrolledwindow viewport.frame { border-style: none; }
+
+scrolledwindow overshoot.top { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(rgba(253, 180, 180, 0.5)), to(rgba(253, 180, 180, 0))), -gtk-gradient(radial, center top, 0, center top, 0.6, from(rgba(253, 180, 180, 0.1)), to(rgba(253, 180, 180, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.top:backdrop { background-image: -gtk-gradient(radial, center top, 0, center top, 0.48, to(#312424), to(rgba(49, 36, 36, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center top; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(rgba(253, 180, 180, 0.5)), to(rgba(253, 180, 180, 0))), -gtk-gradient(radial, center bottom, 0, center bottom, 0.6, from(rgba(253, 180, 180, 0.1)), to(rgba(253, 180, 180, 0))); background-size: 100% 5%, 100% 100%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.bottom:backdrop { background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.48, to(#312424), to(rgba(49, 36, 36, 0))); background-size: 100% 5%; background-repeat: no-repeat; background-position: center bottom; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(rgba(253, 180, 180, 0.5)), to(rgba(253, 180, 180, 0))), -gtk-gradient(radial, left center, 0, left center, 0.6, from(rgba(253, 180, 180, 0.1)), to(rgba(253, 180, 180, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.left:backdrop { background-image: -gtk-gradient(radial, left center, 0, left center, 0.48, to(#312424), to(rgba(49, 36, 36, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: left center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(rgba(253, 180, 180, 0.5)), to(rgba(253, 180, 180, 0))), -gtk-gradient(radial, right center, 0, right center, 0.6, from(rgba(253, 180, 180, 0.1)), to(rgba(253, 180, 180, 0))); background-size: 5% 100%, 100% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow overshoot.right:backdrop { background-image: -gtk-gradient(radial, right center, 0, right center, 0.48, to(#312424), to(rgba(49, 36, 36, 0))); background-size: 5% 100%; background-repeat: no-repeat; background-position: right center; background-color: transparent; border: none; box-shadow: none; }
+
+scrolledwindow undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+scrolledwindow junction { border-color: transparent; border-image: linear-gradient(to bottom, #372626 1px, transparent 1px) 0 0 0 1/0 1px stretch; background-color: transparent; }
+
+scrolledwindow junction:dir(rtl) { border-image-slice: 0 1 0 0; }
+
+scrolledwindow junction:backdrop { border-image-source: linear-gradient(to bottom, #312424 1px, transparent 1px); background-color: transparent; transition: 150ms ease-out; }
+
+separator { background: #372626; min-width: 1px; min-height: 1px; }
+
+/********* Lists * */
+list { color: #fdb4b4; background-color: #1e1515; border-color: transparent; border-radius: 10px; }
+
+list, list.frame { padding-top: 4px; padding-bottom: 4px; }
+
+list.content, list.content list { background-color: transparent; padding: 0; }
+
+list:backdrop { background-color: #1a1313; color: #8b6a6a; border-color: transparent; }
+
+list separator.horizontal { margin: 1px 16px; }
+
+list separator.vertical { margin: 16px 1px; }
+
+list row { padding: 2px; }
+
+row { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+list:not(.content) row { border-radius: 8px; margin: 1px 6px; }
+
+list.content row { background-color: #1e1515; }
+
+list.content row:backdrop { background-color: #1a1313; }
+
+list.content row:first-child { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+list.content row:last-child { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+row.expander { padding: 0px; }
+
+row:hover { transition: none; }
+
+row:backdrop { transition: 150ms ease-out; }
+
+row.activatable { transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+row.activatable.has-open-popup, row.activatable:hover { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #372626; background-image: none; background-color: rgba(253, 180, 180, 0.05); }
+
+row.activatable:active { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #473232; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, rgba(253, 180, 180, 0.15) 10%, transparent 0%); background-size: 0% 0%; }
+
+row.activatable:backdrop:hover { background-color: transparent; background-image: none; background-image: none; color: #8b6a6a; }
+
+row.activatable:selected { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; background: image(#fdb4b4); box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); }
+
+row.activatable:selected label { color: #1e1515; }
+
+row.activatable:selected:active { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); }
+
+row.activatable:selected:backdrop { background-color: #a27878; background-image: none; box-shadow: none; }
+
+row.activatable:selected:backdrop label, row.activatable:selected:backdrop { color: #1a1313; }
+
+/********************* App Notifications * */
+.app-notification, .app-notification.frame { padding: 10px; margin: 8px; border-radius: 30px; border: 1px solid rgba(55, 38, 38, 0.75); box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification:backdrop, .app-notification.frame:backdrop { background-color: #1a1313; transition: 150ms ease-out; border-color: rgba(49, 36, 36, 0.75); box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.4); }
+
+.app-notification border, .app-notification.frame border { border: none; }
+
+.app-notification button:not(.linked), .app-notification.frame button:not(.linked) { border-radius: 999px; -gtk-outline-radius: 999px; }
+
+/************* Expanders * */
+expander title > arrow { min-width: 16px; min-height: 16px; -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+expander title > arrow:dir(rtl) { -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+
+expander title > arrow:hover { color: white; }
+
+expander title > arrow:disabled { color: #926767; }
+
+expander title > arrow:disabled:backdrop { color: #4d3838; }
+
+expander title > arrow:checked { -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+/************ Calendar * */
+calendar { color: #fdb4b4; }
+
+calendar:selected { border-radius: 8px; }
+
+calendar.header { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.header:backdrop { border-bottom-color: rgba(0, 0, 0, 0.1); }
+
+calendar.button { color: rgba(253, 180, 180, 0.45); }
+
+calendar.button:hover { color: #fdb4b4; }
+
+calendar.button:backdrop { color: rgba(139, 106, 106, 0.45); }
+
+calendar.button:disabled { color: rgba(146, 103, 103, 0.45); }
+
+calendar.highlight { color: #926767; }
+
+calendar.highlight:backdrop { color: #4d3838; }
+
+calendar:backdrop { color: #8b6a6a; border-color: #312424; }
+
+calendar:indeterminate { color: alpha(currentColor,0.1); }
+
+/*********** Dialogs * */
+messagedialog .titlebar { min-height: 20px; background-image: none; background-color: #271b1b; border-style: none; border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+messagedialog.csd.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button { padding: 10px 14px; border-right-style: none; border-bottom-style: none; border-radius: 0; margin: 0 2px 0 0; -gtk-outline-radius: 0; }
+
+messagedialog.csd .dialog-action-area button:first-child { border-left-style: none; border-bottom-left-radius: 10px; -gtk-outline-bottom-left-radius: 10px; }
+
+messagedialog.csd .dialog-action-area button:last-child { border-bottom-right-radius: 10px; margin-right: 0; -gtk-outline-bottom-right-radius: 10px; }
+
+filechooser .dialog-action-box { border-top: 1px solid #372626; }
+
+filechooser .dialog-action-box:backdrop { border-top-color: #312424; }
+
+filechooser #pathbarbox { border: none; }
+
+filechooser #pathbarbox:backdrop { background-color: #211818; }
+
+filechooserbutton:drop(active) { box-shadow: none; border-color: transparent; }
+
+/*********** Sidebar * */
+.sidebar { border-style: none; background-color: transparent; border-radius: 0 0 10px 10px; }
+
+stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:not(separator):dir(ltr), .sidebar:not(separator).left { border-right: 1px solid #372626; border-left-style: none; }
+
+stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:not(separator):dir(rtl), .sidebar:not(separator).right { border-left: 1px solid #372626; border-right-style: none; }
+
+.sidebar:backdrop { border-color: #312424; transition: 150ms ease-out; }
+
+.sidebar list { background-color: transparent; }
+
+paned .sidebar.left, paned .sidebar.right, paned .sidebar.left:dir(rtl), paned .sidebar:dir(rtl), paned .sidebar:dir(ltr), paned .sidebar { border-style: none; }
+
+stacksidebar row { padding: 10px 4px; }
+
+stacksidebar row > label { padding-left: 6px; padding-right: 6px; }
+
+stacksidebar row.needs-attention > label { background-size: 6px 6px, 0 0; }
+
+separator.sidebar { background-color: #372626; }
+
+separator.sidebar:backdrop { background-color: #312424; }
+
+separator.sidebar.selection-mode, .selection-mode separator.sidebar { background-color: #eaa6a6; }
+
+/**************** File chooser * */
+row image.sidebar-icon { opacity: 0.7; }
+
+placessidebar > viewport.frame { border-style: none; background-color: transparent; }
+
+placessidebar undershoot.top { background-color: transparent; background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%); padding-top: 1px; background-size: 10px 1px; background-repeat: repeat-x; background-origin: content-box; background-position: center top; border: none; box-shadow: none; }
+
+placessidebar list { padding-top: 0; }
+
+placessidebar row { min-height: 36px; padding: 0px; margin-top: 0; margin-bottom: 0; }
+
+placessidebar row:first-child { margin-top: 0; }
+
+placessidebar row > revealer { padding: 0 8px; }
+
+placessidebar row:selected { color: #1e1515; }
+
+placessidebar row:disabled { color: #926767; }
+
+placessidebar row:backdrop { color: #8b6a6a; }
+
+placessidebar row:backdrop:selected { color: #1a1313; }
+
+placessidebar row:backdrop:disabled { color: #4d3838; }
+
+placessidebar row image.sidebar-icon:dir(ltr) { padding-right: 8px; }
+
+placessidebar row image.sidebar-icon:dir(rtl) { padding-left: 8px; }
+
+placessidebar row label.sidebar-label:dir(ltr) { padding-right: 2px; }
+
+placessidebar row label.sidebar-label:dir(rtl) { padding-left: 2px; }
+
+button.sidebar-button { min-height: 26px; min-width: 26px; margin: 0; padding: 0; border-radius: 100%; -gtk-outline-radius: 100%; }
+
+button.sidebar-button:not(:hover):not(:active) > image, button.sidebar-button:backdrop > image { opacity: 0.7; }
+
+placessidebar row:selected:active { box-shadow: none; }
+
+placessidebar row.sidebar-placeholder-row { padding: 0 8px; min-height: 2px; background-image: image(#4cd9a4); background-clip: content-box; }
+
+placessidebar row.sidebar-new-bookmark-row { color: #fdb4b4; }
+
+placessidebar row:drop(active):not(:disabled) { color: #4cd9a4; box-shadow: inset 0 0 0 2px #4cd9a4; }
+
+placessidebar row:drop(active):not(:disabled):selected { color: #1e1515; background-color: #4cd9a4; }
+
+placesview list { background-color: #271b1b; border-radius: 0 0 10px 0; }
+
+placesview list:backdrop { background-color: #211818; }
+
+placesview .server-list-button > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(0turn); }
+
+placesview .server-list-button:checked > image { transition: 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); -gtk-icon-transform: rotate(-0.5turn); }
+
+placesview row.activatable:hover { background-color: transparent; }
+
+placesview > actionbar > revealer > box > label { padding-left: 8px; padding-right: 8px; }
+
+/********* Paned * */
+paned > separator { min-width: 1px; min-height: 1px; -gtk-icon-source: none; border-style: none; background-color: transparent; background-image: image(#372626); background-size: 1px 1px; }
+
+paned > separator:selected { background-image: image(#fdb4b4); }
+
+paned > separator:backdrop { background-image: image(#312424); }
+
+paned > separator.wide { min-width: 5px; min-height: 5px; background-color: #271b1b; background-image: image(#372626), image(#372626); background-size: 1px 1px, 1px 1px; }
+
+paned > separator.wide:backdrop { background-color: #211818; background-image: image(#312424), image(#312424); }
+
+paned.horizontal > separator { background-repeat: repeat-y; }
+
+paned.horizontal > separator:dir(ltr) { margin: 0 -8px 0 0; padding: 0 8px 0 0; background-position: left; }
+
+paned.horizontal > separator:dir(rtl) { margin: 0 0 0 -8px; padding: 0 0 0 8px; background-position: right; }
+
+paned.horizontal > separator.wide { margin: 0; padding: 0; background-repeat: repeat-y, repeat-y; background-position: left, right; }
+
+paned.vertical > separator { margin: 0 0 -8px 0; padding: 0 0 8px 0; background-repeat: repeat-x; background-position: top; }
+
+paned.vertical > separator.wide { margin: 0; padding: 0; background-repeat: repeat-x, repeat-x; background-position: bottom, top; }
+
+/************** GtkInfoBar * */
+infobar { border-style: none; }
+
+infobar.action:hover > revealer > box { background-color: #2c1d17; border-bottom: 1px solid #271b1b; }
+
+infobar.info, infobar.question, infobar.warning, infobar.error { text-shadow: none; }
+
+infobar.info:backdrop > revealer > box, infobar.info > revealer > box, infobar.question:backdrop > revealer > box, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box, infobar.error > revealer > box { background-color: #32211a; border-bottom: 1px solid #271b1b; }
+
+infobar.info:backdrop > revealer > box label, infobar.info:backdrop > revealer > box, infobar.info > revealer > box label, infobar.info > revealer > box, infobar.question:backdrop > revealer > box label, infobar.question:backdrop > revealer > box, infobar.question > revealer > box label, infobar.question > revealer > box, infobar.warning:backdrop > revealer > box label, infobar.warning:backdrop > revealer > box, infobar.warning > revealer > box label, infobar.warning > revealer > box, infobar.error:backdrop > revealer > box label, infobar.error:backdrop > revealer > box, infobar.error > revealer > box label, infobar.error > revealer > box { color: #faa483; }
+
+infobar.info:backdrop, infobar.question:backdrop, infobar.warning:backdrop, infobar.error:backdrop { text-shadow: none; }
+
+infobar.info button, infobar.question button, infobar.warning button, infobar.error button { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #412b22; background-image: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-image 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: radial-gradient(circle farthest-corner at center, transparent 10%, transparent 0%); background-repeat: no-repeat; background-position: center; background-size: 1000% 1000%; }
+
+infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #50352a; background-image: none; }
+
+infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active { color: #faa483; outline-color: rgba(250, 164, 131, 0.3); background-color: #5a3b2f; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94), background-size 0, background-image 0; animation: ripple_effect 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; background-image: radial-gradient(circle farthest-corner at center, #6e483a 10%, transparent 0%); background-size: 0% 0%; }
+
+infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; background: image(#fdb4b4); box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); }
+
+infobar.info button:checked:active, infobar.question button:checked:active, infobar.warning button:checked:active, infobar.error button:checked:active { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); }
+
+infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled { color: #926767; background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop, infobar.question button:backdrop, infobar.warning button:backdrop, infobar.error button:backdrop { background-color: #291e1e; background-image: none; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.error button:backdrop label, infobar.error button:backdrop { color: #8b6a6a; }
+
+infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled { background-color: transparent; background-image: none; }
+
+infobar.info button:backdrop:disabled label, infobar.info button:backdrop:disabled, infobar.question button:backdrop:disabled label, infobar.question button:backdrop:disabled, infobar.warning button:backdrop:disabled label, infobar.warning button:backdrop:disabled, infobar.error button:backdrop:disabled label, infobar.error button:backdrop:disabled { color: #4d3838; }
+
+infobar.info button:backdrop label, infobar.info button:backdrop, infobar.info button label, infobar.info button, infobar.question button:backdrop label, infobar.question button:backdrop, infobar.question button label, infobar.question button, infobar.warning button:backdrop label, infobar.warning button:backdrop, infobar.warning button label, infobar.warning button, infobar.error button:backdrop label, infobar.error button:backdrop, infobar.error button label, infobar.error button { color: #faa483; }
+
+infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection { background-color: #090606; }
+
+infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link { color: #fee5e5; }
+
+/************ Tooltips * */
+tooltip { padding: 4px; /* not working */ border-radius: 10px; box-shadow: none; }
+
+tooltip.background, tooltip.background.csd { border-radius: 10px; background-color: rgba(0, 0, 0, 0.8); background-clip: padding-box; border: 1px solid rgba(255, 255, 255, 0.1); }
+
+tooltip decoration { background-color: transparent; }
+
+tooltip * { padding: 4px; background-color: transparent; color: white; }
+
+/***************** Color Chooser * */
+colorswatch:drop(active), colorswatch { border-style: none; }
+
+colorswatch.top { border-top-left-radius: 8.5px; border-top-right-radius: 8.5px; }
+
+colorswatch.top overlay { border-top-left-radius: 8px; border-top-right-radius: 8px; }
+
+colorswatch.bottom { border-bottom-left-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.bottom overlay { border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.left, colorswatch:first-child:not(.top) { border-top-left-radius: 8.5px; border-bottom-left-radius: 8.5px; }
+
+colorswatch.left overlay, colorswatch:first-child:not(.top) overlay { border-top-left-radius: 8px; border-bottom-left-radius: 8px; }
+
+colorswatch.right, colorswatch:last-child:not(.bottom) { border-top-right-radius: 8.5px; border-bottom-right-radius: 8.5px; }
+
+colorswatch.right overlay, colorswatch:last-child:not(.bottom) overlay { border-top-right-radius: 8px; border-bottom-right-radius: 8px; }
+
+colorswatch.dark { outline-color: rgba(255, 255, 255, 0.6); }
+
+colorswatch.dark overlay { color: white; }
+
+colorswatch.dark overlay:backdrop { color: rgba(255, 255, 255, 0.5); }
+
+colorswatch.light { outline-color: rgba(0, 0, 0, 0.6); }
+
+colorswatch.light overlay { color: black; }
+
+colorswatch.light overlay:backdrop { color: rgba(0, 0, 0, 0.5); }
+
+colorswatch:drop(active) { box-shadow: none; }
+
+colorswatch:drop(active).light overlay { border-color: #4cd9a4; }
+
+colorswatch:drop(active).dark overlay { border-color: #4cd9a4; }
+
+colorswatch overlay { border: 1px solid transparent; }
+
+colorswatch#add-color-button { border-radius: 8px 8px 0 0; }
+
+colorswatch#add-color-button:only-child { border-radius: 8px; }
+
+colorswatch#add-color-button overlay { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #372626; background-image: none; }
+
+colorswatch#add-color-button overlay:hover { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-color: #473232; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop { background-color: #291e1e; background-image: none; }
+
+colorswatch#add-color-button overlay:backdrop label, colorswatch#add-color-button overlay:backdrop { color: #8b6a6a; }
+
+colorswatch:disabled { opacity: 0.5; }
+
+colorswatch:disabled overlay { border-color: rgba(0, 0, 0, 0.6); box-shadow: none; }
+
+row:selected colorswatch { box-shadow: 0 0 0 2px #1e1515; }
+
+colorswatch#editor-color-sample { border-radius: 8px; }
+
+colorswatch#editor-color-sample overlay { border-radius: 8.5px; }
+
+colorchooser .popover.osd { border-radius: 8px; }
+
+/******** Misc * */
+.content-view { background-color: #201616; }
+
+.content-view:hover { -gtk-icon-effect: highlight; }
+
+.content-view:backdrop { background-color: #1a1313; }
+
+.osd .scale-popup button.flat { border-style: none; border-radius: 8px; }
+
+.scale-popup button:hover { background-color: rgba(253, 180, 180, 0.15); border-radius: 8px; }
+
+/********************** Window Decorations * */
+decoration { border-radius: 10px; border-width: 0px; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(253, 180, 180, 0.1); margin: 10px; }
+
+decoration:backdrop { box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(139, 106, 106, 0.125); transition: 150ms ease-out; }
+
+.maximized decoration, .fullscreen decoration, .tiled decoration, .tiled-top decoration, .tiled-right decoration, .tiled-bottom decoration, .tiled-left decoration { border-radius: 0; }
+
+.popup decoration { box-shadow: none; }
+
+.ssd decoration { box-shadow: 0 0 0 1px rgba(253, 180, 180, 0.1); }
+
+.csd.popup decoration { border-radius: 8px; box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(253, 180, 180, 0.1); }
+
+.csd.popup decoration:backdrop { box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(139, 106, 106, 0.125); }
+
+tooltip.csd decoration { border-radius: 10px; box-shadow: none; }
+
+messagedialog.csd decoration { border-radius: 10px; box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(253, 180, 180, 0.1); }
+
+messagedialog.csd decoration:backdrop { box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(139, 106, 106, 0.125); }
+
+.solid-csd decoration { margin: 0; padding: 4px; background-color: #372626; border: solid 1px #372626; border-radius: 0; box-shadow: none; }
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized), window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration, window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration-overlay { border-radius: 10px; }
+
+button.titlebutton:not(.appmenu) { border-radius: 9999px; padding: 6px; margin: 0 2px; min-width: 0; min-height: 0; }
+
+button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.selection-mode headerbar button.titlebutton:backdrop, .selection-mode .titlebar button.titlebutton:backdrop, headerbar.selection-mode button.titlebutton:backdrop, .titlebar.selection-mode button.titlebutton:backdrop { -gtk-icon-shadow: none; }
+
+.view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { background-color: #fdb4b4; }
+
+.selection-mode button.titlebutton, .view:selected:focus, .view:selected, .view text:selected:focus, textview text:selected:focus, .view text:selected, textview text:selected, iconview:selected:focus, iconview:selected, flowbox flowboxchild:selected, modelbutton.flat:selected, .menuitem.button.flat:selected, treeview.view:selected:focus, treeview.view:selected, row:selected, calendar:selected { color: #1e1515; }
+
+.selection-mode button.titlebutton:disabled, .view:disabled:selected, textview text:disabled:selected:focus, .view text:disabled:selected, textview text:disabled:selected, iconview:disabled:selected:focus, iconview:disabled:selected, flowbox flowboxchild:disabled:selected, modelbutton.flat:disabled:selected, .menuitem.button.flat:disabled:selected, treeview.view:disabled:selected, row:disabled:selected, calendar:disabled:selected { color: #8d6464; }
+
+.selection-mode button.titlebutton:backdrop, .view:backdrop:selected, textview text:backdrop:selected:focus, .view text:backdrop:selected, textview text:backdrop:selected, iconview:backdrop:selected:focus, iconview:backdrop:selected, flowbox flowboxchild:backdrop:selected, modelbutton.flat:backdrop:selected, .menuitem.button.flat:backdrop:selected, treeview.view:backdrop:selected, row:backdrop:selected, calendar:backdrop:selected { color: #1a1313; background-color: #a27878; }
+
+.selection-mode button.titlebutton:backdrop:disabled, .view:backdrop:disabled:selected, .view text:backdrop:disabled:selected, textview text:backdrop:disabled:selected, iconview:backdrop:disabled:selected, flowbox flowboxchild:backdrop:disabled:selected, modelbutton.flat:backdrop:disabled:selected, .menuitem.button.flat:backdrop:disabled:selected, row:backdrop:disabled:selected, calendar:backdrop:disabled:selected { color: #b98484; }
+
+.view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { background-color: #573d3d; }
+
+label:selected, .view text selection:focus, .view text selection, textview text selection:focus, textview text selection, iconview text selection:focus, .view text selection, iconview text selection, label selection, entry selection, spinbutton:not(.vertical) selection { color: #fdb4b4; }
+
+label:disabled selection, label:disabled:selected, .view text selection:disabled, textview text selection:disabled:focus, textview text selection:disabled, iconview text selection:disabled:focus, iconview text selection:disabled, label selection:disabled, entry selection:disabled, spinbutton:not(.vertical) selection:disabled { color: #9d6f6f; }
+
+label:backdrop selection, label:backdrop:selected, .view text selection:backdrop, textview text selection:backdrop:focus, textview text selection:backdrop, iconview text selection:backdrop:focus, iconview text selection:backdrop, label selection:backdrop, entry selection:backdrop, spinbutton:not(.vertical) selection:backdrop { background-color: #3e2e2e; color: #8e6b6b; }
+
+label:backdrop selection:disabled, label:backdrop:disabled:selected, .view text selection:backdrop:disabled, textview text selection:backdrop:disabled, iconview text selection:backdrop:disabled, label selection:backdrop:disabled, entry selection:backdrop:disabled, spinbutton:not(.vertical) selection:backdrop:disabled { color: #563f3f; }
+
+.monospace { font-family: monospace; }
+
+/********************** Touch Copy & Paste * */
+cursor-handle { background-color: transparent; background-image: none; box-shadow: none; border-style: none; color: #fdb4b4; }
+
+cursor-handle:hover { color: #fffefe; }
+
+cursor-handle:active { color: #fdb4b4; }
+
+cursor-handle.top:dir(ltr), cursor-handle.bottom:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-start-symbolic.svg")), -gtk-recolor(url("assets/text-select-start-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.bottom:dir(ltr), cursor-handle.top:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/text-select-end-symbolic.svg")), -gtk-recolor(url("assets/text-select-end-symbolic.symbolic.png"))); padding-left: 10px; }
+
+cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl) { -gtk-icon-source: image(-gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.svg")), -gtk-recolor(url("assets/slider-horz-scale-has-marks-above-symbolic.symbolic.png"))); }
+
+.context-menu { font: initial; }
+
+.keycap { min-width: 20px; min-height: 25px; margin-top: 2px; padding-bottom: 3px; padding-left: 6px; padding-right: 6px; color: #fdb4b4; background-color: #1e1515; border: 1px solid; border-color: #372626; border-radius: 4px; box-shadow: inset 0 -3px #2d1f1f; font-size: smaller; }
+
+.keycap:backdrop { background-color: #1a1313; color: #8b6a6a; transition: 150ms ease-out; }
+
+:not(decoration):not(window):drop(active):focus, :not(decoration):not(window):drop(active) { border-color: #4cd9a4; box-shadow: inset 0 0 0 1px #4cd9a4; caret-color: #4cd9a4; }
+
+stackswitcher button.text-button { min-width: 100px; }
+
+stackswitcher button.circular, stackswitcher button.text-button.circular { min-width: 32px; min-height: 32px; padding: 0; }
+
+/************* App Icons * */
+/* Outline for low res icons */
+.lowres-icon { -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/* Dropshadow for large icons */
+.icon-dropshadow { -gtk-icon-shadow: 0 1px 12px rgba(0, 0, 0, 0.05), 0 -1px rgba(0, 0, 0, 0.05), 1px 0 rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.3), -1px 0 rgba(0, 0, 0, 0.1); }
+
+/********* Emoji * */
+popover.emoji-picker { padding-left: 0; padding-right: 0; }
+
+popover.emoji-picker entry.search { margin: 3px 5px 5px 5px; }
+
+button.emoji-section { border-color: transparent; border-width: 3px; border-style: none none solid; border-radius: 0; margin: 2px 4px 2px 4px; padding: 3px 0 0; min-width: 32px; min-height: 28px; /* reset props inherited from the button style */ background: none; box-shadow: none; text-shadow: none; outline-offset: -5px; }
+
+button.emoji-section:first-child { margin-left: 7px; }
+
+button.emoji-section:last-child { margin-right: 7px; }
+
+button.emoji-section:backdrop:not(:checked) { border-color: transparent; }
+
+button.emoji-section:hover { border-color: #372626; }
+
+button.emoji-section:checked { color: #fdb4b4; border-color: #fdb4b4; }
+
+button.emoji-section:checked:backdrop { color: #8b6a6a; background-color: transparent; }
+
+button.emoji-section label { padding: 0; opacity: 0.55; }
+
+button.emoji-section:hover label { opacity: 0.775; }
+
+button.emoji-section:checked label { opacity: 1; }
+
+popover.emoji-picker .emoji { font-size: x-large; padding: 6px; }
+
+popover.emoji-picker .emoji :hover { background: #fdb4b4; border-radius: 8px; }
+
+popover.emoji-completion arrow { border: none; background: none; }
+
+popover.emoji-completion contents row box { padding: 2px 10px; }
+
+popover.emoji-completion .emoji:hover { background: #372626; }
+
+/***************** View Switcher * */
+viewswitcher button { margin: 0; padding: 0; border-radius: 0; border: none; box-shadow: none; }
+
+viewswitcher button:checked { box-shadow: none; }
+
+viewswitcher button stack > box.narrow { font-size: smaller; padding-top: 6px; padding-bottom: 6px; }
+
+viewswitcher button stack > box.narrow image, viewswitcher button stack > box.narrow label { padding-left: 6px; padding-right: 6px; }
+
+viewswitcher button stack > box.wide { padding: 0 12px; }
+
+viewswitcherbar > actionbar > revealer > box { padding: 0; }
+
+viewswitcherbar > actionbar > revealer > box viewswitcher button:not(:checked):not(:hover) { background: transparent; }
+
+headerbar viewswitcher > box > button:first-child { border-bottom-left-radius: 8px; }
+
+headerbar viewswitcher > box > button:last-child { border-bottom-right-radius: 8px; }
+
+/*********** Chromium * */
+window.background.chromium { background-color: #1e1515; }
+
+window.background.chromium headerbar.titlebar button.toggle, window.background.chromium headerbar.titlebar button.titlebutton { border: none; }
+
+window.background.chromium headerbar.titlebar button.titlebutton { background-image: none; }
+
+window.background.chromium button { border-style: solid; border-width: 1px; border-color: #372626; }
+
+window.background.chromium > textview.view { background-color: #271b1b; }
+
+/*********** Firefox * */
+#MozillaGtkWidget.background { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+
+#MozillaGtkWidget.background scrollbar { background-color: transparent; border-color: transparent; }
+
+/****************** Gnome Calendar * */
+window.background.csd.org-gnome-Calendar > overlay > box.vertical > stack.view { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > button.text-button { margin: 0; border-bottom-right-radius: 10px; }
+
+window.background.csd.org-gnome-Calendar calendar-view.year-view > box.vertical > stack > .sidebar.vertical { border-radius: 0; }
+
+window.background.csd.org-gnome-Calendar.maximized calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.tiled calendar-view.year-view > box.vertical > button.text-button, window.background.csd.org-gnome-Calendar.fullscreen calendar-view.year-view > box.vertical > button.text-button { border-bottom-right-radius: 0; }
+
+/*************** LibreOffice * */
+toolbutton > button.image-button.text-button.flat button { background-color: transparent; background-image: none; background-image: none; }
+
+toolbutton > button.image-button.text-button.flat button:hover { background-color: #372626; }
+
+toolbutton > button.image-button.text-button.flat button:active, toolbutton > button.image-button.text-button.flat button:checked { background-color: #473232; box-shadow: none; }
+
+window.background:not(.solid-csd) > notebook:not(.frame) tab { margin-bottom: 4px; }
+
+/************ Nautilus * */
+.nautilus-window .floating-bar { min-height: 32px; padding: 0; border-radius: 10px 10px 0 0; background-color: #1e1515; background-clip: padding-box; }
+
+.nautilus-window .floating-bar.bottom.left { margin-right: 7px; border-top-left-radius: 0; border-bottom-left-radius: 10px; }
+
+.nautilus-window .floating-bar.bottom.right { margin-left: 7px; border-top-right-radius: 0; border-bottom-right-radius: 10px; }
+
+.nautilus-window .floating-bar button { padding: 0; }
+
+.nautilus-window .nautilus-list-view { background-color: #1e1515; border-radius: 0 0 10px 10px; }
+
+.nautilus-window .nautilus-list-view treeview.view:not(:hover):not(:active):not(:selected) { background-color: transparent; border-radius: 0; }
+
+.nautilus-window.maximized .floating-bar, .nautilus-window.maximized .nautilus-list-view, .nautilus-window.tiled .floating-bar, .nautilus-window.tiled .nautilus-list-view, .nautilus-window.fullscreen .floating-bar, .nautilus-window.fullscreen .nautilus-list-view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.nautilus-window headerbar .path-bar-box { color: transparent; background: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; background: image(#fdb4b4); box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:last-child:active { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { background-color: #a27878; background-image: none; box-shadow: none; }
+
+.nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child label, .nautilus-window headerbar .path-bar-box .linked.nautilus-path-bar > button:backdrop:last-child { color: #1a1313; }
+
+.nautilus-window notebook > header.top:dir(ltr) { border-top-left-radius: 0; }
+
+.nautilus-window notebook > header.top:dir(rtl) { border-top-right-radius: 0; }
+
+.nautilus-canvas-item { border-radius: 8px; }
+
+.nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator, headerbar .nautilus-canvas-item.subtitle, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle, popover.background label.nautilus-canvas-item.separator, .nautilus-list-dim-label { color: #9d6f6f; }
+
+.nautilus-canvas-item.dim-label:backdrop, label.nautilus-canvas-item.separator:backdrop, headerbar .nautilus-canvas-item.subtitle:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:backdrop, popover.background label.nautilus-canvas-item.separator:backdrop, .nautilus-list-dim-label:backdrop { color: #5b4545; }
+
+.nautilus-canvas-item.dim-label:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected, label.nautilus-canvas-item.separator:selected:focus, headerbar .nautilus-canvas-item.subtitle:selected, headerbar .nautilus-canvas-item.subtitle:selected:focus, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus, popover.background label.nautilus-canvas-item.separator:selected, popover.background label.nautilus-canvas-item.separator:selected:focus, .nautilus-list-dim-label:selected, .nautilus-list-dim-label:selected:focus { color: rgba(30, 21, 21, 0.45); }
+
+.nautilus-canvas-item.dim-label:selected:backdrop, .nautilus-canvas-item.dim-label:selected:focus:backdrop, label.nautilus-canvas-item.separator:selected:backdrop, label.nautilus-canvas-item.separator:selected:focus:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:backdrop, headerbar .nautilus-canvas-item.subtitle:selected:focus:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:backdrop, .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus:backdrop, popover.background label.nautilus-canvas-item.separator:selected:backdrop, popover.background label.nautilus-canvas-item.separator:selected:focus:backdrop, .nautilus-list-dim-label:selected:backdrop, .nautilus-list-dim-label:selected:focus:backdrop { color: rgba(26, 19, 19, 0.45); }
+
+.disk-space-display.unknown { background-color: rgba(253, 180, 180, 0.4); color: rgba(253, 180, 180, 0.4); }
+
+.disk-space-display.used { background-color: #fdb4b4; color: #fdb4b4; }
+
+.disk-space-display.free { background-color: rgba(253, 180, 180, 0.1); color: rgba(253, 180, 180, 0.1); }
+
+dialog > box > grid > scrolledwindow > viewport > box > list { padding: 0; background-color: transparent; border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list:backdrop { background-color: transparent; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list > row { border-radius: 0; margin: 0; }
+
+dialog > box > grid > scrolledwindow > viewport > box > list separator.horizontal { margin: 0; }
+
+/**************************************************** documents-scrolledwin (Totem, Documents, EvView) * */
+.documents-scrolledwin:backdrop, .documents-scrolledwin { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin:backdrop .content-view:not(:selected):not(:hover), .documents-scrolledwin .content-view:not(:selected):not(:hover):backdrop, .documents-scrolledwin .content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop .content-view:hover, .documents-scrolledwin .content-view:hover { background-color: rgba(253, 180, 180, 0.075); }
+
+.documents-scrolledwin:backdrop viewport.frame, .documents-scrolledwin viewport.frame { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover), .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) { background-color: transparent; }
+
+.documents-scrolledwin:backdrop viewport.frame widget > frame.content-view:not(:selected):not(:hover) border, .documents-scrolledwin viewport.frame widget > frame.content-view:not(:selected):not(:hover) border { border: none; }
+
+/******************* Document Viewer * */
+window.background.csd > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { background-color: transparent; border-radius: 10px; }
+
+window.background.csd > box.vertical > paned.horizontal > box.vertical > scrolledwindow > treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+window.background.csd evview.view.content-view { background-color: transparent; border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.maximized > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.tiled > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.view.content-view:not(:hover):not(:selected), window.background.csd.fullscreen > box.vertical > scrolledwindow > iconview.content-view:not(:hover):not(:selected) { border-radius: 0; }
+
+window.background.csd.maximized evview.view.content-view, window.background.csd.tiled evview.view.content-view, window.background.csd.fullscreen evview.view.content-view { border-radius: 0; }
+
+/******************* Archive Manager * */
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow { border-radius: 0 0 10px 10px; background-color: #1e1515; }
+
+.background.csd > grid.horizontal > paned.horizontal > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-radius: 0 0 0 10px; background-color: #271b1b; }
+
+.background.csd > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow treeview.view:not(:hover):not(:selected) { background-color: transparent; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.background.csd.maximized > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.tiled > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow, .background.csd.fullscreen > grid.horizontal > paned.horizontal > box.vertical > scrolledwindow { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/********* Geary * */
+frame.geary-conversation-frame scrolledwindow treeview.view:not(:selected) { background: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected { color: #1e1515; outline-color: rgba(30, 21, 21, 0.3); background-color: #fdb4b4; background: image(#fdb4b4); box-shadow: 0 2px 4px rgba(253, 180, 180, 0.2); box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { background-color: #a27878; background-image: none; box-shadow: none; box-shadow: none; }
+
+frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop label, frame.geary-conversation-frame scrolledwindow treeview.view:selected:backdrop { color: #1a1313; }
+
+.geary_email { padding-bottom: 6px; border-radius: 8px; }
+
+.geary_email .geary-message { border-radius: 8px; }
+
+.geary-attachment-pane > separator.horizontal { margin: 0; }
+
+.geary-attachment-pane flowboxchild { border-radius: 8px; }
+
+.geary-attachment-pane > actionbar { background-color: #1e1515; }
+
+.geary-attachment-pane > actionbar:backdrop { background-color: #1a1313; }
+
+/********* Gedit * */
+window.org-gnome-gedit stack scrolledwindow viewport.frame list.gedit-document-panel { background-color: transparent; }
+
+window.org-gnome-gedit .gedit-search-entry-occurrences-tag { border: none; box-shadow: none; margin: 2px; padding: 2px; }
+
+/******************** Gnome Calculator * */
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list { padding: 0; border-radius: 0; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry { margin: 0; border-radius: 0; background-color: #271b1b; }
+
+grid > viewport > box > scrolledwindow.frame.history-view > viewport > list > row.history-entry:backdrop { background-color: #211818; }
+
+grid > viewport > box > scrolledwindow.display-scrolled > .sourceview.view > text, grid > viewport > box > scrolledwindow.display-scrolled > iconview.sourceview > text { border-radius: 10px 10px 0 0; }
+
+grid > viewport > box box > textview.view.info-view > text { border-radius: 0 0 10px 10px; }
+
+/************************ Gnome Control Center * */
+window.background.csd > leaflet > stack.background, window.background.csd > hdyleaflet > stack.background, window.background.csd > box.horizontal > stack.background { border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-left-radius: 10px; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+window.background.csd.maximized > leaflet > stack.background, window.background.csd.maximized > hdyleaflet > stack.background, window.background.csd.maximized > box.horizontal > stack.background, window.background.csd.maximized > leaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.maximized > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.tiled > leaflet > stack.background, window.background.csd.tiled > hdyleaflet > stack.background, window.background.csd.tiled > box.horizontal > stack.background, window.background.csd.tiled > leaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.tiled > box.horizontal > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > leaflet > stack.background, window.background.csd.fullscreen > hdyleaflet > stack.background, window.background.csd.fullscreen > box.horizontal > stack.background, window.background.csd.fullscreen > leaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd.fullscreen > box.horizontal > box.vertical > scrolledwindow.view { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+window.background.csd > leaflet > stack.background > widget > box > box > scrolledwindow > viewport.frame > box.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list, window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list { background-color: transparent; }
+
+window.background.csd > leaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > hdyleaflet > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected), window.background.csd > box.horizontal > box.vertical > scrolledwindow.view > viewport.frame > stack list row.activatable:not(:hover):not(:active):not(:selected) { background-color: transparent; }
+
+/************** Gnome Maps * */
+popover.maps-popover > grid > button.radio.layer-radio-button { border-radius: 4px; color: transparent; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:active { color: #fdb4b4; }
+
+popover.maps-popover > grid > button.radio.layer-radio-button:checked { color: #fdb4b4; }
+
+/*************** Gnome Music * */
+window.background.csd > box.vertical > overlay > stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.maximized > box.vertical > overlay > stack.background, window.background.csd.tiled > box.vertical > overlay > stack.background, window.background.csd.fullscreen > box.vertical > overlay > stack.background { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+/****************** Gnome Software * */
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal { border-radius: 8px; background-color: #1e1515; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal:backdrop { background-color: #1a1313; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal list.app-updates-section { border: none; border-radius: 10px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software { padding-top: 2px; padding-bottom: 2px; margin: 4px 2px; min-height: 24px; min-width: 54px; border-radius: 8px; -gtk-outline-radius: 8px; background-color: transparent; color: #d09494; font-weight: normal; border-style: none; transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); background-image: none; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(ltr) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:first-child:dir(rtl) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(ltr) { margin-right: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:last-child:dir(rtl) { margin-left: 4px; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:hover { color: #fdb4b4; background-color: rgba(253, 180, 180, 0.05); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:checked { color: #fdb4b4; outline-color: rgba(253, 180, 180, 0.3); background-image: none; background-color: #473232; box-shadow: 0 2px 4px rgba(30, 21, 21, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop { color: #8b6a6a; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:hover { background-color: transparent; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { background-image: none; background-color: #312424; box-shadow: 0 1px 2px rgba(26, 19, 19, 0.075); }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked label, window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal > button.toggle.toolbar-primary-buttons-software:backdrop:checked { color: #8b6a6a; }
+
+window.background.csd > headerbar.titlebar > box.horizontal > buttonbox.linked.horizontal button:checked + button { border-image: none; }
+
+window.background.csd button.text-button.content-rating { color: #1e1515; }
+
+window.background.csd button.text-button.content-rating:backdrop { color: #1a1313; }
+
+/****************** Gnome Terminal * */
+terminal-window.background.csd { border-radius: 0; }
+
+terminal-window decoration { background-color: #271b1b; border-radius: 10px 10px 0 0; box-shadow: 0 10px 15px 5px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(253, 180, 180, 0.1), 0 0 0 1px #271b1b; }
+
+terminal-window decoration:backdrop { background-color: #211818; box-shadow: 0 10px 15px 5px transparent, 0 3px 6px 2px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(139, 106, 106, 0.125), 0 0 0 1px #211818; }
+
+terminal-window .terminal-screen { background-color: #271b1b; color: #fdb4b4; }
+
+terminal-window .terminal-screen:backdrop { background-color: #211818; color: #8b6a6a; }
+
+/*************** Gnome Todo * */
+window.background.csd.org-gnome-Todo > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo stack.background { border-radius: 0 0 10px 10px; }
+
+window.background.csd.org-gnome-Todo.maximized > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.maximized stack.background, window.background.csd.org-gnome-Todo.tiled > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.tiled stack.background, window.background.csd.org-gnome-Todo.fullscreen > overlay > stack.background > box.horizontal > tasklistview > box.vertical > overlay.view > scrolledwindow > viewport.view, window.background.csd.org-gnome-Todo.fullscreen stack.background { border-radius: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row { box-shadow: none; padding: 0; }
+
+window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row entry, window.background.csd.org-gnome-Todo taskrow.activatable.new-task-row button { margin: 0; border-radius: 2.5px; }
+
+/**************** Gnome Tweaks * */
+hdyleaflet list.tweak-categories, leaflet list.tweak-categories { background-color: transparent; }
+
+hdyleaflet list.tweak-categories > separator, leaflet list.tweak-categories > separator { background-color: transparent; min-height: 0; }
+
+row#AutostartTitle.tweak { padding: 8px 8px 0 8px; }
+
+.tweak-group-startup { background-color: #1e1515; }
+
+.tweak-group-startup:backdrop { background-color: #1a1313; }
+
+/***************** Gnome Weather * */
+#weather-page, #weekly-forecast-frame { border-bottom-right-radius: 10px; }
+
+#weather-page-content-view { border-bottom-right-radius: 10px; border-bottom-left-radius: 10px; }
+
+/************ Ubiquity * */
+#live_installer #stepPartAuto #partition_container #resizewidget separator { background-image: none; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > * { background-color: transparent; border-radius: 0; border-color: #372626; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame > *:backdrop { border-color: #312424; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box { background-color: #1e1515; }
+
+#live_installer #stepPartAuto #partition_container #resizewidget > frame box:backdrop { background-color: #1a1313; }
+
+/******************** Zorin Appearance * */
+stacksidebar.sidebar > scrolledwindow > viewport.frame > list { border-radius: 0; }
+
+/********** Thunar * */
+.thunar .sidebar.frame { border: none; }
+
+.thunar .sidebar .view, .thunar .sidebar iconview { background-color: #271b1b; border: none; }
+
+.thunar .sidebar .view:selected, .thunar .sidebar iconview:selected { background-color: #473232; color: #fdb4b4; }
+
+.thunar .sidebar .view:backdrop, .thunar .sidebar iconview:backdrop { background-color: #211818; }
+
+.thunar .sidebar .view:backdrop:selected, .thunar .sidebar iconview:backdrop:selected { background-color: #312424; color: #8b6a6a; }
+
+.thunar .standard-view > .view, .thunar .standard-view > iconview { border-radius: 0; }
+
+/*********************** LightDM Gtk Greeter * */
+.lightdm-gtk-greeter #panel_window { border-radius: 0; border: none; background-color: #271b1b; }
+
+.lightdm-gtk-greeter #panel_window menubar { font-weight: bold; }
+
+.lightdm-gtk-greeter #panel_window menubar menu menuitem { font-weight: normal; }
+
+.lightdm-gtk-greeter #buttonbox_frame { padding-top: 20px; }
+
+.lightdm-gtk-greeter #login_window, .lightdm-gtk-greeter #shutdown_dialog, .lightdm-gtk-greeter #restart_dialog { border-style: none; border-radius: 10px; background-color: #271b1b; color: #fdb4b4; box-shadow: none; }
+
+.lightdm-gtk-greeter #login_window menu { border-radius: 0; }
+
+/******** XFCE * */
+.xfce4-panel.background { background-color: #1e1515; }
+
+.xfce4-panel.background button { border-radius: 0; margin: 0; font-weight: bold; }
+
+.xfce4-panel.background button menuitem { font-weight: normal; }
+
+.xfce4-panel.background button:hover { background-color: #372626; }
+
+.xfce4-panel.background button:active, .xfce4-panel.background button:checked { color: #fdb4b4; background-color: #473232; background-image: none; }
+
+.xfce4-panel.background button.flat image, .xfce4-panel.background button.image-button image { -gtk-icon-transform: scale(1); transition: none; }
+
+.xfce4-panel.background button.flat:active image, .xfce4-panel.background button.image-button:active image { -gtk-icon-transform: scale(1); }
+
+.tasklist button.toggle { background-color: transparent; border-top-width: 0; border-bottom-width: 0; }
+
+.tasklist button.toggle:checked { background: none; box-shadow: inset 0 -3px #fdb4b4; }
+
+wnck-pager { background-color: #2f2121; }
+
+wnck-pager:hover { background-color: #3f2d2d; }
+
+wnck-pager:selected { background-color: #4b3535; }
+
+XfdesktopIconView.view { background: transparent; color: white; }
+
+XfdesktopIconView.view:active { background: #fdb4b4; color: #1e1515; text-shadow: none; }
+
+XfdesktopIconView.view .label { text-shadow: 1px 1px 2px black; }
+
+#XfceNotifyWindow { background-color: #1e1515; border: none; box-shadow: inset 0 0 0 1px rgba(55, 38, 38, 0.75); border-radius: 10px; }
+
+#XfceNotifyWindow label#summary { font-weight: bold; }
+
+#XfceNotifyWindow progressbar progress { animation: none; background-image: none; background: image(#fdb4b4); }
+
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin { border-radius: 10px; }
+
+/* GTK NAMED COLORS ---------------- use responsibly! */
+/*
+widget text/foreground color */
+@define-color theme_fg_color #fdb4b4;
+/*
+text color for entries, views and content in general */
+@define-color theme_text_color #fdb4b4;
+/*
+widget base background color */
+@define-color theme_bg_color #271b1b;
+/*
+text widgets and the like base background color */
+@define-color theme_base_color #1e1515;
+/*
+base background color of selections */
+@define-color theme_selected_bg_color #e8a4a4;
+/* Tinting in dark variant to avoid a white selection on white page background when highlighting text in Evince when using Grey-Dark theme */
+/*
+text/foreground color of selections */
+@define-color theme_selected_fg_color #1e1515;
+/*
+base background color of insensitive widgets */
+@define-color insensitive_bg_color #271b1b;
+/*
+text foreground color of insensitive widgets */
+@define-color insensitive_fg_color #926767;
+/*
+insensitive text widgets and the like base background color */
+@define-color insensitive_base_color #1e1515;
+/*
+widget text/foreground color on backdrop windows */
+@define-color theme_unfocused_fg_color #8b6a6a;
+/*
+text color for entries, views and content in general on backdrop windows */
+@define-color theme_unfocused_text_color #fdb4b4;
+/*
+widget base background color on backdrop windows */
+@define-color theme_unfocused_bg_color #211818;
+/*
+text widgets and the like base background color on backdrop windows */
+@define-color theme_unfocused_base_color #1a1313;
+/*
+base background color of selections on backdrop windows */
+@define-color theme_unfocused_selected_bg_color #fdb4b4;
+/*
+text/foreground color of selections on backdrop windows */
+@define-color theme_unfocused_selected_fg_color #1e1515;
+/*
+insensitive color on backdrop windows*/
+@define-color unfocused_insensitive_color #4d3838;
+/*
+widgets main borders color */
+@define-color borders #372626;
+/*
+widgets main borders color on backdrop windows */
+@define-color unfocused_borders #312424;
+/*
+these are pretty self explicative */
+@define-color placeholder_text_color #8d6464;
+@define-color warning_color #faa483;
+@define-color error_color #fb7c7c;
+@define-color success_color #6ee1b6;
+/*
+these colors are exported for the window manager and shouldn't be used in applications,
+read if you used those and something break with a version upgrade you're on your own... */
+@define-color wm_title shade(#fdb4b4, 1.8);
+@define-color wm_unfocused_title #8b6a6a;
+@define-color wm_highlight transparent;
+@define-color wm_borders_edge rgba(253, 180, 180, 0.07);
+@define-color wm_bg_a shade(#271b1b, 1.2);
+@define-color wm_bg_b #271b1b;
+@define-color wm_shadow alpha(black, 0.35);
+@define-color wm_border alpha(black, 0.18);
+@define-color wm_button_hover_color_a shade(#271b1b, 1.3);
+@define-color wm_button_hover_color_b #271b1b;
+@define-color wm_button_active_color_a shade(#271b1b, 0.85);
+@define-color wm_button_active_color_b shade(#271b1b, 0.89);
+@define-color wm_button_active_color_c shade(#271b1b, 0.9);
+/* content view background such as thumbnails view in Photos or Boxes */
+@define-color content_view_bg #1e1515;
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #1e1515;


### PR DESCRIPTION
Added gtk-dark.css to every dark theme to fix forced dark theme apps being set to default theme on gnome.
The gtk-dark.css files added are just copies of the gtk.css files in the same folder.